### PR TITLE
chore: GHA release - use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/reusable_semantic_release.yaml
+++ b/.github/workflows/reusable_semantic_release.yaml
@@ -10,7 +10,7 @@ on:
         required: true
 
 env:
-  GH_TOKEN: ${{ secrets.ORB_CI_GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SLACK_SEMANTIC_RELEASE_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
 
 jobs:

--- a/.github/workflows/reusable_semantic_release_get_next_version.yaml
+++ b/.github/workflows/reusable_semantic_release_get_next_version.yaml
@@ -17,7 +17,7 @@ on:
         value: ${{ jobs.get-next-version.outputs.short-sha }}
 
 env:
-  GH_TOKEN: ${{ secrets.ORB_CI_GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SLACK_SEMANTIC_RELEASE_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
 
 jobs:

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GH_TOKEN: ${{ secrets.ORB_CI_GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
   GO_VERSION: '1.23'
 


### PR DESCRIPTION
- reason: decommission use of `ORB_CI_GH_TOKEN`