### PR TITLE
fix: docker - configure redis append only file directory

### DIFF
--- a/diode-server/docker/docker-compose.yaml
+++ b/diode-server/docker/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
     command:
       - sh
       - -c
-      - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD --loadmodule /opt/redis-stack/lib/rejson.so --loadmodule /opt/redis-stack/lib/redisearch.so --port $$REDIS_PORT
+      - redis-server --appendonly yes --dir /data --save 60 1 --requirepass $$REDIS_PASSWORD --loadmodule /opt/redis-stack/lib/rejson.so --loadmodule /opt/redis-stack/lib/redisearch.so --port $$REDIS_PORT
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - REDIS_PORT=${REDIS_PORT}


### PR DESCRIPTION
Setting append only file directory to `/data` to match mounted volume so data is loaded between docker compose down and up.

Also setting snapshotting to 60s for at least 1 write operation.