### PR TITLE
feat: assign a name to changesets with no changes

### DIFF
--- a/diode-server/reconciler/differ/differ.go
+++ b/diode-server/reconciler/differ/differ.go
@@ -97,7 +97,7 @@ func Diff(ctx context.Context, entity IngestEntity, branchID string, netboxAPI n
 		changes = append(changes, change)
 	}
 
-	deviationName := genDeviationName(objectsToReconcile)
+	deviationName := genDeviationName(objectsToReconcile, entity.ObjectType)
 
 	cs := &changeset.ChangeSet{ChangeSetID: uuid.NewString(), ChangeSet: changes, DeviationName: deviationName}
 	if branchID != "" {
@@ -192,13 +192,23 @@ func extractNetBoxObjectStateData(obj ObjectState) (netbox.ComparableData, error
 	return dw, nil
 }
 
-func genDeviationName(objects []netbox.ComparableData) *string {
+func genDeviationName(objects []netbox.ComparableData, objectType string) *string {
+	var typeName string
+
+	t, err := netbox.NewDataWrapper(objectType)
+	if err != nil {
+		typeName = objectType
+	} else {
+		typeName = t.ObjectTypeName()
+	}
+
 	if len(objects) == 0 {
-		return nil
+		deviationName := fmt.Sprintf("%s unchanged", typeName)
+		return &deviationName
 	}
 
 	primaryObject := objects[len(objects)-1]
-	deviationName := fmt.Sprintf("%s %s", primaryObject.ObjectTypeName(), primaryObject.ObjectPrimaryValue())
+	deviationName := fmt.Sprintf("%s %s", typeName, primaryObject.ObjectPrimaryValue())
 
 	if primaryObject.ID() > 0 {
 		deviationName += " modified"

--- a/diode-server/reconciler/differ/differ_test.go
+++ b/diode-server/reconciler/differ/differ_test.go
@@ -106,7 +106,7 @@ func TestGenDeviationName(t *testing.T) {
 			wantChangeSet: changeset.ChangeSet{
 				ChangeSetID:   "5663a77e-9bad-4981-afe9-77d8a9f2b8b5",
 				ChangeSet:     []changeset.Change{},
-				DeviationName: nil,
+				DeviationName: strPtr("Site unchanged"),
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
This pull request includes updates to the `diode-server/reconciler/differ` package to enhance the generation of deviation names by incorporating the object type. The most important changes include modifications to the `genDeviationName` function and its usage, as well as updates to the corresponding tests.

Enhancements to deviation name generation:

* [`diode-server/reconciler/differ/differ.go`](diffhunk://#diff-8b58c9783e8eb190ee1f1d9231497e1258392144a0cafc34b235540c3fc13cafL195-R211): Updated the `genDeviationName` function to accept an additional `objectType` parameter and use it to generate more descriptive deviation names.
* [`diode-server/reconciler/differ/differ.go`](diffhunk://#diff-8b58c9783e8eb190ee1f1d9231497e1258392144a0cafc34b235540c3fc13cafL100-R100): Modified the call to `genDeviationName` in the `Diff` function to pass the new `objectType` parameter.

Updates to tests:

* [`diode-server/reconciler/differ/differ_test.go`](diffhunk://#diff-c9ff870d47cb55cc2b4a11b08f56d0310f033d1f1c539088f21556ecbe631ef7L109-R109): Adjusted the `TestGenDeviationName` test to reflect the changes in the `genDeviationName` function, ensuring it correctly handles the new deviation name format.