### PR TITLE
perf: license update to NetBox Limited Use License 1.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,164 +1,85 @@
-# PolyForm Shield License 1.0.0
-
-<https://polyformproject.org/licenses/shield/1.0.0>
+# NetBox Limited Use License 1.0
 
 ## Acceptance
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+In order to get any license under these terms, you must agree to them as
+both strict obligations and conditions to all your licenses.
 
 ## Copyright License
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+NetBox Labs grants you a copyright license to use and modify the software
+only as part of a NetBox installation obtained from NetBox Labs or a NetBox
+distributor authorized by NetBox Labs, and only for your own internal use.
 
-## Distribution License
-
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
-
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
-
-## Changes and New Works License
-
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+For clarity, this license grants no rights to distribute the software or
+make it available to others as part of a commercial offering.
 
 ## Patent License
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
-
-## Noncompete
-
-Any purpose is a permitted purpose, except for providing any
-product that competes with the software or any product the
-licensor or any of its affiliates provides using the software.
-
-## Competition
-
-Goods and services compete even when they provide functionality
-through different kinds of interfaces or for different technical
-platforms.  Applications can compete with services, libraries
-with plugins, frameworks with development tools, and so on,
-even if they're written in different programming languages
-or for different computer architectures.  Goods and services
-compete even when provided free of charge.  If you market a
-product as a practical substitute for the software or another
-product, it definitely competes.
-
-## New Products
-
-If you are using the software to provide a product that does
-not compete, but the licensor or any of its affiliates brings
-your product into competition by providing a new version of
-the software or another product using the software, you may
-continue using versions of the software available under these
-terms beforehand to provide your competing product, but not
-any later versions.
-
-## Discontinued Products
-
-You may begin using the software to compete with a product
-or service that the licensor or any of its affiliates has
-stopped providing, unless the licensor includes a plain-text
-line beginning with `Licensor Line of Business:` with the
-software that mentions that line of business.  For example:
-
-> Licensor Line of Business: YoyodyneCMS Content Management
-System (http://example.com/cms)
-
-## Sales of Business
-
-If the licensor or any of its affiliates sells a line of
-business developing the software or using the software
-to provide a product, the buyer can also enforce
-[Noncompete](#noncompete) for that product.
-
-## Fair Use
-
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
-
-## No Other Rights
-
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+NetBox Labs grants you a patent license for the software that covers patent
+claims the licensor can license, or becomes able to license, that you would
+infringe by using the software, as allowed in the copyright license above.
 
 ## Patent Defense
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+If you make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted
+under these terms ends immediately. If your company makes such a claim,
+your patent license ends immediately for work on behalf of your company.
+Competitive Restrictions
+
+This license does not grant you the right to use the software:
+
+- To provide a managed service or software products that includes, integrates
+  with, or extends NetBox in a way that competes with any product or service
+  of NetBox Labs.
+
+- To assist or enable a third party in offering a service or product that
+  competes with any product or service of NetBox Labs.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses
+to anyone else, or prevent NetBox Labs from granting licenses to anyone else.
+These terms do not imply any other licenses.
 
 ## Violations
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+The first time you are notified in writing that you have violated any of
+these terms, or done anything with the software not covered by your licenses,
+your licenses can nonetheless continue if you come into full compliance with
+these terms, and take practical steps to correct past violations, within 30
+days of receiving notice.  Otherwise, all your licenses end immediately.
 
 ## No Liability
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+As far as the law allows, the software comes as is, without any warranty or
+condition, and NetBox Labs will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+If this disclaimer is unenforceable under applicable law, this license is void.
 
 ## Definitions
 
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
+**NetBox Labs** is NetBox Labs, Inc.
 
-A **product** can be a good or service, or a combination
-of them.
+**NetBox** is the community edition of NetBox found at
+<https://github.com/netbox-community/netbox> or any derivative thereof.
 
-**You** refers to the individual or entity agreeing to these
-terms.
+The **software** is the software NetBox Labs makes available under these terms.
 
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-its affiliates.
+**You** refers to the individual or entity agreeing to these terms.
 
-**Affiliates** means the other organizations than an
-organization has control over, is under the control of, or is
-under common control with.
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
 
-**Control** means ownership of substantially all the assets of
-an entity, or the power to direct its management and policies
-by vote, contract, or otherwise.  Control can be direct or
-indirect.
+**Control** means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
 
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
 
-**Use** means anything you do with the software requiring one
-of your licenses.
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ component):
 
 ## License
 
-Distributed under the PolyForm Shield License 1.0.0 License. See [LICENSE.md](./LICENSE.md) for more information.
+Distributed under the NetBox Limited Use License 1.0. See [LICENSE.md](./LICENSE.md) for more information.
 
 Diode protocol buffers are distributed under the Apache 2.0 License. See [LICENSE.txt](./diode-proto/LICENSE.txt) for
 more information.

--- a/diode-server/README.md
+++ b/diode-server/README.md
@@ -113,4 +113,4 @@ docker compose -f docker-compose.yaml up -d
 
 ## License
 
-Distributed under the PolyForm Shield License 1.0.0 License. See [LICENSE.md](./LICENSE.md) for more information.
+Distributed under the NetBox Limited Use License 1.0. See [LICENSE.md](../LICENSE.md) for more information.

--- a/diode-server/docker/Dockerfile
+++ b/diode-server/docker/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 COPY build/$SVC /usr/local/bin/diode-server
 

--- a/diode-server/docker/Dockerfile-build
+++ b/diode-server/docker/Dockerfile-build
@@ -28,6 +28,6 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 CMD ["/usr/local/bin/diode-server"]

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -37,6 +37,6 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 CMD ["/usr/local/bin/diode-server"]

--- a/diode-server/docker/Dockerfile-build.ingester
+++ b/diode-server/docker/Dockerfile-build.ingester
@@ -28,6 +28,6 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 CMD ["/usr/local/bin/diode-server"]

--- a/diode-server/docker/Dockerfile-build.reconciler
+++ b/diode-server/docker/Dockerfile-build.reconciler
@@ -29,6 +29,6 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 CMD ["/usr/local/bin/diode-server"]

--- a/diode-server/docker/Dockerfile.auth
+++ b/diode-server/docker/Dockerfile.auth
@@ -22,6 +22,6 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 CMD ["/usr/local/bin/diode-server"]

--- a/diode-server/docker/Dockerfile.ingester
+++ b/diode-server/docker/Dockerfile.ingester
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 COPY build/$SVC /usr/local/bin/diode-server
 

--- a/diode-server/docker/Dockerfile.reconciler
+++ b/diode-server/docker/Dockerfile.reconciler
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/diod
 LABEL org.opencontainers.image.description="NetBox Labs diode $SVC image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"
-LABEL org.opencontainers.image.licenses="PolyForm Shield License 1.0.0"
+LABEL org.opencontainers.image.licenses="NetBox Limited Use License 1.0"
 
 COPY /build/$SVC /usr/local/bin/diode-server
 COPY /dbstore/postgres/migrations /etc/diode/migrations


### PR DESCRIPTION
This pull request updates the licensing terms across the project, transitioning from the "PolyForm Shield License 1.0.0" to the "NetBox Limited Use License 1.0." The changes affect the license file, documentation references, and Docker image metadata.

### Licensing Updates:

* [`LICENSE.md`](diffhunk://#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1dL1-R85): Replaced the PolyForm Shield License terms with the NetBox Limited Use License terms, including restrictions on distribution, competitive use, and sublicensing.
* `README.md` and `diode-server/README.md`: Updated license references to reflect the new NetBox Limited Use License. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R50) [[2]](diffhunk://#diff-b53baf8d60598dce1f679755983d40a2cdb28a5baefb2dac28984be6db2e6061L116-R116)
* Dockerfiles (`diode-server/docker/Dockerfile`, `Dockerfile-build`, `Dockerfile-build.auth`, `Dockerfile-build.ingester`, `Dockerfile-build.reconciler`, `Dockerfile.auth`, `Dockerfile.ingester`, `Dockerfile.reconciler`): Changed the `org.opencontainers.image.licenses` label to specify the NetBox Limited Use License. [[1]](diffhunk://#diff-9d7447babe2ed63befc5e1e93b547e72c3c085267111bb4d73e1eb5a6cc3730bL14-R14) [[2]](diffhunk://#diff-8515511e0d541c06fb4d4f37e30d48249e5ded4e801b70e2b7e904b5f92a5113L31-R31) [[3]](diffhunk://#diff-e0d6ee70e9f6f939273a84c6edaf3b2a6a2b7c36d289a856149fae31832fa56cL40-R40) [[4]](diffhunk://#diff-b7ea1a2e2a50e01bd94630121d42f119077e46e63276e9f2d57acd15b392205aL32-R32) [[5]](diffhunk://#diff-e2c96e42912145147aab195db4e37ea8a5ffb68cbe1c4e189f53d33625af1c92L25-R25) [[6]](diffhunk://#diff-ba6775900926eb96dec719725f96b60b079ebfbf46045106b40acc7eef96a9caL14-R14)