### PR TITLE
feat: add service dedicated dockerfiles

### DIFF
--- a/.github/pull_request_labeler.yaml
+++ b/.github/pull_request_labeler.yaml
@@ -48,7 +48,7 @@ dependencies:
 
 build:
   - changed-files:
-      - any-glob-to-any-file: '**/Dockerfile'
+      - any-glob-to-any-file: '**/Dockerfile*'
 
 go:
   - changed-files:

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Get apps
         id: apps
         run: |
-          echo 'apps=["ingester", "reconciler"]' >> "$GITHUB_OUTPUT"
+          echo 'apps=["auth", "ingester", "reconciler"]' >> "$GITHUB_OUTPUT"
 
   get-next-version:
     name: Get next version - ${{ matrix.app }}
@@ -81,7 +81,7 @@ jobs:
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6
         with:
           context: diode-server
-          file: diode-server/docker/Dockerfile-build
+          file: diode-server/docker/Dockerfile-build.${{ matrix.app }}
           platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha

--- a/diode-server/Makefile
+++ b/diode-server/Makefile
@@ -67,7 +67,7 @@ $(DOCKER_SERVICES):
 
 	@GOOS=$(GOOS) GOARCH=$(GOARCH) $(MAKE) build-$(SVC)
 
-	$(eval DOCKERFILE := $(if $(filter auth,$(SVC)),Dockerfile.auth,Dockerfile))
+	@$(eval DOCKERFILE=Dockerfile.$(SVC))
 
 	docker build \
 	  --no-cache \

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -24,6 +24,9 @@ COPY --chown=appuser:appgroup --from=oryd/hydra:v2.3.0 /usr/bin/hydra /usr/bin/h
 ARG SVC
 
 COPY --chown=appuser:appgroup --from=build /build/$SVC /usr/local/bin/diode-server
+COPY --chown=appuser:appgroup --from=build /docker/oauth2/bootstrap-clients.sh /etc/config/oauth2
+
+RUN chmod +x /etc/config/oauth2/bootstrap-clients.sh
 
 USER appuser
 

--- a/diode-server/docker/Dockerfile-build.ingester
+++ b/diode-server/docker/Dockerfile-build.ingester
@@ -1,19 +1,25 @@
-FROM alpine:3.21
+ARG GO_VERSION=1.23
 
-RUN apk add --no-cache jq
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+WORKDIR /diode-server
 
-COPY --chown=appuser:appgroup --from=oryd/hydra:v2.3.0 /usr/bin/hydra /usr/bin/hydra
+COPY . .
+
+ARG TARGETOS TARGETARCH SVC
+
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
+
+FROM gcr.io/distroless/base:latest
+
+USER nonroot
 
 ARG SVC
 
-COPY --chown=appuser:appgroup /build/$SVC /usr/local/bin/diode-server
-COPY --chown=appuser:appgroup /docker/oauth2/bootstrap-clients.sh /etc/config/oauth2/
-
-RUN chmod +x /etc/config/oauth2/bootstrap-clients.sh
-
-USER appuser
+COPY --from=build /build/$SVC /usr/local/bin/diode-server
 
 LABEL maintainer="techops@netboxlabs.com"
 LABEL org.opencontainers.image.title="Diode $SVC"

--- a/diode-server/docker/Dockerfile-build.reconciler
+++ b/diode-server/docker/Dockerfile-build.reconciler
@@ -1,19 +1,26 @@
-FROM alpine:3.21
+ARG GO_VERSION=1.23
 
-RUN apk add --no-cache jq
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+WORKDIR /diode-server
 
-COPY --chown=appuser:appgroup --from=oryd/hydra:v2.3.0 /usr/bin/hydra /usr/bin/hydra
+COPY . .
+
+ARG TARGETOS TARGETARCH SVC
+
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
+
+FROM gcr.io/distroless/base:latest
+
+USER nonroot
 
 ARG SVC
 
-COPY --chown=appuser:appgroup /build/$SVC /usr/local/bin/diode-server
-COPY --chown=appuser:appgroup /docker/oauth2/bootstrap-clients.sh /etc/config/oauth2/
-
-RUN chmod +x /etc/config/oauth2/bootstrap-clients.sh
-
-USER appuser
+COPY --from=build /build/$SVC /usr/local/bin/diode-server
+COPY --from=build /dbstore/postgres/migrations /etc/diode/migrations
 
 LABEL maintainer="techops@netboxlabs.com"
 LABEL org.opencontainers.image.title="Diode $SVC"

--- a/diode-server/docker/Dockerfile.ingester
+++ b/diode-server/docker/Dockerfile.ingester
@@ -1,19 +1,8 @@
-FROM alpine:3.21
+FROM gcr.io/distroless/base:latest
 
-RUN apk add --no-cache jq
-
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-
-COPY --chown=appuser:appgroup --from=oryd/hydra:v2.3.0 /usr/bin/hydra /usr/bin/hydra
+USER nonroot
 
 ARG SVC
-
-COPY --chown=appuser:appgroup /build/$SVC /usr/local/bin/diode-server
-COPY --chown=appuser:appgroup /docker/oauth2/bootstrap-clients.sh /etc/config/oauth2/
-
-RUN chmod +x /etc/config/oauth2/bootstrap-clients.sh
-
-USER appuser
 
 LABEL maintainer="techops@netboxlabs.com"
 LABEL org.opencontainers.image.title="Diode $SVC"
@@ -23,5 +12,7 @@ LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
 LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+
+COPY build/$SVC /usr/local/bin/diode-server
 
 CMD ["/usr/local/bin/diode-server"]

--- a/diode-server/docker/Dockerfile.reconciler
+++ b/diode-server/docker/Dockerfile.reconciler
@@ -1,19 +1,8 @@
-FROM alpine:3.21
+FROM gcr.io/distroless/base:latest
 
-RUN apk add --no-cache jq
-
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-
-COPY --chown=appuser:appgroup --from=oryd/hydra:v2.3.0 /usr/bin/hydra /usr/bin/hydra
+USER nonroot
 
 ARG SVC
-
-COPY --chown=appuser:appgroup /build/$SVC /usr/local/bin/diode-server
-COPY --chown=appuser:appgroup /docker/oauth2/bootstrap-clients.sh /etc/config/oauth2/
-
-RUN chmod +x /etc/config/oauth2/bootstrap-clients.sh
-
-USER appuser
 
 LABEL maintainer="techops@netboxlabs.com"
 LABEL org.opencontainers.image.title="Diode $SVC"
@@ -23,5 +12,8 @@ LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
 LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+
+COPY /build/$SVC /usr/local/bin/diode-server
+COPY /dbstore/postgres/migrations /etc/diode/migrations
 
 CMD ["/usr/local/bin/diode-server"]


### PR DESCRIPTION
This pull request introduces several changes to enhance the flexibility and modularity of the build and deployment process for the `diode-server` services. Key updates include the introduction of service-specific Dockerfiles, adjustments to the CI/CD workflow, and modifications to the `Makefile` to support dynamic Dockerfile selection. These changes aim to streamline the build process and improve maintainability.

### CI/CD Workflow Updates:
* Updated `.github/pull_request_labeler.yaml` to include files matching `**/Dockerfile*` for build-related labels, ensuring all relevant Dockerfiles are captured.
* Modified `.github/workflows/server-release.yaml` to:
  - Add the `auth` service to the list of apps processed during releases.
  - Dynamically select the appropriate Dockerfile for building each service based on the `matrix.app` value.

### Build System Improvements:
* Updated `diode-server/Makefile` to dynamically assign the Dockerfile for each service using the `SVC` variable, simplifying service-specific builds.

### Service-Specific Dockerfiles:
* Added new service-specific Dockerfiles for `ingester` and `reconciler` with tailored build and runtime configurations:
  - `diode-server/docker/Dockerfile-build.ingester`
  - `diode-server/docker/Dockerfile-build.reconciler`
* Introduced runtime Dockerfiles for `ingester` and `reconciler` with appropriate labels and configurations:
  - `diode-server/docker/Dockerfile.ingester`
  - `diode-server/docker/Dockerfile.reconciler`

### Enhancements to `auth` Service:
* Updated `diode-server/docker/Dockerfile.auth` to include the `bootstrap-clients.sh` script for OAuth2 configuration and ensure it is executable. [[1]](diffhunk://#diff-e2c96e42912145147aab195db4e37ea8a5ffb68cbe1c4e189f53d33625af1c92L11-R14) [[2]](diffhunk://#diff-e0d6ee70e9f6f939273a84c6edaf3b2a6a2b7c36d289a856149fae31832fa56cR27-R29)