### PR TITLE
chore: docker-compose - increase nginx client_max_body_size

### DIFF
--- a/diode-server/docker/docker-compose.yaml
+++ b/diode-server/docker/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
         listen ${DIODE_NGINX_PORT};
         http2 on;
         server_name localhost;
+        client_max_body_size 25m;
         location /diode {
           rewrite /diode/(.*) /$$1 break;
           grpc_pass grpc://diode;


### PR DESCRIPTION
Increase nginx's `client_max_body_size` from default `1m` to `25m`