### PR TITLE
feat: check for breaking protopub changes

### DIFF
--- a/.github/workflows/protobuf-break-detection.yaml
+++ b/.github/workflows/protobuf-break-detection.yaml
@@ -1,0 +1,25 @@
+name: Buf Breaking Change Check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  buf-breaking-check:
+    name: Buf Breaking Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Needed to access other branches for comparison
+
+      - name: Run Buf Breaking Change Check
+        uses: bufbuild/buf-action@5150a1eef5c10b6a5cf8a69fc872f24a09473195 # v1.1.1
+        with:
+          input: diode-proto
+          command: breaking
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          args: --against 'https://github.com/${{ github.repository }}.git#branch=develop'

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ gen-diode-netbox-plugin-reconciler-sdk-python:
 	@find ../diode-netbox-plugin/netbox_diode_plugin/reconciler/sdk/ \( -name '*.py' -o -name '*.pyi' \) \
 	-exec sed -i.bak -e 's/^from diode.v1/from netbox_diode_plugin.reconciler.sdk.v1/' \
 	-e 's/^from validate/from netbox_diode_plugin.reconciler.sdk.validate/' {} \; -exec rm -f {}.bak \;
+
+.PHONY: detect-breaking-changes
+detect-breaking-changes:
+	@cd diode-proto/ && buf breaking --against '../.git#subdir=diode-proto'


### PR DESCRIPTION
Adds:
- github action to check for breaking changes - this currently just runs manually but we can change this in future we have stabilised the protobuf definition
- a make file recipe to check for breaking changes locally as part of development

Both of these compare against develop to work out what is a breaking change.