### PR TITLE
feat(diode-auth): configure nginx with OAuth2 token introspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ coverage.txt
 diode-server/.coverage/
 diode-server/build/
 diode-server/docker/dev.env
-diode-server/docker/oauth2/client/
+diode-server/docker/oauth2/client/*
+!diode-server/docker/oauth2/client/.gitkeep
 
 # Python
 __pycache__/

--- a/diode-server/docker/docker-compose.yaml
+++ b/diode-server/docker/docker-compose.yaml
@@ -2,40 +2,14 @@ name: ${PROJECT_NAME:-diode}
 services:
   ingress-nginx:
     image: nginx:latest
-    command: >
-      /bin/sh -c "echo 'upstream diode-ingester {
-        server diode-ingester:8081;
-      }
-      upstream diode-reconciler {
-        server diode-reconciler:8081;
-      }
-      upstream diode-auth {
-        server diode-auth:8080;
-      }
-      server {
-        listen 80;
-        http2 on;
-        server_name localhost;
-        client_max_body_size 25m;
-        location /diode/diode.v1.IngesterService {
-          rewrite /diode/(.*) /$$1 break;
-          grpc_pass grpc://diode-ingester;
-        }
-        location /diode/diode.v1.ReconcilerService {
-          rewrite /diode/(.*) /$$1 break;
-          grpc_pass grpc://diode-reconciler;
-        }
-        location /diode/auth {
-          rewrite /diode/auth/(.*) /$$1 break;
-          proxy_pass http://diode-auth;
-        }
-      }'
-      > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    command: nginx -g 'daemon off;'
     restart: always
     environment:
       - DIODE_NGINX_PORT=${DIODE_NGINX_PORT}
     ports:
       - ${DIODE_NGINX_PORT}:80
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:z,ro
     depends_on:
       - diode-auth
       - diode-ingester

--- a/diode-server/docker/nginx/nginx.conf
+++ b/diode-server/docker/nginx/nginx.conf
@@ -1,0 +1,74 @@
+upstream diode-ingester {
+  server diode-ingester:8081;
+}
+
+upstream diode-reconciler {
+  server diode-reconciler:8081;
+}
+
+upstream diode-auth {
+  server diode-auth:8080;
+}
+
+server {
+  listen 80;
+  listen [::]:80;
+  http2 on;
+  server_name localhost;
+  client_max_body_size 25m;
+
+  location = /auth/introspect {
+    internal;
+
+    proxy_method POST;
+    proxy_pass http://diode-auth/introspect;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+  }
+
+  location /diode/auth/token {
+    proxy_pass http://diode-auth/token;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /diode/diode.v1.IngesterService {
+    auth_request /auth/introspect;
+    auth_request_set $auth_status $upstream_status;
+    error_page 401 = @error401;
+    error_page 403 = @error403;
+
+    rewrite /diode/(.*) /$1 break;
+    grpc_pass grpc://diode-ingester;
+    grpc_set_header Host $host;
+    grpc_set_header X-Real-IP $remote_addr;
+    grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    grpc_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /diode/diode.v1.ReconcilerService {
+    auth_request /auth/introspect;
+    auth_request_set $auth_status $upstream_status;
+    error_page 401 = @error401;
+    error_page 403 = @error403;
+
+    rewrite /diode/(.*) /$1 break;
+    grpc_pass grpc://diode-reconciler;
+    grpc_set_header Host $host;
+    grpc_set_header X-Real-IP $remote_addr;
+    grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    grpc_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location @error401 {
+    return 401 '{"error":"unauthorized","error_description":"Authentication required"}';
+  }
+
+  location @error403 {
+    return 403 '{"error":"forbidden","error_description":"Access denied"}';
+  }
+}


### PR DESCRIPTION
This pull request includes significant changes to the NGINX configuration for the `diode-server` project. The key changes involve moving the NGINX configuration from inline commands in the `docker-compose.yaml` file to a separate `nginx.conf` file. This improves maintainability and clarity of the configuration.

Key changes:

### NGINX Configuration Refactor:

* [`diode-server/docker/docker-compose.yaml`](diffhunk://#diff-98e24b4e980cf032bcfa27e58ea28e9fdf87ed03db596e0b81675b12e71e714bL5-R12): Removed the inline NGINX configuration commands and replaced them with a command to run NGINX in the foreground. Added a volume mount to include the new `nginx.conf` file.
* [`diode-server/docker/nginx/nginx.conf`](diffhunk://#diff-5b7b0572ef117f2da0251421531ae293749a6d52aaec5e476ef91314c0d295a4R1-R74): Created a new NGINX configuration file with upstream server definitions and location blocks for handling gRPC and HTTP proxying, including authentication and error handling.