### PR TITLE
fix: retrieve ingestion logs with null change set

### DIFF
--- a/diode-server/gen/dbstore/postgres/types.go
+++ b/diode-server/gen/dbstore/postgres/types.go
@@ -65,6 +65,6 @@ type VIngestionLogsWithChangeSet struct {
 	SourceMetadata     []byte             `json:"source_metadata"`
 	CreatedAt          pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
-	ChangeSet          ChangeSet          `json:"change_set"`
+	ChangeSet          *ChangeSet         `json:"change_set"`
 	Changes            []byte             `json:"changes"`
 }

--- a/diode-server/sqlc.yaml
+++ b/diode-server/sqlc.yaml
@@ -14,6 +14,7 @@ sql:
           - column: v_ingestion_logs_with_change_set.change_set
             go_type:
               type: ChangeSet
+              pointer: true
           - column: changes.data
             go_type:
               type: any


### PR DESCRIPTION
When change set is not being created, for example due to unreachable NetBox, postgres view returns NULL value and row scanning cannot cast to type value:
```
can't scan into dest[15]: cannot scan NULL into *postgres.ChangeSet
```

We can solve this by changing ChangeSet type to pointer with sqlc config.

<img width="1613" alt="Screenshot 2024-12-30 at 21 38 04" src="https://github.com/user-attachments/assets/eb0a5f25-241f-4272-a719-d6551b6a1525" />
