### PR TITLE
fix: dcim.interface missing change before state

### DIFF
--- a/diode-server/netbox/dcim_wrappers.go
+++ b/diode-server/netbox/dcim_wrappers.go
@@ -1126,6 +1126,8 @@ func (dw *DcimInterfaceDataWrapper) Patch(cmp ComparableData, intendedNestedObje
 			currentNestedObjectsMap[fmt.Sprintf("%p", obj.Data())] = obj
 		}
 
+		dw.intendedData = intended.Data()
+
 		dw.Interface.ID = intended.Interface.ID
 		dw.Interface.Name = intended.Interface.Name
 


### PR DESCRIPTION
This pull request includes a small change to the `diode-server/netbox/dcim_wrappers.go` file. The change updates the `Patch` method in the `DcimInterfaceDataWrapper` struct to ensure that `intendedData` is set from the `intended` parameter.

* [`diode-server/netbox/dcim_wrappers.go`](diffhunk://#diff-f74ba408ea47e9bde2fba8cc177086d2701a6929b00f167f601c2d09fa9a0852R1129-R1130): Added a line to set `dw.intendedData` to `intended.Data()` in the `Patch` method.