### PR TITLE
fix: GHA release workflow

### DIFF
--- a/.github/workflows/reusable_semantic_release.yaml
+++ b/.github/workflows/reusable_semantic_release.yaml
@@ -37,7 +37,6 @@ jobs:
             {
               "name": "${{ inputs.app_name }}",
               "version": "1.0.0",
-              "extends": "semantic-release-monorepo",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
@@ -89,4 +88,4 @@ jobs:
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
-        run: npx semantic-release -e semantic-release-monorepo --debug
+        run: npx semantic-release --debug

--- a/.github/workflows/reusable_semantic_release_get_next_version.yaml
+++ b/.github/workflows/reusable_semantic_release_get_next_version.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
-        run: npx semantic-release -e semantic-release-monorepo --debug --dry-run
+        run: npx semantic-release --debug --dry-run
         id: get-next-version
       - name: Set short sha output
         id: short-sha


### PR DESCRIPTION
Remove references to `semantic-release-monorepo`