### PR TITLE
fix: NO_CHANGES state on empty change set

### DIFF
--- a/diode-server/reconciler/ingestion_processor_internal_test.go
+++ b/diode-server/reconciler/ingestion_processor_internal_test.go
@@ -434,6 +434,41 @@ func TestIngestionProcessor_GenerateAndApplyChangeSet(t *testing.T) {
 			expectedStatus:      reconcilerpb.State_OPEN,
 			expectedError:       false,
 		},
+		{
+			name: "generate change set without changes",
+			ingestionLog: &reconcilerpb.IngestionLog{
+				Id:                 uuid.NewString(),
+				RequestId:          "cfa0f129-125c-440d-9e41-e87583cd7d89",
+				ProducerAppName:    "test-app",
+				ProducerAppVersion: "0.1.0",
+				SdkName:            "diode-sdk-go",
+				SdkVersion:         "0.2.0",
+				ObjectType:         "dcim.site",
+				Entity: &diodepb.Entity{
+					Entity: &diodepb.Entity_Site{
+						Site: &diodepb.Site{
+							Name: "Site A",
+						},
+					},
+				},
+				IngestionTs: time.Now().UnixNano(),
+				State:       reconcilerpb.State_QUEUED,
+			},
+			mockRetrieveObjectStateResponse: &netboxdiodeplugin.ObjectState{
+				ObjectType: "dcim.site",
+				ObjectID:   1,
+				Object: &netbox.DcimSiteDataWrapper{
+					Site: &netbox.DcimSite{
+						ID:   1,
+						Name: "Site A",
+						Slug: "site-a",
+					},
+				},
+			},
+			autoApplyChangesets: false,
+			expectedStatus:      reconcilerpb.State_NO_CHANGES,
+			expectedError:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -457,12 +492,12 @@ func TestIngestionProcessor_GenerateAndApplyChangeSet(t *testing.T) {
 
 			ingestionLogID := int32(1)
 
-			mockRepository.On("UpdateIngestionLogStateWithError", ctx, ingestionLogID, reconcilerpb.State_OPEN, mock.Anything).Return(nil)
 			mockNbClient.On("RetrieveObjectState", ctx, mock.Anything).Return(tt.mockRetrieveObjectStateResponse, nil)
 			if tt.autoApplyChangesets {
-				mockRepository.On("UpdateIngestionLogStateWithError", ctx, ingestionLogID, tt.expectedStatus, mock.Anything).Return(nil)
+				mockRepository.On("UpdateIngestionLogStateWithError", ctx, ingestionLogID, reconcilerpb.State_OPEN, mock.Anything).Return(nil)
 				mockNbClient.On("ApplyChangeSet", ctx, mock.Anything).Return(tt.mockApplyChangeSetResponse, nil)
 			}
+			mockRepository.On("UpdateIngestionLogStateWithError", ctx, ingestionLogID, tt.expectedStatus, mock.Anything).Return(nil)
 			mockRepository.On("CreateChangeSet", ctx, mock.Anything, ingestionLogID).Return(int32Ptr(1), nil)
 
 			bufCapacity := 1

--- a/diode-server/reconciler/ops.go
+++ b/diode-server/reconciler/ops.go
@@ -67,17 +67,14 @@ func (o *Ops) GenerateChangeSet(ctx context.Context, ingestionLogID int32, inges
 		return nil, nil, err
 	}
 
+	state := reconcilerpb.State_OPEN
 	if len(changeSet.ChangeSet) == 0 {
-		ingestionLog.State = reconcilerpb.State_NO_CHANGES
-		if err := o.repository.UpdateIngestionLogStateWithError(ctx, ingestionLogID, reconcilerpb.State_NO_CHANGES, nil); err != nil {
-			o.logger.Warn("failed to update ingestion log state (error ignored)", "ingestionLogID", ingestionLogID, "error", err)
-			// TODO(ltucker): This should be in a transaction.  Can leave an inconsistent state marked on the ingestion log.
-			// return nil, err
-		}
+		state = reconcilerpb.State_NO_CHANGES
 	}
 
-	ingestionLog.State = reconcilerpb.State_OPEN
-	if err := o.repository.UpdateIngestionLogStateWithError(ctx, ingestionLogID, reconcilerpb.State_OPEN, nil); err != nil {
+	ingestionLog.State = state
+
+	if err := o.repository.UpdateIngestionLogStateWithError(ctx, ingestionLogID, state, nil); err != nil {
 		o.logger.Warn("failed to update ingestion log state (error ignored)", "ingestionLogID", ingestionLogID, "error", err)
 		// TODO(ltucker): This should be in a transaction.  Can leave an inconsistent state marked on the ingestion log.
 		// return nil, err


### PR DESCRIPTION
Enhancements to ingestion process and change set handling:

* [`diode-server/reconciler/ops.go`](diffhunk://#diff-b77c00f1ed9dfc36d1b5c951497705b84d1fd9c372691e93e3648c15fe42ac00R70-R77): Refactored the logic to set the ingestion log state to `NO_CHANGES` if the generated change set is empty. This change consolidates the state update logic and ensures consistency by updating the state in one place.
* [`diode-server/reconciler/ingestion_processor_internal_test.go`](diffhunk://#diff-483c6b79031bd3ecaa94fee7fb5c66b7377e91fd630f69594c69f172d4d070b7R437-R471): Added a new test case to handle scenarios where the change set is generated without any changes. This test case ensures that the state is correctly set to `NO_CHANGES` when there are no updates.
* [`diode-server/reconciler/ingestion_processor_internal_test.go`](diffhunk://#diff-483c6b79031bd3ecaa94fee7fb5c66b7377e91fd630f69594c69f172d4d070b7L460-R500): Modified the mock repository behavior to update the ingestion log state with the expected status after checking the `autoApplyChangesets` flag. This ensures that the state is correctly updated regardless of whether changesets are auto-applied.