### PR TITLE
feat: add golangci-lint gci linter (go package import order)

### DIFF
--- a/.github/golangci.yaml
+++ b/.github/golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - govet
     - gosimple
     - bodyclose
+    - gci
 
 issues:
   exclude-use-default: false
@@ -26,3 +27,11 @@ issues:
 
 severity:
   default-severity: error
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/netboxlabs/diode)
+    custom-order: true

--- a/diode-server/server/server_test.go
+++ b/diode-server/server/server_test.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/netboxlabs/diode/diode-server/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/diode/diode-server/server"
 )
 
 func TestNewServer(t *testing.T) {


### PR DESCRIPTION
Configuring golangci-lint gci linter: https://golangci-lint.run/usage/linters/#gci