### PR TITLE
fix: ensure consistent change data json fields order

### DIFF
--- a/diode-server/dbstore/postgres/repository.go
+++ b/diode-server/dbstore/postgres/repository.go
@@ -13,6 +13,7 @@ import (
 	"github.com/netboxlabs/diode/diode-server/gen/dbstore/postgres"
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/reconcilerpb"
+	"github.com/netboxlabs/diode/diode-server/netbox"
 	"github.com/netboxlabs/diode/diode-server/reconciler/changeset"
 )
 
@@ -389,11 +390,17 @@ func (r *Repository) RetrieveDeviations(ctx context.Context, filter *reconcilerp
 					ObjectPrimaryValue: dbChange.ObjectPrimaryValue,
 				}
 				if dbChange.Before != nil {
-					beforeJSON, _ := json.Marshal(dbChange.Before)
+					beforeJSON, err := MarshalChangeDataToJSON(dbChange.Before, dbChange.ObjectType)
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal before state: %w", err)
+					}
 					change.Before = beforeJSON
 				}
 				if dbChange.After != nil {
-					afterJSON, _ := json.Marshal(dbChange.After)
+					afterJSON, err := MarshalChangeDataToJSON(dbChange.After, dbChange.ObjectType)
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal after state: %w", err)
+					}
 					change.After = afterJSON
 				}
 				changes = append(changes, change)
@@ -467,11 +474,17 @@ func (r *Repository) RetrieveDeviationByID(ctx context.Context, externalID strin
 				ObjectPrimaryValue: dbChange.ObjectPrimaryValue,
 			}
 			if dbChange.Before != nil {
-				beforeJSON, _ := json.Marshal(dbChange.Before)
+				beforeJSON, err := MarshalChangeDataToJSON(dbChange.Before, dbChange.ObjectType)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal before state: %w", err)
+				}
 				change.Before = beforeJSON
 			}
 			if dbChange.After != nil {
-				afterJSON, _ := json.Marshal(dbChange.After)
+				afterJSON, err := MarshalChangeDataToJSON(dbChange.After, dbChange.ObjectType)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal after state: %w", err)
+				}
 				change.After = afterJSON
 			}
 			changes = append(changes, change)
@@ -481,4 +494,173 @@ func (r *Repository) RetrieveDeviationByID(ctx context.Context, externalID strin
 	}
 
 	return deviation, nil
+}
+
+// MarshalChangeDataToJSON marshals change data to JSON.
+func MarshalChangeDataToJSON(data any, objectType string) ([]byte, error) {
+	dataJSON, _ := json.Marshal(data)
+	switch objectType {
+	case netbox.DcimDeviceObjectType:
+		var o netbox.DcimDevice
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal device data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal device data: %w", err)
+		}
+		return b, nil
+	case netbox.DcimDeviceRoleObjectType:
+		var o netbox.DcimDeviceRole
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal device role data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal device role data: %w", err)
+		}
+		return b, nil
+	case netbox.DcimDeviceTypeObjectType:
+		var o netbox.DcimDeviceType
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal device type data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal device type data: %w", err)
+		}
+		return b, nil
+	case netbox.DcimInterfaceObjectType:
+		var o netbox.DcimInterface
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal interface data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal interface data: %w", err)
+		}
+		return b, nil
+	case netbox.DcimManufacturerObjectType:
+		var o netbox.DcimManufacturer
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal manufacturer data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal manufacturer data: %w", err)
+		}
+		return b, nil
+	case netbox.DcimPlatformObjectType:
+		var o netbox.DcimPlatform
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal platform data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal platform data: %w", err)
+		}
+		return b, nil
+	case netbox.DcimSiteObjectType:
+		var o netbox.DcimSite
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal site data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal site data: %w", err)
+		}
+		return b, nil
+	case netbox.ExtrasTagObjectType:
+		var o netbox.Tag
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal tag data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal tag data: %w", err)
+		}
+		return b, nil
+	case netbox.IpamIPAddressObjectType:
+		var o netbox.IpamIPAddress
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal ip address data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal ip address data: %w", err)
+		}
+		return b, nil
+	case netbox.IpamPrefixObjectType:
+		var o netbox.IpamPrefix
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal prefix data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal prefix data: %w", err)
+		}
+		return b, nil
+	case netbox.VirtualizationClusterGroupObjectType:
+		var o netbox.VirtualizationClusterGroup
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cluster group data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal cluster group data: %w", err)
+		}
+		return b, nil
+	case netbox.VirtualizationClusterTypeObjectType:
+		var o netbox.VirtualizationClusterType
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cluster type data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal cluster type data: %w", err)
+		}
+		return b, nil
+	case netbox.VirtualizationClusterObjectType:
+		var o netbox.VirtualizationCluster
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cluster data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal cluster data: %w", err)
+		}
+		return b, nil
+	case netbox.VirtualizationVirtualMachineObjectType:
+		var o netbox.VirtualizationVirtualMachine
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal virtual machine data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal virtual machine data: %w", err)
+		}
+		return b, nil
+	case netbox.VirtualizationVMInterfaceObjectType:
+		var o netbox.VirtualizationVMInterface
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal vm interface data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal vm interface data: %w", err)
+		}
+		return b, nil
+	case netbox.VirtualizationVirtualDiskObjectType:
+		var o netbox.VirtualizationVirtualDisk
+		if err := json.Unmarshal(dataJSON, &o); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal virtual disk data: %w", err)
+		}
+		b, err := json.Marshal(o)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal virtual disk data: %w", err)
+		}
+		return b, nil
+	default:
+		return nil, fmt.Errorf("unsupported object type: %s", objectType)
+	}
 }

--- a/diode-server/reconciler/deviation_test.go
+++ b/diode-server/reconciler/deviation_test.go
@@ -20,12 +20,13 @@ import (
 
 func TestRetrieveDeviations(t *testing.T) {
 	tests := []struct {
-		name       string
-		deviations []*reconcilerpb.Deviation
-		req        *reconcilerpb.RetrieveDeviationsRequest
-		resp       *reconcilerpb.RetrieveDeviationsResponse
-		repoError  error
-		wantErr    error
+		name            string
+		deviations      []*reconcilerpb.Deviation
+		req             *reconcilerpb.RetrieveDeviationsRequest
+		resp            *reconcilerpb.RetrieveDeviationsResponse
+		changeAfterJSON []byte
+		repoError       error
+		wantErr         error
 	}{
 		{
 			name: "deviations found",
@@ -94,8 +95,9 @@ func TestRetrieveDeviations(t *testing.T) {
 					LastUpdateTs: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
 				},
 			},
-			repoError: nil,
-			wantErr:   nil,
+			changeAfterJSON: []byte(`{"id": 1, "name": "X", "description": "Example description"}`),
+			repoError:       nil,
+			wantErr:         nil,
 		},
 	}
 	for i := range tests {
@@ -135,6 +137,7 @@ func TestRetrieveDeviations(t *testing.T) {
 					assert.Equal(t, len(tt.deviations[i].Changes), len(deviation.Changes))
 					assert.Equal(t, tt.deviations[i].Changes[0].Before, deviation.Changes[0].Before)
 					assert.Equal(t, tt.deviations[i].Changes[0].After, deviation.Changes[0].After)
+					assert.Equal(t, tt.changeAfterJSON, deviation.Changes[0].After)
 					require.NotZero(t, deviation.IngestionTs)
 					require.NotZero(t, deviation.LastUpdateTs)
 					assert.Equal(t, tt.deviations[i].IngestionTs, deviation.IngestionTs)
@@ -148,12 +151,13 @@ func TestRetrieveDeviations(t *testing.T) {
 
 func TestRetrieveDeviationByID(t *testing.T) {
 	tests := []struct {
-		name      string
-		deviation *reconcilerpb.Deviation
-		req       *reconcilerpb.RetrieveDeviationByIDRequest
-		resp      *reconcilerpb.RetrieveDeviationByIDResponse
-		repoError error
-		wantErr   error
+		name            string
+		deviation       *reconcilerpb.Deviation
+		req             *reconcilerpb.RetrieveDeviationByIDRequest
+		resp            *reconcilerpb.RetrieveDeviationByIDResponse
+		changeAfterJSON []byte
+		repoError       error
+		wantErr         error
 	}{
 		{
 			name: "deviation found",
@@ -218,8 +222,9 @@ func TestRetrieveDeviationByID(t *testing.T) {
 				IngestionTs:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
 				LastUpdateTs: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
 			},
-			repoError: nil,
-			wantErr:   nil,
+			changeAfterJSON: []byte(`{"id": 1, "name": "X", "description": "Example description"}`),
+			repoError:       nil,
+			wantErr:         nil,
 		},
 		{
 			name:      "deviation not found",
@@ -266,6 +271,7 @@ func TestRetrieveDeviationByID(t *testing.T) {
 				assert.Equal(t, len(tt.resp.Deviation.Changes), len(response.Deviation.Changes))
 				assert.Equal(t, tt.resp.Deviation.Changes[0].Before, response.Deviation.Changes[0].Before)
 				assert.Equal(t, tt.resp.Deviation.Changes[0].After, response.Deviation.Changes[0].After)
+				assert.Equal(t, tt.changeAfterJSON, response.Deviation.Changes[0].After)
 				require.NotZero(t, response.Deviation.IngestionTs)
 				require.NotZero(t, response.Deviation.LastUpdateTs)
 				assert.Equal(t, tt.resp.Deviation.IngestionTs, response.Deviation.IngestionTs)


### PR DESCRIPTION
This pull request introduces a new function to handle JSON marshaling for different object types and updates existing methods to use this function in the `diode-server/dbstore/postgres/repository.go` file. The most important changes include the addition of the `MarshalChangeDataToJSON` function and updates to the `RetrieveDeviations` and `RetrieveDeviationByID` methods to handle errors more effectively.

### Codebase Improvements:

* [`diode-server/dbstore/postgres/repository.go`](diffhunk://#diff-b09a3677ee89bbcf37c20a93ab9afd8362545b47c4074104b0b488b564b10cf1R498-R666): Added the `MarshalChangeDataToJSON` function to handle JSON marshaling for different object types, improving code readability and maintainability.
* [`diode-server/dbstore/postgres/repository.go`](diffhunk://#diff-b09a3677ee89bbcf37c20a93ab9afd8362545b47c4074104b0b488b564b10cf1L392-R403): Updated the `RetrieveDeviations` method to use `MarshalChangeDataToJSON` for marshaling the `Before` and `After` states, and added error handling for the marshaling process.
* [`diode-server/dbstore/postgres/repository.go`](diffhunk://#diff-b09a3677ee89bbcf37c20a93ab9afd8362545b47c4074104b0b488b564b10cf1L470-R487): Updated the `RetrieveDeviationByID` method to use `MarshalChangeDataToJSON` for marshaling the `Before` and `After` states, and added error handling for the marshaling process.

### Dependency Updates:

* [`diode-server/dbstore/postgres/repository.go`](diffhunk://#diff-b09a3677ee89bbcf37c20a93ab9afd8362545b47c4074104b0b488b564b10cf1R16): Added an import statement for the `netbox` package to support the new marshaling function.