### PR TITLE
feat: store reconciliation errors in redis

### DIFF
--- a/diode-server/netboxdiodeplugin/client_test.go
+++ b/diode-server/netboxdiodeplugin/client_test.go
@@ -574,11 +574,8 @@ func TestApplyChangeSet(t *testing.T) {
 			},
 			mockServerResponse: `{"change_set_id":"00000000-0000-0000-0000-000000000000","result":"error"}`,
 			mockStatusCode:     http.StatusBadRequest,
-			response: &netboxdiodeplugin.ChangeSetResponse{
-				ChangeSetID: "00000000-0000-0000-0000-000000000000",
-				Result:      "error",
-			},
-			shouldError: true,
+			response:           nil,
+			shouldError:        true,
 		},
 		{
 			name:   "unmarshal error",


### PR DESCRIPTION
Store reconciliation and any other errors occurred when processing ingested data in redis. This will allow us to retrieve ingestion logs and display meaningful details regarding failures.

Example:
```json
{
    "data_type": "dcim.device",
    "entity": {
        "Device": {
            "name": "Conference_Room_AP_02",
            "device_type": {
                "model": "Cisco Aironet 3802",
                "manufacturer": {
                    "name": "Cisco"
                }
            },
            "role": {
                "name": "Wireless_AP"
            },
            "serial": "PQR456789012",
            "site": {
                "name": "HQ"
            },
            "asset_tag": ""
        }
    },
    "error": {
        "Message": "failed to apply change set",
        "Code": 400,
        "Details": {
            "change_set_id": "7667cf0a-6499-4312-ba39-e45118282e7f",
            "result": "failed",
            "errors": [
                {
                    "asset_tag": "asset_tag: Device with this Asset tag already exists.",
                    "change_id": "be011399-17a9-47e8-ac25-16fdd35514f1"
                }
            ]
        }
    },
    "ingestion_ts": 1723191515569084347,
    "producer_app_name": "csv-parser",
    "producer_app_version": "0.0.1",
    "request_id": "328491ce-b2c4-48d9-b8eb-9793ff9f32ef",
    "sdk_name": "diode-sdk-python",
    "sdk_version": "0.0.1",
    "state": 2
}
```

Also improve logging:
```json
{
    "time": "2024-08-09T08:18:36.24933293Z",
    "level": "WARN",
    "msg": "failed to handle ingest request",
    "errors": [
        "msg: failed to apply change set, code: 400, change set id: a4b65636-19fc-4001-ab4c-e2b582f48d47, result: failed, errors: [{\"asset_tag\":\"asset_tag: Device with this Asset tag already exists.\",\"change_id\":\"78cadf30-b75d-4c58-8f00-e4dc2bdb178b\"}]",
        "msg: failed to apply change set, code: 400, change set id: a8ce7d8e-20fb-4a52-873c-2c071ce5996b, result: failed, errors: [{\"asset_tag\":\"asset_tag: Device with this Asset tag already exists.\",\"change_id\":\"7646dbb9-511a-48da-9d2e-73eb8cae5a80\"}]",
        "msg: failed to apply change set, code: 400, change set id: 7a154db7-3ac8-4194-848d-bab64ed19089, result: failed, errors: [{\"asset_tag\":\"asset_tag: Device with this Asset tag already exists.\",\"change_id\":\"916cf2b9-0273-40c5-87ab-cdb3d8ee8bbe\"}]",
        "msg: failed to apply change set, code: 400, change set id: adccf83a-a651-48b8-81ec-3e3e574d7c59, result: failed, errors: [{\"asset_tag\":\"asset_tag: Device with this Asset tag already exists.\",\"change_id\":\"bcf5dca9-303b-493b-a098-4061bd670b2a\"}]",
        "msg: failed to apply change set, code: 400, change set id: 7667cf0a-6499-4312-ba39-e45118282e7f, result: failed, errors: [{\"asset_tag\":\"asset_tag: Device with this Asset tag already exists.\",\"change_id\":\"be011399-17a9-47e8-ac25-16fdd35514f1\"}]"
    ]
}

```