### PR TITLE
fix: GHA release workflow

### DIFF
--- a/.github/workflows/reusable_semantic_release.yaml
+++ b/.github/workflows/reusable_semantic_release.yaml
@@ -39,7 +39,6 @@ jobs:
               "version": "1.0.0",
               "extends": "semantic-release-monorepo",
               "devDependencies": {
-                "semantic-release-monorepo": "^7.0.0",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -54,7 +53,6 @@ jobs:
               "branches": "release",
               "repositoryUrl": "https://github.com/netboxlabs/diode",
               "debug": "true",
-              "extends": "semantic-release-monorepo",
               "tagFormat": "${{ inputs.app_name }}/v${version}",
               "plugins": [
                 ["semantic-release-export-data"],

--- a/.github/workflows/reusable_semantic_release_get_next_version.yaml
+++ b/.github/workflows/reusable_semantic_release_get_next_version.yaml
@@ -41,14 +41,11 @@ jobs:
             {
               "name": "${{ inputs.app_name }}",
               "version": "1.0.0",
-              "extends": "semantic-release-monorepo",
               "devDependencies": {
-                "semantic-release-monorepo": "^7.0.0",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^9.0.2",
                 "@semantic-release/github": "^8.0.0",
-                "@semantic-release/npm": "^9.0.0",
                 "@semantic-release/release-notes-generator": "^10.0.0"
               }
             }
@@ -62,7 +59,6 @@ jobs:
               "branches": "release",
               "repositoryUrl": "https://github.com/netboxlabs/diode",
               "debug": "true",
-              "extends": "semantic-release-monorepo",
               "tagFormat": "${{ inputs.app_name }}/v${version}",
               "plugins": [
                 ["semantic-release-export-data"],

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -35,7 +35,7 @@ jobs:
         app: ${{ fromJSON(needs.setup.outputs.apps) }}
     with:
       app_name: diode-${{ matrix.app }}
-      app_dir: diode-server/cmd/${{ matrix.app }}
+      app_dir: diode-server
     secrets: inherit
 
   build:
@@ -98,5 +98,5 @@ jobs:
     if: needs.setup.outputs.app != ''
     with:
       app_name: diode-${{ matrix.app }}
-      app_dir: diode-server/cmd/${{ matrix.app }}
+      app_dir: diode-server
     secrets: inherit


### PR DESCRIPTION
semantic-release-monorepo only picks up changes withing working directory (and where package.json is located) and it seems not possible (AFAIK) to filter which directories to analyse