### PR TITLE
refactor: update client credentials scopes

### DIFF
--- a/charts/diode/scripts/generate-client-credentials.sh
+++ b/charts/diode/scripts/generate-client-credentials.sh
@@ -9,9 +9,9 @@ generate_secret() {
 
 # Define client credentials in an associative array
 declare -A CLIENT_CREDENTIALS
-CLIENT_CREDENTIALS["diode-ingest"]="default:diode:ingest"
-CLIENT_CREDENTIALS["diode-to-netbox"]="default:diode:netbox"
-CLIENT_CREDENTIALS["netbox-to-diode"]="default:netbox:diode"
+CLIENT_CREDENTIALS["diode-ingest"]="diode:ingest"
+CLIENT_CREDENTIALS["diode-to-netbox"]="netbox:read netbox:write"
+CLIENT_CREDENTIALS["netbox-to-diode"]="diode:read diode:write"
 
 output="["
 first=true

--- a/diode-server/docker/oauth2/bootstrap-clients.sh
+++ b/diode-server/docker/oauth2/bootstrap-clients.sh
@@ -39,7 +39,7 @@ create_client() {
       --secret $client_secret \
       --grant-type "client_credentials" \
       --response-type "token" \
-      --scope $scope \
+      --scope "$scope" \
       --token-endpoint-auth-method "client_secret_post" \
       --format json)
 

--- a/diode-server/docker/scripts/generate-client-credentials.sh
+++ b/diode-server/docker/scripts/generate-client-credentials.sh
@@ -9,9 +9,9 @@ generate_secret() {
 
 # Define client credentials in an associative array
 declare -A CLIENT_CREDENTIALS
-CLIENT_CREDENTIALS["diode-ingest"]="default:diode:ingest"
-CLIENT_CREDENTIALS["diode-to-netbox"]="default:diode:netbox"
-CLIENT_CREDENTIALS["netbox-to-diode"]="default:netbox:diode"
+CLIENT_CREDENTIALS["diode-ingest"]="diode:ingest"
+CLIENT_CREDENTIALS["diode-to-netbox"]="netbox:read netbox:write"
+CLIENT_CREDENTIALS["netbox-to-diode"]="diode:read diode:write"
 
 output="["
 first=true


### PR DESCRIPTION
This pull request updates client credential definitions and improves the handling of scopes in OAuth2 client creation scripts. The most important changes include modifying client credential scopes and ensuring proper quoting for scope variables.

### Updates to client credential definitions:

* [`charts/diode/scripts/generate-client-credentials.sh`](diffhunk://#diff-eedeef4c8a19ded5f50fd42951bb9ef2bfee077805eb51bf7ee8fcc5d8589546L12-R14): Updated the `CLIENT_CREDENTIALS` associative array to refine the scopes for each client. For example, `diode-to-netbox` now uses `netbox:read netbox:write` instead of `default:diode:netbox`.
* [`diode-server/docker/scripts/generate-client-credentials.sh`](diffhunk://#diff-eedeef4c8a19ded5f50fd42951bb9ef2bfee077805eb51bf7ee8fcc5d8589546L12-R14): Made similar updates to the `CLIENT_CREDENTIALS` associative array to align the scopes with the refined permissions model.

### Improvements to scope handling:

* [`diode-server/docker/oauth2/bootstrap-clients.sh`](diffhunk://#diff-c06ea06f3cd475f4790c3d34c5e0c1559df5c58ed93e79de68c0c410d330e2a3L42-R42): Added proper quoting around the `$scope` variable to handle multi-word scopes correctly when creating OAuth2 clients.