### PR TITLE
feat: check token scopes in reconciler, ingester

### DIFF
--- a/diode-server/authutil/check.go
+++ b/diode-server/authutil/check.go
@@ -1,0 +1,103 @@
+package authutil
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// ErrMetadataNotFoundMsg is an error for missing metadata
+	ErrMetadataNotFoundMsg = "no request metadata found"
+
+	// ErrUnauthenticatedMsg is an error for unauthenticated requests
+	ErrUnauthenticatedMsg = "missing or invalid authorization header"
+
+	// ErrMissingScopeMsg is an error for missing scopes
+	ErrMissingScopeMsg = "missing required scope"
+)
+
+// TokenStringFromMetadata returns the bearer token from incoming metadata
+func TokenStringFromMetadata(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", status.Errorf(codes.InvalidArgument, ErrMetadataNotFoundMsg)
+	}
+	auth := md["authorization"]
+	if len(auth) == 0 {
+		return "", status.Errorf(codes.Unauthenticated, ErrUnauthenticatedMsg)
+	}
+
+	return strings.TrimPrefix(auth[0], "Bearer "), nil
+}
+
+// Authorizer is an interface for checking if a token has the required scopes
+type Authorizer interface {
+	RequireScopes(token string, scopes []string) error
+	RequireScopesContext(ctx context.Context, scopes []string) error
+}
+
+// UnverifiedJWTAuthorizer is an authorizer that does not verify the JWT token's
+// signature. It is only used to check if the token has the required scopes
+// and is otherwise well formed.
+type UnverifiedJWTAuthorizer struct {
+	logger *slog.Logger
+}
+
+// NewUnverifiedJWTAuthorizer creates a new UnverifiedJWTAuthorizer
+func NewUnverifiedJWTAuthorizer(logger *slog.Logger) *UnverifiedJWTAuthorizer {
+	return &UnverifiedJWTAuthorizer{logger: logger}
+}
+
+// RequireScopesContext checks if the token in context has the required scopes
+func (j *UnverifiedJWTAuthorizer) RequireScopesContext(ctx context.Context, scopes []string) error {
+	tokenString, err := TokenStringFromMetadata(ctx)
+	if err != nil {
+		return err
+	}
+	return j.RequireScopes(tokenString, scopes)
+}
+
+// RequireScopes checks if the token has the required scopes
+func (j *UnverifiedJWTAuthorizer) RequireScopes(tokenString string, requiredScopes []string) error {
+	token, _, err := jwt.NewParser().ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		j.logger.Debug("failed to parse token", "error", err)
+		return status.Errorf(codes.Unauthenticated, ErrUnauthenticatedMsg)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		j.logger.Debug("invalid claims type", "claims", claims)
+		return status.Errorf(codes.Unauthenticated, ErrUnauthenticatedMsg)
+	}
+
+	scopeClaim, ok := claims["scope"]
+	if !ok {
+		j.logger.Debug("missing scope claim")
+		return status.Errorf(codes.Unauthenticated, ErrUnauthenticatedMsg)
+	}
+	scopeClaimStr, ok := scopeClaim.(string)
+	if !ok {
+		j.logger.Debug("scope claim is not a string", "scope", scopeClaim)
+		return status.Errorf(codes.Unauthenticated, ErrUnauthenticatedMsg)
+	}
+	scopeList := strings.Split(scopeClaimStr, " ")
+	scopeSet := make(map[string]bool)
+	for _, scope := range scopeList {
+		scopeSet[scope] = true
+	}
+
+	for _, scope := range requiredScopes {
+		if !scopeSet[scope] {
+			j.logger.Debug("missing scope", "scope", scope)
+			return status.Errorf(codes.Unauthenticated, ErrMissingScopeMsg)
+		}
+	}
+	return nil
+}

--- a/diode-server/authutil/check_test.go
+++ b/diode-server/authutil/check_test.go
@@ -25,25 +25,25 @@ func TestRequireScopes(t *testing.T) {
 		wantErr       error
 	}
 
-	validToken := validWithScopes(t, []string{"diode:read", "diode:write"})
+	validToken := validWithScopes(t, []string{authutil.ScopeDiodeRead, authutil.ScopeDiodeWrite})
 
 	tests := []test{
 		{
 			name:          "valid with valid scopes",
 			token:         validToken,
-			requireScopes: []string{"diode:read", "diode:write"},
+			requireScopes: []string{authutil.ScopeDiodeRead, authutil.ScopeDiodeWrite},
 			wantErr:       nil,
 		},
 		{
 			name:          "valid with valid read scope",
 			token:         validToken,
-			requireScopes: []string{"diode:read"},
+			requireScopes: []string{authutil.ScopeDiodeRead},
 			wantErr:       nil,
 		},
 		{
 			name:          "valid with valid write scopes",
 			token:         validToken,
-			requireScopes: []string{"diode:write"},
+			requireScopes: []string{authutil.ScopeDiodeWrite},
 			wantErr:       nil,
 		},
 		{
@@ -55,13 +55,13 @@ func TestRequireScopes(t *testing.T) {
 		{
 			name:          "valid with some missing scopes",
 			token:         validToken,
-			requireScopes: []string{"diode:read", "diode:write", "diode:sleep"},
+			requireScopes: []string{authutil.ScopeDiodeRead, authutil.ScopeDiodeWrite, "diode:sleep"},
 			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrMissingScopeMsg),
 		},
 		{
 			name:          "invalid token",
 			token:         "some-invalid-token",
-			requireScopes: []string{"diode:read"},
+			requireScopes: []string{authutil.ScopeDiodeRead},
 			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrUnauthenticatedMsg),
 		},
 	}
@@ -81,7 +81,7 @@ func TestRequireScopes(t *testing.T) {
 
 func TestRequireScopesContext(t *testing.T) {
 	authorizer := authutil.NewUnverifiedJWTAuthorizer(slog.Default())
-	validToken := validWithScopes(t, []string{"diode:read", "diode:write"})
+	validToken := validWithScopes(t, []string{authutil.ScopeDiodeRead, authutil.ScopeDiodeWrite})
 
 	type test struct {
 		name          string
@@ -94,7 +94,7 @@ func TestRequireScopesContext(t *testing.T) {
 		{
 			name:          "valid with valid scopes",
 			ctx:           contextWithToken(validToken),
-			requireScopes: []string{"diode:read", "diode:write"},
+			requireScopes: []string{authutil.ScopeDiodeRead, authutil.ScopeDiodeWrite},
 			wantErr:       nil,
 		},
 		{
@@ -106,13 +106,13 @@ func TestRequireScopesContext(t *testing.T) {
 		{
 			name:          "no metadata",
 			ctx:           context.Background(),
-			requireScopes: []string{"diode:read"},
+			requireScopes: []string{authutil.ScopeDiodeRead},
 			wantErr:       status.Errorf(codes.InvalidArgument, authutil.ErrMetadataNotFoundMsg),
 		},
 		{
 			name:          "invalid token",
 			ctx:           contextWithToken("some-invalid-token"),
-			requireScopes: []string{"diode:read"},
+			requireScopes: []string{authutil.ScopeDiodeRead},
 			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrUnauthenticatedMsg),
 		},
 	}

--- a/diode-server/authutil/check_test.go
+++ b/diode-server/authutil/check_test.go
@@ -1,0 +1,147 @@
+package authutil_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/netboxlabs/diode/diode-server/authutil"
+)
+
+func TestRequireScopes(t *testing.T) {
+	authorizer := authutil.NewUnverifiedJWTAuthorizer(slog.Default())
+
+	type test struct {
+		name          string
+		token         string
+		requireScopes []string
+		wantErr       error
+	}
+
+	validToken := validWithScopes(t, []string{"diode:read", "diode:write"})
+
+	tests := []test{
+		{
+			name:          "valid with valid scopes",
+			token:         validToken,
+			requireScopes: []string{"diode:read", "diode:write"},
+			wantErr:       nil,
+		},
+		{
+			name:          "valid with valid read scope",
+			token:         validToken,
+			requireScopes: []string{"diode:read"},
+			wantErr:       nil,
+		},
+		{
+			name:          "valid with valid write scopes",
+			token:         validToken,
+			requireScopes: []string{"diode:write"},
+			wantErr:       nil,
+		},
+		{
+			name:          "valid with missing scope",
+			token:         validToken,
+			requireScopes: []string{"diode:sleep"},
+			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrMissingScopeMsg),
+		},
+		{
+			name:          "valid with some missing scopes",
+			token:         validToken,
+			requireScopes: []string{"diode:read", "diode:write", "diode:sleep"},
+			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrMissingScopeMsg),
+		},
+		{
+			name:          "invalid token",
+			token:         "some-invalid-token",
+			requireScopes: []string{"diode:read"},
+			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrUnauthenticatedMsg),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := authorizer.RequireScopes(tt.token, tt.requireScopes)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.wantErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRequireScopesContext(t *testing.T) {
+	authorizer := authutil.NewUnverifiedJWTAuthorizer(slog.Default())
+	validToken := validWithScopes(t, []string{"diode:read", "diode:write"})
+
+	type test struct {
+		name          string
+		ctx           context.Context
+		requireScopes []string
+		wantErr       error
+	}
+
+	tests := []test{
+		{
+			name:          "valid with valid scopes",
+			ctx:           contextWithToken(validToken),
+			requireScopes: []string{"diode:read", "diode:write"},
+			wantErr:       nil,
+		},
+		{
+			name:          "missing scope",
+			ctx:           contextWithToken(validToken),
+			requireScopes: []string{"diode:sleep"},
+			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrMissingScopeMsg),
+		},
+		{
+			name:          "no metadata",
+			ctx:           context.Background(),
+			requireScopes: []string{"diode:read"},
+			wantErr:       status.Errorf(codes.InvalidArgument, authutil.ErrMetadataNotFoundMsg),
+		},
+		{
+			name:          "invalid token",
+			ctx:           contextWithToken("some-invalid-token"),
+			requireScopes: []string{"diode:read"},
+			wantErr:       status.Errorf(codes.Unauthenticated, authutil.ErrUnauthenticatedMsg),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := authorizer.RequireScopesContext(tt.ctx, tt.requireScopes)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.wantErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func validWithScopes(t *testing.T, scopes []string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"scope": strings.Join(scopes, " "),
+	})
+	tokenString, err := token.SignedString([]byte("secret"))
+	require.NoError(t, err)
+	return tokenString
+}
+
+func contextWithToken(tokenString string) context.Context {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		"authorization": "Bearer " + tokenString,
+	}))
+	return ctx
+}

--- a/diode-server/authutil/constants.go
+++ b/diode-server/authutil/constants.go
@@ -1,10 +1,14 @@
 package authutil
 
 const (
-	// ScopeDiodeRead is the scope for read access to diode services
+	// ScopeDiodeRead is the OAuth2 scope for read access to diode services
 	ScopeDiodeRead = "diode:read"
-	// ScopeDiodeWrite is the scope for write access to diode services
+	// ScopeDiodeWrite is the OAuth2 scope for write access to diode services
 	ScopeDiodeWrite = "diode:write"
-	// ScopeDiodeIngest is the scope for ingest access to diode services
+	// ScopeDiodeIngest is the OAuth2 scope for ingest access to diode services
 	ScopeDiodeIngest = "diode:ingest"
+	// ScopeNetBoxRead is the OAuth2 scope for read access to NetBox diode data plugin
+	ScopeNetBoxRead = "netbox:read"
+	// ScopeNetBoxWrite is the OAuth2 scope for write access to NetBox diode data plugin
+	ScopeNetBoxWrite = "netbox:write"
 )

--- a/diode-server/authutil/constants.go
+++ b/diode-server/authutil/constants.go
@@ -1,0 +1,10 @@
+package authutil
+
+const (
+	// ScopeDiodeRead is the scope for read access to diode services
+	ScopeDiodeRead = "diode:read"
+	// ScopeDiodeWrite is the scope for write access to diode services
+	ScopeDiodeWrite = "diode:write"
+	// ScopeDiodeIngest is the scope for ingest access to diode services
+	ScopeDiodeIngest = "diode:ingest"
+)

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/netboxlabs/diode/diode-server/authutil"
 	"github.com/netboxlabs/diode/diode-server/dbstore/postgres"
 	"github.com/netboxlabs/diode/diode-server/migrator"
 	"github.com/netboxlabs/diode/diode-server/netboxdiodeplugin"
@@ -112,7 +113,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	gRPCServer, err := reconciler.NewServer(ctx, s.Logger(), repository)
+	authorizer := authutil.NewUnverifiedJWTAuthorizer(s.Logger())
+
+	gRPCServer, err := reconciler.NewServer(ctx, s.Logger(), repository, authorizer)
 	if err != nil {
 		s.Logger().Error("failed to instantiate gRPC server", "error", err)
 		os.Exit(1)

--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -206,7 +206,7 @@ func validateRequest(in *diodepb.IngestRequest) error {
 
 func newAuthUnaryInterceptor(authorizer authutil.Authorizer) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if err := authorizer.RequireScopesContext(ctx, []string{"diode:ingest"}); err != nil {
+		if err := authorizer.RequireScopesContext(ctx, []string{authutil.ScopeDiodeIngest}); err != nil {
 			return nil, err
 		}
 

--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/netboxlabs/diode/diode-server/authutil"
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
 	"github.com/netboxlabs/diode/diode-server/sentry"
 	"github.com/netboxlabs/diode/diode-server/telemetry"
@@ -60,7 +62,12 @@ func New(ctx context.Context, logger *slog.Logger, cfg Config, meter metric.Mete
 		return nil, fmt.Errorf("failed to get hostname: %v", err)
 	}
 
-	grpcServer := grpc.NewServer()
+	authorizer := authutil.NewUnverifiedJWTAuthorizer(logger)
+
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(newAuthUnaryInterceptor(authorizer)),
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+	)
 
 	metrics, err := NewMetrics(meter)
 	if err != nil {
@@ -195,4 +202,14 @@ func validateRequest(in *diodepb.IngestRequest) error {
 	}
 
 	return nil
+}
+
+func newAuthUnaryInterceptor(authorizer authutil.Authorizer) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if err := authorizer.RequireScopesContext(ctx, []string{"diode:ingest"}); err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}
 }

--- a/diode-server/ingester/component_test.go
+++ b/diode-server/ingester/component_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/netboxlabs/diode/diode-server/authutil"
 	pb "github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
 	"github.com/netboxlabs/diode/diode-server/ingester"
 	"github.com/netboxlabs/diode/diode-server/reconciler"
@@ -72,7 +73,7 @@ const bufSize = 1024 * 1024
 func startReconcilerServer(ctx context.Context, t *testing.T) *reconciler.Server {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 	mockRepository := mocks.NewRepository(t)
-	server, err := reconciler.NewServer(ctx, logger, mockRepository)
+	server, err := reconciler.NewServer(ctx, logger, mockRepository, authutil.NewUnverifiedJWTAuthorizer(logger))
 	require.NoError(t, err)
 
 	errChan := make(chan error, 1)

--- a/diode-server/netboxdiodeplugin/client.go
+++ b/diode-server/netboxdiodeplugin/client.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/netboxlabs/diode/diode-server/authutil"
 	diodeErrors "github.com/netboxlabs/diode/diode-server/errors"
 	"github.com/netboxlabs/diode/diode-server/reconciler/changeset"
 )
@@ -49,12 +50,6 @@ const (
 
 	// NetBoxBranchParam is a query parameter that indicates the NetBox branch to target
 	NetBoxBranchParam = "_branch"
-
-	// DiodeOAuth2NetBoxReadScope is the OAuth2 scope for NetBox read access
-	DiodeOAuth2NetBoxReadScope = "netbox:read"
-
-	// DiodeOAuth2NetBoxWriteScope is the OAuth2 scope for NetBox write access
-	DiodeOAuth2NetBoxWriteScope = "netbox:write"
 )
 
 // ErrInvalidTimeout is an error for invalid timeout value
@@ -185,7 +180,7 @@ func NewClient(logger *slog.Logger, baseURL, clientID, clientSecret, tokenURL st
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     t.String(),
-		Scopes:       []string{DiodeOAuth2NetBoxReadScope, DiodeOAuth2NetBoxWriteScope},
+		Scopes:       []string{authutil.ScopeNetBoxRead, authutil.ScopeNetBoxWrite},
 	}
 
 	oauthTransport := &oauth2.Transport{

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -110,7 +110,7 @@ func newAuthUnaryInterceptor(authorizer authutil.Authorizer) grpc.UnaryServerInt
 	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		// TODO: this is applied to all rpcs but could be checked per rpc
 		// if the permissions differ (all are reads currently)
-		if err := authorizer.RequireScopesContext(ctx, []string{"diode:read"}); err != nil {
+		if err := authorizer.RequireScopesContext(ctx, []string{authutil.ScopeDiodeRead}); err != nil {
 			return nil, err
 		}
 

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -12,15 +12,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
+	"github.com/netboxlabs/diode/diode-server/authutil"
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/reconcilerpb"
-)
-
-const (
-	// ErrMetadataNotFoundMsg is an error for missing metadata
-	ErrMetadataNotFoundMsg = "no request metadata found"
-
-	// ErrUnauthenticatedMsg is an error for unauthenticated requests
-	ErrUnauthenticatedMsg = "missing or invalid authorization header"
 )
 
 // Server is a reconciler Server
@@ -36,7 +29,7 @@ type Server struct {
 }
 
 // NewServer creates a new reconciler server
-func NewServer(ctx context.Context, logger *slog.Logger, repository Repository) (*Server, error) {
+func NewServer(ctx context.Context, logger *slog.Logger, repository Repository, authorizer authutil.Authorizer) (*Server, error) {
 	var cfg Config
 	envconfig.MustProcess("", &cfg)
 
@@ -56,6 +49,7 @@ func NewServer(ctx context.Context, logger *slog.Logger, repository Repository) 
 	}
 
 	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(newAuthUnaryInterceptor(authorizer)),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 	)
 
@@ -110,4 +104,16 @@ func (s *Server) RetrieveDeviations(ctx context.Context, req *reconcilerpb.Retri
 // RetrieveDeviationByID retrieves a deviation by ID
 func (s *Server) RetrieveDeviationByID(ctx context.Context, req *reconcilerpb.RetrieveDeviationByIDRequest) (*reconcilerpb.RetrieveDeviationByIDResponse, error) {
 	return retrieveDeviationByID(ctx, s.logger, s.repository, req)
+}
+
+func newAuthUnaryInterceptor(authorizer authutil.Authorizer) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		// TODO: this is applied to all rpcs but could be checked per rpc
+		// if the permissions differ (all are reads currently)
+		if err := authorizer.RequireScopesContext(ctx, []string{"diode:read"}); err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}
 }

--- a/diode-server/reconciler/server_test.go
+++ b/diode-server/reconciler/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/netboxlabs/diode/diode-server/authutil"
 	"github.com/netboxlabs/diode/diode-server/reconciler"
 	"github.com/netboxlabs/diode/diode-server/reconciler/mocks"
 )
@@ -24,7 +25,7 @@ func TestNewServer(t *testing.T) {
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 	mockRepository := mocks.NewRepository(t)
-	server, err := reconciler.NewServer(ctx, logger, mockRepository)
+	server, err := reconciler.NewServer(ctx, logger, mockRepository, authutil.NewUnverifiedJWTAuthorizer(logger))
 	require.NoError(t, err)
 	require.NotNil(t, server)
 


### PR DESCRIPTION
This pull request introduces a new authorization utility for handling JWT-based scope validation and integrates it across multiple components of the `diode-server`. The changes include the creation of an `authutil` package, the addition of JWT scope validation logic, and updates to the `ingester` and `reconciler` components to enforce scope-based access control. Comprehensive tests have also been added to ensure the correctness of the new functionality.

### New Authorization Utility

* Added the `authutil` package, which includes:
  - `UnverifiedJWTAuthorizer` for validating JWT scopes without verifying the token's signature.
  - Helper functions such as `TokenStringFromMetadata` for extracting tokens from gRPC metadata.

* Implemented error constants for common authentication failures, such as missing metadata, invalid authorization headers, or missing required scopes.

### Integration with Components

* **Reconciler**:
  - Updated `reconciler/server.go` to accept an `Authorizer` instance and enforce scope-based access control using a new gRPC unary interceptor. [[1]](diffhunk://#diff-12121d2a690f7a0ae10349adfc99e79732e826dd942381750a40700596ca67bdL39-R32) [[2]](diffhunk://#diff-12121d2a690f7a0ae10349adfc99e79732e826dd942381750a40700596ca67bdR52) [[3]](diffhunk://#diff-12121d2a690f7a0ae10349adfc99e79732e826dd942381750a40700596ca67bdR108-R119)
  - Modified `NewServer` to include the `UnverifiedJWTAuthorizer` as a dependency.
  
* **Ingester**:
  - Updated `ingester/component.go` to include a similar gRPC unary interceptor for validating scopes. [[1]](diffhunk://#diff-dfc46b7c1aacfb0580bb8035932d326f32f8c56f21b6472a000ea488849ffe73L63-R70) [[2]](diffhunk://#diff-dfc46b7c1aacfb0580bb8035932d326f32f8c56f21b6472a000ea488849ffe73R206-R215)
  - Integrated the `UnverifiedJWTAuthorizer` into the gRPC server initialization.

### Unit Tests

* Added extensive unit tests for `authutil` in `check_test.go`, covering various scenarios such as valid tokens, missing scopes, and invalid tokens.
* Updated tests for the `ingester` and `reconciler` components to include the new `UnverifiedJWTAuthorizer` dependency and validate its integration. [[1]](diffhunk://#diff-089756c29f20d04a149d5c8ccd56c407202a19a8ed1245381ee0dbbdc93a0b7eL75-R76) [[2]](diffhunk://#diff-326eabd82a19c5cc56a28f8fec4b067f2e532ea451dbac1f8222c00a26305d9fL27-R28)

### Code Refactoring and Cleanup

* Removed redundant error constants from `reconciler/server.go` as they are now part of the `authutil` package.
* Updated import statements across multiple files to include the new `authutil` package. [[1]](diffhunk://#diff-cd86f7227f1786d5281fbb95507b9c82c88ffe79117211d8104c2b871b5f62c9R17) [[2]](diffhunk://#diff-dfc46b7c1aacfb0580bb8035932d326f32f8c56f21b6472a000ea488849ffe73R12-R19) [[3]](diffhunk://#diff-089756c29f20d04a149d5c8ccd56c407202a19a8ed1245381ee0dbbdc93a0b7eR20) [[4]](diffhunk://#diff-326eabd82a19c5cc56a28f8fec4b067f2e532ea451dbac1f8222c00a26305d9fR13)

These changes collectively enhance the security and maintainability of the `diode-server` by centralizing authorization logic and enforcing consistent scope validation across components.