### PR TITLE
feat: add diode-reconciler to ingress nginx config

### DIFF
--- a/diode-server/docker/docker-compose.yaml
+++ b/diode-server/docker/docker-compose.yaml
@@ -3,18 +3,24 @@ services:
   ingress-nginx:
     image: nginx:latest
     command: >
-      /bin/sh -c "echo 'upstream diode {
+      /bin/sh -c "echo 'upstream diode-ingester {
         server diode-ingester:8081;
       }
-
+      upstream diode-reconciler {
+        server diode-reconciler:8081;
+      }
       server {
         listen 80;
         http2 on;
         server_name localhost;
         client_max_body_size 25m;
-        location /diode {
+        location /diode/diode.v1.IngesterService {
           rewrite /diode/(.*) /$$1 break;
-          grpc_pass grpc://diode;
+          grpc_pass grpc://diode-ingester;
+        }
+        location /diode/diode.v1.ReconcilerService {
+          rewrite /diode/(.*) /$$1 break;
+          grpc_pass grpc://diode-reconciler;
         }
       }'
       > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
@@ -39,8 +45,7 @@ services:
       - INGESTER_TO_RECONCILER_API_KEY=${INGESTER_TO_RECONCILER_API_KEY}
       - SENTRY_DSN=${SENTRY_DSN}
     restart: always
-    ports:
-      - "8081:8081"
+    ports: [ ]
     depends_on:
       - diode-redis
       - diode-reconciler


### PR DESCRIPTION
![Diode service - Ingestion logs (5)](https://github.com/user-attachments/assets/024fd22f-ca9a-4028-bdb4-1ab98e97e43e)

Logs confirming new configuration works as expected:
```
2024-09-20 14:49:57 192.168.65.1 - - [20/Sep/2024:13:49:57 +0000] "POST /diode/diode.v1.IngesterService/Ingest HTTP/2.0" 200 5 "-" "diode-sdk-go/0.2.0 grpc-go/1.63.2" "-"
2024-09-20 14:49:59 192.168.65.1 - - [20/Sep/2024:13:49:59 +0000] "POST /diode/diode.v1.ReconcilerService/RetrieveIngestionLogs HTTP/2.0" 200 9537 "-" "reconciler-sdk-python/0.0.1 netbox_diode_plugin/0.0.0 grpc-python/1.62.1 grpc-c/39.0.0 (linux; chttp2)" "-"
```

