### PR TITLE
Fix: update migration to fix broken function declaration

### DIFF
--- a/diode-server/dbstore/postgres/migrations/00001_ingestion_logs.sql
+++ b/diode-server/dbstore/postgres/migrations/00001_ingestion_logs.sql
@@ -28,19 +28,22 @@ CREATE INDEX IF NOT EXISTS idx_ingestion_logs_state ON ingestion_logs (state);
 CREATE INDEX IF NOT EXISTS idx_ingestion_logs_request_id ON ingestion_logs (request_id);
 
 -- Create trigger function
-CREATE OR REPLACE FUNCTION update_updated_at_column()
-RETURNS TRIGGER AS $$
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_updated_at_column() RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = CURRENT_TIMESTAMP;
     RETURN NEW;
 END;
-$$ language 'plpgsql';
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
 
 -- Create trigger
+-- +goose StatementBegin
 CREATE TRIGGER update_ingestion_logs_updated_at
     BEFORE UPDATE ON ingestion_logs
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
+-- +goose StatementEnd
 
 -- +goose Down
 


### PR DESCRIPTION
Was getting `unterminated dollar-quoted string at or near "$$`

Requires some special goose annotations for statements with ; looks like. 