### PR TITLE
fix: OBS-451 - diode-netbox-plugin: IP address interface lookup by ID

### DIFF
--- a/diode-netbox-plugin/netbox_diode_plugin/api/views.py
+++ b/diode-netbox-plugin/netbox_diode_plugin/api/views.py
@@ -340,15 +340,16 @@ class ApplyChangeSetView(views.APIView):
                 args = {}
 
                 if model_name == "interface":
-                    try:
-                        device = assigned_object_properties_dict.get("device", {})
-                        args = (
-                            self._retrieve_assigned_object_interface_device_lookup_args(
+                    if assigned_object_properties_dict.get("id"):
+                        args["id"] = assigned_object_properties_dict.get("id")
+                    else:
+                        try:
+                            device = assigned_object_properties_dict.get("device", {})
+                            args = self._retrieve_assigned_object_interface_device_lookup_args(
                                 device
                             )
-                        )
-                    except ValidationError as e:
-                        return {"assigned_object": str(e)}
+                        except ValidationError as e:
+                            return {"assigned_object": str(e)}
 
                 assigned_object_instance = (
                     assigned_object_model.objects.prefetch_related(*lookups).get(**args)


### PR DESCRIPTION
In diode-netbox-plugin, lookup by interface ID when applying change for IP address, otherwise by given device and site details