### PR TITLE
feat: netboxdiodeplugin - use new oauth2 token scopes

### DIFF
--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -84,12 +84,10 @@ func main() {
 
 	repository := postgres.NewRepository(dbPool)
 
-	diodeToNetBoxTokenScopes := []string{"default:diode:netbox"}
-
 	diodeToNetBoxMaxRetries := 3
 
 	nbClient, err := netboxdiodeplugin.NewClient(s.Logger(), cfg.NetBoxDiodePluginAPIBaseURL, cfg.DiodeToNetBoxClientID,
-		cfg.DiodeToNetBoxClientSecret, cfg.DiodeAuthTokenURL, diodeToNetBoxTokenScopes, cfg.DiodeToNetBoxRateLimiterRPS,
+		cfg.DiodeToNetBoxClientSecret, cfg.DiodeAuthTokenURL, cfg.DiodeToNetBoxRateLimiterRPS,
 		cfg.DiodeToNetBoxRateLimiterBurst, diodeToNetBoxMaxRetries)
 	if err != nil {
 		s.Logger().Error("failed to create netbox diode plugin client", "error", err)

--- a/diode-server/netboxdiodeplugin/client.go
+++ b/diode-server/netboxdiodeplugin/client.go
@@ -49,6 +49,12 @@ const (
 
 	// NetBoxBranchParam is a query parameter that indicates the NetBox branch to target
 	NetBoxBranchParam = "_branch"
+
+	// DiodeOAuth2NetBoxReadScope is the OAuth2 scope for NetBox read access
+	DiodeOAuth2NetBoxReadScope = "netbox:read"
+
+	// DiodeOAuth2NetBoxWriteScope is the OAuth2 scope for NetBox write access
+	DiodeOAuth2NetBoxWriteScope = "netbox:write"
 )
 
 // ErrInvalidTimeout is an error for invalid timeout value
@@ -133,7 +139,7 @@ func NewHTTPTransport() *http.Transport {
 }
 
 // NewClient creates a new NetBox Diode plugin client
-func NewClient(logger *slog.Logger, baseURL, clientID, clientSecret, tokenURL string, tokenScopes []string, rateLimitRps, rateLimitBurstRps int, maxRetries int) (*Client, error) {
+func NewClient(logger *slog.Logger, baseURL, clientID, clientSecret, tokenURL string, rateLimitRps, rateLimitBurstRps int, maxRetries int) (*Client, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
@@ -179,7 +185,7 @@ func NewClient(logger *slog.Logger, baseURL, clientID, clientSecret, tokenURL st
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     t.String(),
-		Scopes:       tokenScopes,
+		Scopes:       []string{DiodeOAuth2NetBoxReadScope, DiodeOAuth2NetBoxWriteScope},
 	}
 
 	oauthTransport := &oauth2.Transport{

--- a/diode-server/netboxdiodeplugin/client_test.go
+++ b/diode-server/netboxdiodeplugin/client_test.go
@@ -55,7 +55,6 @@ func TestNewClient(t *testing.T) {
 		diodeAuthTokenURL         string
 		diodeToNetBoxClientID     string
 		diodeToNetBoxClientSecret string
-		diodeToNetBoxTokenScopes  []string
 		rateLimiterRPS            int
 		rateLimiterBurst          int
 		timeout                   string
@@ -69,7 +68,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "5",
@@ -83,7 +81,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "5",
@@ -97,7 +94,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "",
@@ -111,7 +107,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "-1",
@@ -125,7 +120,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "5",
@@ -139,7 +133,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "5",
@@ -153,7 +146,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "5",
@@ -167,7 +159,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          1,
 			timeout:                   "5",
@@ -181,7 +172,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            0,
 			rateLimiterBurst:          1,
 			timeout:                   "5",
@@ -195,7 +185,6 @@ func TestNewClient(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			rateLimiterRPS:            1,
 			rateLimiterBurst:          0,
 			timeout:                   "5",
@@ -220,7 +209,7 @@ func TestNewClient(t *testing.T) {
 
 			maxRetries := 3
 
-			client, err := netboxdiodeplugin.NewClient(logger, tt.baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, tt.diodeAuthTokenURL, tt.diodeToNetBoxTokenScopes, tt.rateLimiterRPS, tt.rateLimiterBurst, maxRetries)
+			client, err := netboxdiodeplugin.NewClient(logger, tt.baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, tt.diodeAuthTokenURL, tt.rateLimiterRPS, tt.rateLimiterBurst, maxRetries)
 			if tt.shouldError {
 				require.Error(t, err)
 				return
@@ -239,7 +228,6 @@ func TestGenerateDiff(t *testing.T) {
 		diodeAuthTokenURL         string
 		diodeToNetBoxClientID     string
 		diodeToNetBoxClientSecret string
-		diodeToNetBoxTokenScopes  []string
 		generateDiffRequest       netboxdiodeplugin.GenerateDiffRequest
 		mockStatusCode            int
 		expectedBody              string
@@ -258,7 +246,6 @@ func TestGenerateDiff(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			generateDiffRequest: netboxdiodeplugin.GenerateDiffRequest{
 				ObjectType: "dcim.device",
 				Entity: &diodepb.Entity{
@@ -300,7 +287,6 @@ func TestGenerateDiff(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			generateDiffRequest: netboxdiodeplugin.GenerateDiffRequest{
 				ObjectType: "dcim.device",
 				Entity: &diodepb.Entity{
@@ -333,7 +319,6 @@ func TestGenerateDiff(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			generateDiffRequest: netboxdiodeplugin.GenerateDiffRequest{
 				ObjectType: "dcim.device",
 				Entity: &diodepb.Entity{
@@ -396,7 +381,7 @@ func TestGenerateDiff(t *testing.T) {
 			defer ts.Close()
 
 			baseURL := fmt.Sprintf("%s/api/diode", ts.URL)
-			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.diodeToNetBoxTokenScopes, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
+			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
 			require.NoError(t, err)
 			resp, err := client.GenerateDiff(context.Background(), tt.generateDiffRequest)
 			if tt.shouldError {
@@ -425,7 +410,6 @@ func TestGenerateDiffRateLimiting(t *testing.T) {
 		diodeAuthTokenURL         string
 		diodeToNetBoxClientID     string
 		diodeToNetBoxClientSecret string
-		diodeToNetBoxTokenScopes  []string
 		expectedCalls             int
 		generateDiffRequest       netboxdiodeplugin.GenerateDiffRequest
 		mockStatusCode            int
@@ -443,7 +427,6 @@ func TestGenerateDiffRateLimiting(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			expectedCalls:             2,
 			generateDiffRequest: netboxdiodeplugin.GenerateDiffRequest{
 				ObjectType: "dcim.device",
@@ -521,7 +504,7 @@ func TestGenerateDiffRateLimiting(t *testing.T) {
 			defer ts.Close()
 
 			baseURL := fmt.Sprintf("%s/api/diode", ts.URL)
-			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.diodeToNetBoxTokenScopes, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
+			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
 			require.NoError(t, err)
 			resp, err := client.GenerateDiff(context.Background(), tt.generateDiffRequest)
 			_, _ = client.GenerateDiff(context.Background(), tt.generateDiffRequest)
@@ -545,7 +528,6 @@ func TestApplyChangeSet(t *testing.T) {
 		diodeAuthTokenURL         string
 		diodeToNetBoxClientID     string
 		diodeToNetBoxClientSecret string
-		diodeToNetBoxTokenScopes  []string
 		changeSetRequest          netboxdiodeplugin.ApplyChangeSetRequest
 		mockServerResponse        string
 		mockStatusCode            int
@@ -563,7 +545,6 @@ func TestApplyChangeSet(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
 				ID: "00000000-0000-0000-0000-000000000000",
 				Changes: []netboxdiodeplugin.Change{
@@ -601,7 +582,6 @@ func TestApplyChangeSet(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
 				ID:       "00000000-0000-0000-0000-000000000000",
 				BranchID: "test-branch",
@@ -632,7 +612,6 @@ func TestApplyChangeSet(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
 				ID: "00000000-0000-0000-0000-000000000000",
 				Changes: []netboxdiodeplugin.Change{
@@ -659,7 +638,6 @@ func TestApplyChangeSet(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
 				ID: "00000000-0000-0000-0000-000000000000",
 				Changes: []netboxdiodeplugin.Change{
@@ -692,7 +670,6 @@ func TestApplyChangeSet(t *testing.T) {
 			diodeAuthTokenURL:         "http://diode-auth:8000/diode/auth/token",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
 				ID: "00000000-0000-0000-0000-000000000000",
 				Changes: []netboxdiodeplugin.Change{
@@ -750,7 +727,7 @@ func TestApplyChangeSet(t *testing.T) {
 			defer ts.Close()
 
 			baseURL := fmt.Sprintf("%s/api/diode", ts.URL)
-			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.diodeToNetBoxTokenScopes, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
+			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
 			require.NoError(t, err)
 			resp, err := client.ApplyChangeSet(context.Background(), tt.changeSetRequest)
 			if tt.shouldError {
@@ -780,7 +757,6 @@ func TestApplyChangeSetRateLimiting(t *testing.T) {
 		baseURL                   string
 		diodeToNetBoxClientID     string
 		diodeToNetBoxClientSecret string
-		diodeToNetBoxTokenScopes  []string
 		changeSetRequest          netboxdiodeplugin.ApplyChangeSetRequest
 		expectedCalls             int
 		mockServerResponse        string
@@ -795,7 +771,6 @@ func TestApplyChangeSetRateLimiting(t *testing.T) {
 			name:                      "rate limit error",
 			diodeToNetBoxClientID:     "test",
 			diodeToNetBoxClientSecret: "test",
-			diodeToNetBoxTokenScopes:  []string{"default:diode:netbox"},
 			changeSetRequest: netboxdiodeplugin.ApplyChangeSetRequest{
 				ID:       "00000000-0000-0000-0000-000000000000",
 				BranchID: "test-branch",
@@ -859,7 +834,7 @@ func TestApplyChangeSetRateLimiting(t *testing.T) {
 
 			baseURL := fmt.Sprintf("%s/api/diode", ts.URL)
 
-			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.diodeToNetBoxTokenScopes, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
+			client, err := netboxdiodeplugin.NewClient(logger, baseURL, tt.diodeToNetBoxClientID, tt.diodeToNetBoxClientSecret, mockOAuth2ServerURL, tt.rateLimiterRPS, tt.rateLimiterBurst, tt.maxRetries)
 			require.NoError(t, err)
 			resp, err := client.ApplyChangeSet(context.Background(), tt.changeSetRequest)
 			_, _ = client.ApplyChangeSet(context.Background(), tt.changeSetRequest)
@@ -917,6 +892,7 @@ func newMockOAuth2Server(authTokenURL, wantClientID, wantClientSecret, mockedTok
 			"access_token": mockedToken,
 			"token_type":   "Bearer",
 			"expires_in":   3600,
+			"scope":        "dummy-scope",
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/diode-server/reconciler/ingestion_processor_test.go
+++ b/diode-server/reconciler/ingestion_processor_test.go
@@ -47,7 +47,7 @@ func TestNewIngestionProcessor(t *testing.T) {
 
 	mockOAuth2ServerURL := mockOAuth2Server.URL + authTokenURL
 
-	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.NetBoxDiodePluginAPIBaseURL, cfg.DiodeToNetBoxClientID, cfg.DiodeToNetBoxClientSecret, mockOAuth2ServerURL, []string{"scope1", "scope2"}, cfg.DiodeToNetBoxRateLimiterRPS, cfg.DiodeToNetBoxRateLimiterBurst, 0)
+	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.NetBoxDiodePluginAPIBaseURL, cfg.DiodeToNetBoxClientID, cfg.DiodeToNetBoxClientSecret, mockOAuth2ServerURL, cfg.DiodeToNetBoxRateLimiterRPS, cfg.DiodeToNetBoxRateLimiterBurst, 0)
 	require.NoError(t, err)
 	metrics := mocks.NewIngestionProcessorMetrics(t)
 	processor, err := reconciler.NewIngestionProcessor(ctx, logger, reconciler.NewOps(mockRepository, nbClient, logger), metrics)
@@ -81,7 +81,7 @@ func TestIngestionProcessorStart(t *testing.T) {
 	mockOAuth2ServerURL := mockOAuth2Server.URL + authTokenURL
 
 	maxRetries := 3
-	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.NetBoxDiodePluginAPIBaseURL, cfg.DiodeToNetBoxClientID, cfg.DiodeToNetBoxClientSecret, mockOAuth2ServerURL, []string{"default:diode:netbox"}, cfg.DiodeToNetBoxRateLimiterRPS, cfg.DiodeToNetBoxRateLimiterBurst, maxRetries)
+	nbClient, err := netboxdiodeplugin.NewClient(logger, cfg.NetBoxDiodePluginAPIBaseURL, cfg.DiodeToNetBoxClientID, cfg.DiodeToNetBoxClientSecret, mockOAuth2ServerURL, cfg.DiodeToNetBoxRateLimiterRPS, cfg.DiodeToNetBoxRateLimiterBurst, maxRetries)
 	require.NoError(t, err)
 	mockMetrics := new(mocks.IngestionProcessorMetrics)
 	mockMetrics.On("RecordHandleMessage", mock.Anything, mock.Anything).Return()


### PR DESCRIPTION
This pull request simplifies the handling of OAuth2 token scopes in the `diode-server/netboxdiodeplugin` package by replacing dynamic scope configuration with predefined constants. It also updates related tests and refactors the `NewClient` function to remove the `tokenScopes` parameter.

### OAuth2 Scope Handling Updates:
* Introduced constants `DiodeOAuth2NetBoxReadScope` and `DiodeOAuth2NetBoxWriteScope` for predefined OAuth2 token scopes (`netbox:read` and `netbox:write`) in `client.go`. These replace the need for dynamically passed scopes.
* Updated the `NewClient` function to use the predefined scope constants instead of accepting `tokenScopes` as a parameter. [[1]](diffhunk://#diff-38db3cdde31556b77cc828328a121810d7a77837567b7577d9410b7a72e626baL136-R142) [[2]](diffhunk://#diff-38db3cdde31556b77cc828328a121810d7a77837567b7577d9410b7a72e626baL182-R188)

### Codebase Refactoring:
* Removed the `diodeToNetBoxTokenScopes` variable in `main.go` and its usage in the `NewClient` call.
* Refactored all test cases in `client_test.go` to eliminate the `diodeToNetBoxTokenScopes` field and update calls to `NewClient` accordingly. [[1]](diffhunk://#diff-942dc83d740b777140260e15d74275175f1245166a6e5c4790fde86672492fcfL58) [[2]](diffhunk://#diff-942dc83d740b777140260e15d74275175f1245166a6e5c4790fde86672492fcfL223-R212) [[3]](diffhunk://#diff-942dc83d740b777140260e15d74275175f1245166a6e5c4790fde86672492fcfL753-R730)

### Test Updates:
* Adjusted test cases across `client_test.go` for `TestNewClient`, `TestGenerateDiff`, and `TestApplyChangeSet` to align with the removal of `tokenScopes` and the use of predefined constants. This ensures consistency with the updated `NewClient` function. [[1]](diffhunk://#diff-942dc83d740b777140260e15d74275175f1245166a6e5c4790fde86672492fcfL72) [[2]](diffhunk://#diff-942dc83d740b777140260e15d74275175f1245166a6e5c4790fde86672492fcfL399-R384) [[3]](diffhunk://#diff-942dc83d740b777140260e15d74275175f1245166a6e5c4790fde86672492fcfL548)