### PR TITLE
fix: add custom json unmarshal for ip address assigned object

### DIFF
--- a/diode-server/netbox/ipam.go
+++ b/diode-server/netbox/ipam.go
@@ -1,6 +1,7 @@
 package netbox
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -262,4 +263,33 @@ func FromProtoPrefix(prefixPb *diodepb.Prefix) *IpamPrefix {
 		Comments:     prefixPb.Comments,
 		Tags:         FromProtoTags(prefixPb.Tags),
 	}
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (ip *IpamIPAddress) UnmarshalJSON(data []byte) error {
+	type Alias IpamIPAddress // Create alias to avoid recursive UnmarshalJSON calls
+
+	aux := struct {
+		*Alias
+		AssignedObject map[string]interface{} `json:"assigned_object"`
+	}{
+		Alias: (*Alias)(ip),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Handle AssignedObject based on the map contents
+	if aux.AssignedObject != nil {
+		if _, hasInterface := aux.AssignedObject["interface"]; hasInterface {
+			var ipInterface IPAddressInterface
+			if err := mapstructure.Decode(aux.AssignedObject, &ipInterface); err != nil {
+				return fmt.Errorf("failed to decode assigned object: %w", err)
+			}
+			ip.AssignedObject = &ipInterface
+		}
+	}
+
+	return nil
 }

--- a/diode-server/netbox/ipam_test.go
+++ b/diode-server/netbox/ipam_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/netboxlabs/diode/diode-server/netbox"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/diode/diode-server/netbox"
 )
 
 func TestIpamIPAddress_UnmarshalJSON(t *testing.T) {

--- a/diode-server/netbox/ipam_test.go
+++ b/diode-server/netbox/ipam_test.go
@@ -1,9 +1,10 @@
-package netbox
+package netbox_test
 
 import (
 	"encoding/json"
 	"testing"
 
+	"github.com/netboxlabs/diode/diode-server/netbox"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,7 +12,7 @@ func TestIpamIPAddress_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
 		json    string
-		want    *IpamIPAddress
+		want    *netbox.IpamIPAddress
 		wantErr bool
 	}{
 		{
@@ -28,11 +29,11 @@ func TestIpamIPAddress_UnmarshalJSON(t *testing.T) {
 				"status": "active",
 				"dns_name": "test.example.com"
 			}`,
-			want: &IpamIPAddress{
+			want: &netbox.IpamIPAddress{
 				ID:      1,
 				Address: "192.168.1.1",
-				AssignedObject: &IPAddressInterface{
-					Interface: &DcimInterface{
+				AssignedObject: &netbox.IPAddressInterface{
+					Interface: &netbox.DcimInterface{
 						ID:   123,
 						Name: "eth0",
 					},
@@ -49,7 +50,7 @@ func TestIpamIPAddress_UnmarshalJSON(t *testing.T) {
 				"address": "192.168.1.2",
 				"status": "active"
 			}`,
-			want: &IpamIPAddress{
+			want: &netbox.IpamIPAddress{
 				ID:      2,
 				Address: "192.168.1.2",
 				Status:  stringPtr("active"),
@@ -66,7 +67,7 @@ func TestIpamIPAddress_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var got IpamIPAddress
+			var got netbox.IpamIPAddress
 			err := json.Unmarshal([]byte(tt.json), &got)
 
 			if tt.wantErr {

--- a/diode-server/netbox/ipam_test.go
+++ b/diode-server/netbox/ipam_test.go
@@ -1,0 +1,86 @@
+package netbox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIpamIPAddress_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    *IpamIPAddress
+		wantErr bool
+	}{
+		{
+			name: "valid IP address with interface",
+			json: `{
+				"id": 1,
+				"address": "192.168.1.1",
+				"assigned_object": {
+					"interface": {
+						"id": 123,
+						"name": "eth0"
+					}
+				},
+				"status": "active",
+				"dns_name": "test.example.com"
+			}`,
+			want: &IpamIPAddress{
+				ID:      1,
+				Address: "192.168.1.1",
+				AssignedObject: &IPAddressInterface{
+					Interface: &DcimInterface{
+						ID:   123,
+						Name: "eth0",
+					},
+				},
+				Status:  stringPtr("active"),
+				DNSName: stringPtr("test.example.com"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid IP address without assigned object",
+			json: `{
+				"id": 2,
+				"address": "192.168.1.2",
+				"status": "active"
+			}`,
+			want: &IpamIPAddress{
+				ID:      2,
+				Address: "192.168.1.2",
+				Status:  stringPtr("active"),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON",
+			json:    `{"id": 1, "address": }`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got IpamIPAddress
+			err := json.Unmarshal([]byte(tt.json), &got)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, &got)
+		})
+	}
+}
+
+// stringPtr returns a pointer to the string value passed in
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
This fixes an error in `MarshalChangeDataToJSON` when working with an `ipam.ipaddress` containing an assigned object.

```failed to marshal after state: failed to unmarshal ip address data: json: cannot unmarshal object into Go struct field IpamIPAddress.assigned_object of type netbox.IPAddressAssignedObject ```

The AssignedObject field of IpamIPAddress (IPAddressAssignedObject) is an interface type which json cannot directly unmarshal (doesn't know which implementing type to create).  Elsewhere there is a mapstructure helper `IpamIPAddressAssignedObjectHookFunc` that is used. 

This adds a custom `UnmarshalJSON` to the `IpamIPAddress` struct which does something very similar.  Possibly could be combined or simplified eslewhere, though mapstructure is used directly.