### PR TITLE
adds rate limiting to calls to netbox

### DIFF
--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	repository := postgres.NewRepository(dbPool)
 
-	nbClient, err := netboxdiodeplugin.NewClient(s.Logger(), cfg.DiodeToNetBoxAPIKey)
+	nbClient, err := netboxdiodeplugin.NewClient(s.Logger(), cfg.DiodeToNetBoxAPIKey, cfg.DiodeToNetboxRateLimiterRPS, cfg.DiodeToNetboxRateLimiterBurst)
 	if err != nil {
 		s.Logger().Error("failed to create netbox diode plugin client", "error", err)
 	}

--- a/diode-server/netboxdiodeplugin/client.go
+++ b/diode-server/netboxdiodeplugin/client.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -160,6 +161,7 @@ type Client struct {
 	logger     *slog.Logger
 	httpClient *http.Client
 	baseURL    *url.URL
+	limiter    *rate.Limiter
 }
 
 // NewHTTPTransport creates a http Transport Layer
@@ -182,7 +184,7 @@ func NewHTTPTransport() *http.Transport {
 }
 
 // NewClient creates a new NetBox Diode plugin client
-func NewClient(logger *slog.Logger, apiKey string) (*Client, error) {
+func NewClient(logger *slog.Logger, apiKey string, rateLimitRps, rateLimitBurstRps int) (*Client, error) {
 	transport := NewHTTPTransport()
 
 	rt, err := newAPIRoundTripper(apiKey, transport)
@@ -209,6 +211,7 @@ func NewClient(logger *slog.Logger, apiKey string) (*Client, error) {
 		logger:     logger,
 		httpClient: httpClient,
 		baseURL:    u,
+		limiter:    rate.NewLimiter(rate.Limit(rateLimitRps), rateLimitBurstRps),
 	}
 
 	return client, nil
@@ -300,6 +303,10 @@ func (c *Client) GenerateDiff(ctx context.Context, payload GenerateDiffRequest) 
 		return nil, err
 	}
 
+	if err := c.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL.String(), bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, err
@@ -372,6 +379,10 @@ func (c *Client) ApplyChangeSet(ctx context.Context, payload ApplyChangeSetReque
 
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := c.limiter.Wait(ctx); err != nil {
 		return nil, err
 	}
 

--- a/diode-server/netboxdiodeplugin/client.go
+++ b/diode-server/netboxdiodeplugin/client.go
@@ -207,6 +207,10 @@ func NewClient(logger *slog.Logger, apiKey string, rateLimitRps, rateLimitBurstR
 		return nil, err
 	}
 
+	if rateLimitRps <= 0 || rateLimitBurstRps <= 0 {
+		return nil, fmt.Errorf("invalid rate limit values: %d %d", rateLimitRps, rateLimitBurstRps)
+	}
+
 	client := &Client{
 		logger:     logger,
 		httpClient: httpClient,

--- a/diode-server/netboxdiodeplugin/client_test.go
+++ b/diode-server/netboxdiodeplugin/client_test.go
@@ -144,7 +144,7 @@ func TestNewClient(t *testing.T) {
 				_ = os.Setenv(netboxdiodeplugin.TLSSkipVerifyEnvVarName, "true")
 			}
 
-			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey)
+			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey, 1, 1)
 			if tt.shouldError {
 				require.Error(t, err)
 				return
@@ -164,6 +164,8 @@ func TestGenerateDiff(t *testing.T) {
 		mockStatusCode      int
 		expectedBody        string
 		mockServerResponse  string
+		rateLimiterRPS      int
+		rateLimiterBurst    int
 		response            *netboxdiodeplugin.GenerateDiffResponse
 		shouldError         bool
 	}{
@@ -186,6 +188,8 @@ func TestGenerateDiff(t *testing.T) {
 			mockStatusCode:     http.StatusOK,
 			expectedBody:       `{"object_type":"dcim.device","entity":{"device":{"name":"test","site":{"name":"test-site"}}}}`,
 			mockServerResponse: `{"changes": [{"id": "00000000-0000-0000-0000-000000000001", "change_type": "create", "object_type": "dcim.device", "data": {"name": "test"}}]}`,
+			rateLimiterRPS:     1,
+			rateLimiterBurst:   1,
 			response: &netboxdiodeplugin.GenerateDiffResponse{
 				Changes: []netboxdiodeplugin.Change{
 					{
@@ -196,6 +200,31 @@ func TestGenerateDiff(t *testing.T) {
 					},
 				},
 			},
+			shouldError: false,
+		},
+		{
+			name:   "valid generate diff response",
+			apiKey: "foobar",
+			generateDiffRequest: netboxdiodeplugin.GenerateDiffRequest{
+				ObjectType: "dcim.device",
+				Entity: &diodepb.Entity{
+					Entity: &diodepb.Entity_Device{
+						Device: &diodepb.Device{
+							Name: strPtr("test"),
+							Site: &diodepb.Site{
+								Name: "test-site",
+							},
+						},
+					},
+				},
+			},
+			mockStatusCode:     http.StatusOK,
+			expectedBody:       `{"object_type":"dcim.device","entity":{"device":{"name":"test","site":{"name":"test-site"}}}}`,
+			mockServerResponse: `{"changes": [{"id": "00000000-0000-0000-0000-000000000001", "change_type": "create", "object_type": "dcim.device", "data": {"name": "test"}}]}`,
+			rateLimiterRPS:     0, // Any calls made to netbox will be rate limited
+			rateLimiterBurst:   0,
+			response:           nil,
+			shouldError:        true,
 		},
 	}
 
@@ -230,7 +259,7 @@ func TestGenerateDiff(t *testing.T) {
 
 			_ = os.Setenv(netboxdiodeplugin.BaseURLEnvVarName, fmt.Sprintf("%s/api/diode", ts.URL))
 
-			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey)
+			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey, tt.rateLimiterRPS, tt.rateLimiterBurst)
 			require.NoError(t, err)
 			resp, err := client.GenerateDiff(context.Background(), tt.generateDiffRequest)
 			if tt.shouldError {
@@ -252,6 +281,8 @@ func TestApplyChangeSet(t *testing.T) {
 		changeSetRequest   netboxdiodeplugin.ApplyChangeSetRequest
 		mockServerResponse string
 		mockStatusCode     int
+		rateLimiterRPS     int
+		rateLimiterBurst   int
 		response           *netboxdiodeplugin.ApplyChangeSetResponse
 		shouldError        bool
 	}{
@@ -281,6 +312,8 @@ func TestApplyChangeSet(t *testing.T) {
 			},
 			mockServerResponse: `{"id":"00000000-0000-0000-0000-000000000000","result":"success"}`,
 			mockStatusCode:     http.StatusOK,
+			rateLimiterRPS:     1,
+			rateLimiterBurst:   1,
 			response: &netboxdiodeplugin.ApplyChangeSetResponse{
 				ID:     "00000000-0000-0000-0000-000000000000",
 				Result: "success",
@@ -306,11 +339,37 @@ func TestApplyChangeSet(t *testing.T) {
 			},
 			mockServerResponse: `{"id":"00000000-0000-0000-0000-000000000000","result":"success"}`,
 			mockStatusCode:     http.StatusOK,
+			rateLimiterRPS:     1,
+			rateLimiterBurst:   1,
 			response: &netboxdiodeplugin.ApplyChangeSetResponse{
 				ID:     "00000000-0000-0000-0000-000000000000",
 				Result: "success",
 			},
 			shouldError: false,
+		},
+		{
+			name:   "rate limit error",
+			apiKey: "foobar",
+			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
+				ID:       "00000000-0000-0000-0000-000000000000",
+				BranchID: "test-branch",
+				Changes: []netboxdiodeplugin.Change{
+					{
+						ID:            "00000000-0000-0000-0000-000000000001",
+						ChangeType:    "create",
+						ObjectType:    "dcim.device",
+						ObjectID:      nil,
+						ObjectVersion: nil,
+						Data:          json.RawMessage(`{"name": "test"}`),
+					},
+				},
+			},
+			mockServerResponse: `{"id":"00000000-0000-0000-0000-000000000000","result":"success"}`,
+			mockStatusCode:     http.StatusOK,
+			rateLimiterRPS:     0, // Any calls made to netbox will be rate limited
+			rateLimiterBurst:   0,
+			response:           nil,
+			shouldError:        true,
 		},
 		{
 			name:   "invalid request",
@@ -328,8 +387,10 @@ func TestApplyChangeSet(t *testing.T) {
 					},
 				},
 			},
-			response:    nil,
-			shouldError: true,
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
+			response:         nil,
+			shouldError:      true,
 		},
 		{
 			name:   "invalid post message",
@@ -349,6 +410,8 @@ func TestApplyChangeSet(t *testing.T) {
 			},
 			mockServerResponse: `{"id":"00000000-0000-0000-0000-000000000000","result":"error"}`,
 			mockStatusCode:     http.StatusBadRequest,
+			rateLimiterRPS:     1,
+			rateLimiterBurst:   1,
 			response:           nil,
 			shouldError:        true,
 		},
@@ -370,6 +433,8 @@ func TestApplyChangeSet(t *testing.T) {
 			},
 			mockServerResponse: `{"id"  - "00000000-0000-0000\-0000-000000000000","result":"error"}`,
 			mockStatusCode:     http.StatusBadRequest,
+			rateLimiterRPS:     1,
+			rateLimiterBurst:   1,
 			response:           nil,
 			shouldError:        true,
 		},
@@ -402,7 +467,7 @@ func TestApplyChangeSet(t *testing.T) {
 
 			_ = os.Setenv(netboxdiodeplugin.BaseURLEnvVarName, fmt.Sprintf("%s/api/diode", ts.URL))
 
-			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey)
+			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey, tt.rateLimiterRPS, tt.rateLimiterBurst)
 			require.NoError(t, err)
 			resp, err := client.ApplyChangeSet(context.Background(), tt.changeSetRequest)
 			if tt.shouldError {

--- a/diode-server/netboxdiodeplugin/client_test.go
+++ b/diode-server/netboxdiodeplugin/client_test.go
@@ -51,6 +51,8 @@ func TestNewClient(t *testing.T) {
 		name             string
 		apiKey           string
 		baseURL          string
+		rateLimiterRPS   int
+		rateLimiterBurst int
 		timeout          string
 		setBaseURLEnvVar bool
 		setTimeoutEnvVar bool
@@ -61,6 +63,8 @@ func TestNewClient(t *testing.T) {
 			name:             "valid client",
 			apiKey:           "test",
 			baseURL:          "http://",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
 			timeout:          "5",
 			setBaseURLEnvVar: true,
 			setTimeoutEnvVar: true,
@@ -71,6 +75,8 @@ func TestNewClient(t *testing.T) {
 			name:             "default base URL",
 			apiKey:           "test",
 			baseURL:          "",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
 			timeout:          "5",
 			setBaseURLEnvVar: false,
 			setTimeoutEnvVar: true,
@@ -80,6 +86,8 @@ func TestNewClient(t *testing.T) {
 			name:             "invalid base URL",
 			apiKey:           "test",
 			baseURL:          "http://local\nhost",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
 			timeout:          "5",
 			setBaseURLEnvVar: true,
 			setTimeoutEnvVar: true,
@@ -90,6 +98,8 @@ func TestNewClient(t *testing.T) {
 			name:             "default timeout",
 			apiKey:           "test",
 			baseURL:          "http://",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
 			timeout:          "",
 			setBaseURLEnvVar: true,
 			setTimeoutEnvVar: false,
@@ -100,6 +110,8 @@ func TestNewClient(t *testing.T) {
 			name:             "invalid timeout",
 			apiKey:           "test",
 			baseURL:          "http://",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
 			timeout:          "-1",
 			setBaseURLEnvVar: true,
 			setTimeoutEnvVar: true,
@@ -110,6 +122,8 @@ func TestNewClient(t *testing.T) {
 			name:             "API key not provided",
 			apiKey:           "",
 			baseURL:          "http://",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
 			timeout:          "5",
 			setBaseURLEnvVar: true,
 			setTimeoutEnvVar: true,
@@ -120,11 +134,37 @@ func TestNewClient(t *testing.T) {
 			name:             "set TLS skip verify",
 			apiKey:           "test",
 			baseURL:          "",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 1,
 			timeout:          "5",
 			setBaseURLEnvVar: false,
 			setTimeoutEnvVar: true,
 			setTLSSkipEnvVar: true,
 			shouldError:      false,
+		},
+		{
+			name:             "invalid rate limiter rps parameter",
+			apiKey:           "test",
+			baseURL:          "http://",
+			rateLimiterRPS:   0,
+			rateLimiterBurst: 1,
+			timeout:          "5",
+			setBaseURLEnvVar: true,
+			setTimeoutEnvVar: true,
+			setTLSSkipEnvVar: false,
+			shouldError:      true,
+		},
+		{
+			name:             "invalid rate limiter burst parameter",
+			apiKey:           "test",
+			baseURL:          "http://",
+			rateLimiterRPS:   1,
+			rateLimiterBurst: 0,
+			timeout:          "5",
+			setBaseURLEnvVar: true,
+			setTimeoutEnvVar: true,
+			setTLSSkipEnvVar: false,
+			shouldError:      true,
 		},
 	}
 
@@ -144,7 +184,7 @@ func TestNewClient(t *testing.T) {
 				_ = os.Setenv(netboxdiodeplugin.TLSSkipVerifyEnvVarName, "true")
 			}
 
-			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey, 1, 1)
+			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey, tt.rateLimiterRPS, tt.rateLimiterBurst)
 			if tt.shouldError {
 				require.Error(t, err)
 				return
@@ -202,30 +242,6 @@ func TestGenerateDiff(t *testing.T) {
 			},
 			shouldError: false,
 		},
-		{
-			name:   "valid generate diff response",
-			apiKey: "foobar",
-			generateDiffRequest: netboxdiodeplugin.GenerateDiffRequest{
-				ObjectType: "dcim.device",
-				Entity: &diodepb.Entity{
-					Entity: &diodepb.Entity_Device{
-						Device: &diodepb.Device{
-							Name: strPtr("test"),
-							Site: &diodepb.Site{
-								Name: "test-site",
-							},
-						},
-					},
-				},
-			},
-			mockStatusCode:     http.StatusOK,
-			expectedBody:       `{"object_type":"dcim.device","entity":{"device":{"name":"test","site":{"name":"test-site"}}}}`,
-			mockServerResponse: `{"changes": [{"id": "00000000-0000-0000-0000-000000000001", "change_type": "create", "object_type": "dcim.device", "data": {"name": "test"}}]}`,
-			rateLimiterRPS:     0, // Any calls made to netbox will be rate limited
-			rateLimiterBurst:   0,
-			response:           nil,
-			shouldError:        true,
-		},
 	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
@@ -270,6 +286,105 @@ func TestGenerateDiff(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.response, resp)
 			assert.Equal(t, tt.mockStatusCode, http.StatusOK)
+		})
+	}
+}
+
+func TestGenerateDiffRateLimiting(t *testing.T) {
+	tests := []struct {
+		name                string
+		apiKey              string
+		expectedCalls       int
+		generateDiffRequest netboxdiodeplugin.GenerateDiffRequest
+		mockStatusCode      int
+		expectedBody        string
+		mockServerResponse  string
+		rateLimiterRPS      int
+		rateLimiterBurst    int
+		response            *netboxdiodeplugin.GenerateDiffResponse
+		shouldError         bool
+	}{
+		{
+			name:          "rate limited requests",
+			apiKey:        "foobar",
+			expectedCalls: 2,
+			generateDiffRequest: netboxdiodeplugin.GenerateDiffRequest{
+				ObjectType: "dcim.device",
+				Entity: &diodepb.Entity{
+					Entity: &diodepb.Entity_Device{
+						Device: &diodepb.Device{
+							Name: strPtr("test"),
+							Site: &diodepb.Site{
+								Name: "test-site",
+							},
+						},
+					},
+				},
+			},
+			mockStatusCode:     http.StatusOK,
+			expectedBody:       `{"object_type":"dcim.device","entity":{"device":{"name":"test","site":{"name":"test-site"}}}}`,
+			mockServerResponse: `{"changes": [{"id": "00000000-0000-0000-0000-000000000001", "change_type": "create", "object_type": "dcim.device", "data": {"name": "test"}}]}`,
+			rateLimiterRPS:     1,
+			rateLimiterBurst:   1,
+			response: &netboxdiodeplugin.GenerateDiffResponse{
+				Changes: []netboxdiodeplugin.Change{
+					{
+						ID:         "00000000-0000-0000-0000-000000000001",
+						ChangeType: "create",
+						ObjectType: "dcim.device",
+						Data:       json.RawMessage(`{"name": "test"}`),
+					},
+				},
+			},
+			shouldError: false,
+		},
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanUpEnvVars()
+			actualCalls := 0
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				actualCalls++
+				assert.Equal(t, r.Method, http.MethodPost)
+				assert.Equal(t, r.URL.Path, "/api/diode/generate-diff/")
+				assert.Equal(t, r.Header.Get("Authorization"), fmt.Sprintf("Token %s", tt.apiKey))
+				assert.Equal(t, r.Header.Get("User-Agent"), fmt.Sprintf("%s/%s", netboxdiodeplugin.SDKName, netboxdiodeplugin.SDKVersion))
+				assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
+
+				if tt.generateDiffRequest.BranchID != "" {
+					assert.Equal(t, r.Header.Get(netboxdiodeplugin.NetBoxBranchHeader), tt.generateDiffRequest.BranchID)
+				} else {
+					assert.Len(t, r.Header.Values(netboxdiodeplugin.NetBoxBranchHeader), 0)
+				}
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedBody, string(body))
+				w.WriteHeader(tt.mockStatusCode)
+				_, _ = w.Write([]byte(tt.mockServerResponse))
+			}
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/diode/generate-diff/", handler)
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			_ = os.Setenv(netboxdiodeplugin.BaseURLEnvVarName, fmt.Sprintf("%s/api/diode", ts.URL))
+
+			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey, tt.rateLimiterRPS, tt.rateLimiterBurst)
+			require.NoError(t, err)
+			resp, err := client.GenerateDiff(context.Background(), tt.generateDiffRequest)
+			_, _ = client.GenerateDiff(context.Background(), tt.generateDiffRequest)
+			if tt.shouldError {
+				require.Error(t, err)
+				assert.Equal(t, tt.response, resp)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.response, resp)
+			assert.Equal(t, tt.mockStatusCode, http.StatusOK)
+			assert.Equal(t, tt.expectedCalls, actualCalls)
 		})
 	}
 }
@@ -346,30 +461,6 @@ func TestApplyChangeSet(t *testing.T) {
 				Result: "success",
 			},
 			shouldError: false,
-		},
-		{
-			name:   "rate limit error",
-			apiKey: "foobar",
-			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
-				ID:       "00000000-0000-0000-0000-000000000000",
-				BranchID: "test-branch",
-				Changes: []netboxdiodeplugin.Change{
-					{
-						ID:            "00000000-0000-0000-0000-000000000001",
-						ChangeType:    "create",
-						ObjectType:    "dcim.device",
-						ObjectID:      nil,
-						ObjectVersion: nil,
-						Data:          json.RawMessage(`{"name": "test"}`),
-					},
-				},
-			},
-			mockServerResponse: `{"id":"00000000-0000-0000-0000-000000000000","result":"success"}`,
-			mockStatusCode:     http.StatusOK,
-			rateLimiterRPS:     0, // Any calls made to netbox will be rate limited
-			rateLimiterBurst:   0,
-			response:           nil,
-			shouldError:        true,
 		},
 		{
 			name:   "invalid request",
@@ -478,6 +569,95 @@ func TestApplyChangeSet(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.response, resp)
 			assert.Equal(t, tt.mockStatusCode, http.StatusOK)
+		})
+	}
+}
+
+func TestApplyChangeSetRateLimiting(t *testing.T) {
+	tests := []struct {
+		name               string
+		apiKey             string
+		changeSetRequest   netboxdiodeplugin.ApplyChangeSetRequest
+		expectedCalls      int
+		mockServerResponse string
+		mockStatusCode     int
+		rateLimiterRPS     int
+		rateLimiterBurst   int
+		response           *netboxdiodeplugin.ApplyChangeSetResponse
+		shouldError        bool
+	}{
+		{
+			name:   "rate limit error",
+			apiKey: "foobar",
+			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
+				ID:       "00000000-0000-0000-0000-000000000000",
+				BranchID: "test-branch",
+				Changes: []netboxdiodeplugin.Change{
+					{
+						ID:            "00000000-0000-0000-0000-000000000001",
+						ChangeType:    "create",
+						ObjectType:    "dcim.device",
+						ObjectID:      nil,
+						ObjectVersion: nil,
+						Data:          json.RawMessage(`{"name": "test"}`),
+					},
+				},
+			},
+			expectedCalls:      2,
+			mockServerResponse: `{"id":"00000000-0000-0000-0000-000000000000","result":"success"}`,
+			mockStatusCode:     http.StatusOK,
+			rateLimiterRPS:     1,
+			rateLimiterBurst:   1,
+			response: &netboxdiodeplugin.ApplyChangeSetResponse{
+				ID:     "00000000-0000-0000-0000-000000000000",
+				Result: "success",
+			},
+			shouldError: false,
+		},
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanUpEnvVars()
+			actualCalls := 0
+
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				actualCalls++
+				assert.Equal(t, r.Method, http.MethodPost)
+				assert.Equal(t, r.URL.Path, "/api/diode/apply-change-set/")
+				assert.Equal(t, r.Header.Get("Authorization"), fmt.Sprintf("Token %s", tt.apiKey))
+				assert.Equal(t, r.Header.Get("User-Agent"), fmt.Sprintf("%s/%s", netboxdiodeplugin.SDKName, netboxdiodeplugin.SDKVersion))
+				assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
+				if tt.changeSetRequest.BranchID != "" {
+					assert.Equal(t, r.Header.Get(netboxdiodeplugin.NetBoxBranchHeader), tt.changeSetRequest.BranchID)
+				} else {
+					assert.Len(t, r.Header.Values(netboxdiodeplugin.NetBoxBranchHeader), 0)
+				}
+				w.WriteHeader(tt.mockStatusCode)
+				_, _ = w.Write([]byte(tt.mockServerResponse))
+			}
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/diode/apply-change-set/", handler)
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			_ = os.Setenv(netboxdiodeplugin.BaseURLEnvVarName, fmt.Sprintf("%s/api/diode", ts.URL))
+
+			client, err := netboxdiodeplugin.NewClient(logger, tt.apiKey, tt.rateLimiterRPS, tt.rateLimiterBurst)
+			require.NoError(t, err)
+			resp, err := client.ApplyChangeSet(context.Background(), tt.changeSetRequest)
+			_, _ = client.ApplyChangeSet(context.Background(), tt.changeSetRequest)
+			if tt.shouldError {
+				require.Error(t, err)
+				assert.Equal(t, tt.response, resp)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.response, resp)
+			assert.Equal(t, tt.mockStatusCode, http.StatusOK)
+			assert.Equal(t, tt.expectedCalls, actualCalls)
 		})
 	}
 }

--- a/diode-server/reconciler/config.go
+++ b/diode-server/reconciler/config.go
@@ -4,21 +4,23 @@ import "github.com/netboxlabs/diode/diode-server/telemetry"
 
 // Config is the configuration for the reconciler service
 type Config struct {
-	GRPCPort                   int    `envconfig:"GRPC_PORT" default:"8081"`
-	RedisHost                  string `envconfig:"REDIS_HOST" default:"127.0.0.1"`
-	RedisPort                  string `envconfig:"REDIS_PORT" default:"6379"`
-	RedisPassword              string `envconfig:"REDIS_PASSWORD" required:"true"`
-	RedisDB                    int    `envconfig:"REDIS_DB" default:"0"`
-	RedisStreamDB              int    `envconfig:"REDIS_STREAM_DB" default:"1"`
-	MigrationEnabled           bool   `envconfig:"MIGRATION_ENABLED" default:"true"`
-	AutoApplyChangesets        bool   `envconfig:"AUTO_APPLY_CHANGESETS" default:"true"`
-	ReconcilerRateLimiterRPS   int    `envconfig:"RECONCILER_RATE_LIMITER_RPS" default:"20"`
-	ReconcilerRateLimiterBurst int    `envconfig:"RECONCILER_RATE_LIMITER_BURST" default:"1"`
-	PostgresHost               string `envconfig:"POSTGRES_HOST"`
-	PostgresPort               int    `envconfig:"POSTGRES_PORT"`
-	PostgresDBName             string `envconfig:"POSTGRES_DB_NAME"`
-	PostgresUser               string `envconfig:"POSTGRES_USER"`
-	PostgresPassword           string `envconfig:"POSTGRES_PASSWORD"`
+	GRPCPort                      int    `envconfig:"GRPC_PORT" default:"8081"`
+	RedisHost                     string `envconfig:"REDIS_HOST" default:"127.0.0.1"`
+	RedisPort                     string `envconfig:"REDIS_PORT" default:"6379"`
+	RedisPassword                 string `envconfig:"REDIS_PASSWORD" required:"true"`
+	RedisDB                       int    `envconfig:"REDIS_DB" default:"0"`
+	RedisStreamDB                 int    `envconfig:"REDIS_STREAM_DB" default:"1"`
+	MigrationEnabled              bool   `envconfig:"MIGRATION_ENABLED" default:"true"`
+	AutoApplyChangesets           bool   `envconfig:"AUTO_APPLY_CHANGESETS" default:"true"`
+	ReconcilerRateLimiterRPS      int    `envconfig:"RECONCILER_RATE_LIMITER_RPS" default:"20"`
+	ReconcilerRateLimiterBurst    int    `envconfig:"RECONCILER_RATE_LIMITER_BURST" default:"1"`
+	DiodeToNetboxRateLimiterRPS   int    `envconfig:"DIODE_TO_NETBOX_RATE_LIMITER_RPS" default:"20"`
+	DiodeToNetboxRateLimiterBurst int    `envconfig:"DIODE_TO_NETBOX_RATE_LIMITER_BURST" default:"1"`
+	PostgresHost                  string `envconfig:"POSTGRES_HOST"`
+	PostgresPort                  int    `envconfig:"POSTGRES_PORT"`
+	PostgresDBName                string `envconfig:"POSTGRES_DB_NAME"`
+	PostgresUser                  string `envconfig:"POSTGRES_USER"`
+	PostgresPassword              string `envconfig:"POSTGRES_PASSWORD"`
 
 	// API keys
 	DiodeToNetBoxAPIKey string `envconfig:"DIODE_TO_NETBOX_API_KEY" required:"true"`

--- a/diode-server/reconciler/ingestion_processor_test.go
+++ b/diode-server/reconciler/ingestion_processor_test.go
@@ -36,7 +36,7 @@ func TestNewIngestionProcessor(t *testing.T) {
 	mockRepository := mocks.NewRepository(t)
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
-	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.DiodeToNetBoxAPIKey)
+	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.DiodeToNetBoxAPIKey, cfg.DiodeToNetboxRateLimiterRPS, cfg.DiodeToNetboxRateLimiterBurst)
 	require.NoError(t, err)
 	metrics := mocks.NewIngestionProcessorMetrics(t)
 	processor, err := reconciler.NewIngestionProcessor(ctx, logger, reconciler.NewOps(mockRepository, nbClient, logger), metrics)
@@ -62,7 +62,7 @@ func TestIngestionProcessorStart(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	ctx := context.Background()
 
-	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.DiodeToNetBoxAPIKey)
+	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.DiodeToNetBoxAPIKey, cfg.DiodeToNetboxRateLimiterRPS, cfg.DiodeToNetboxRateLimiterBurst)
 	require.NoError(t, err)
 	mockMetrics := new(mocks.IngestionProcessorMetrics)
 	mockMetrics.On("RecordHandleMessage", mock.Anything, mock.Anything).Return()


### PR DESCRIPTION
## In scope of this PR
Adds rate limiting for request from diode-server to netbox. Set based on the environment variables
- `DIODE_TO_NETBOX_RATE_LIMITER_RPS` - defaulted to 20
- `DIODE_TO_NETBOX_RATE_LIMITER_BURST` - defaulted to 1

## Out of scope of this PR
- retrying due to timeouts

## Future changes
- to support multitenancy a separate client could be created per netbox instance with different environment

## Questions
- Given this PR introduces a breaking change to the netboxdiodeplugin.NewClient function, what does that mean for versioning?