### PR TITLE
fix: adjust workdir, copy non build items from workdir

### DIFF
--- a/diode-server/docker/Dockerfile-build
+++ b/diode-server/docker/Dockerfile-build
@@ -2,9 +2,8 @@ ARG GO_VERSION=1.23
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
-WORKDIR /diode-server
-
-COPY . .
+COPY . /app
+WORKDIR /app
 
 ARG TARGETOS TARGETARCH SVC
 

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -2,9 +2,8 @@ ARG GO_VERSION=1.23
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
-WORKDIR /diode-server
-
-COPY . .
+COPY . /app
+WORKDIR /app
 
 ARG TARGETOS TARGETARCH SVC
 
@@ -24,7 +23,7 @@ COPY --chown=appuser:appgroup --from=oryd/hydra:v2.3.0 /usr/bin/hydra /usr/bin/h
 ARG SVC
 
 COPY --chown=appuser:appgroup --from=build /build/$SVC /usr/local/bin/diode-server
-COPY --chown=appuser:appgroup --from=build /docker/oauth2/bootstrap-clients.sh /etc/config/oauth2
+COPY --chown=appuser:appgroup --from=build /app/docker/oauth2/bootstrap-clients.sh /etc/config/oauth2/
 
 RUN chmod +x /etc/config/oauth2/bootstrap-clients.sh
 

--- a/diode-server/docker/Dockerfile-build.ingester
+++ b/diode-server/docker/Dockerfile-build.ingester
@@ -2,9 +2,8 @@ ARG GO_VERSION=1.23
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
-WORKDIR /diode-server
-
-COPY . .
+COPY . /app
+WORKDIR /app
 
 ARG TARGETOS TARGETARCH SVC
 

--- a/diode-server/docker/Dockerfile-build.reconciler
+++ b/diode-server/docker/Dockerfile-build.reconciler
@@ -2,9 +2,8 @@ ARG GO_VERSION=1.23
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
-WORKDIR /diode-server
-
-COPY . .
+COPY . /app
+WORKDIR /app
 
 ARG TARGETOS TARGETARCH SVC
 
@@ -20,7 +19,7 @@ USER nonroot
 ARG SVC
 
 COPY --from=build /build/$SVC /usr/local/bin/diode-server
-COPY --from=build /dbstore/postgres/migrations /etc/diode/migrations
+COPY --from=build /app/dbstore/postgres/migrations /etc/diode/migrations
 
 LABEL maintainer="techops@netboxlabs.com"
 LABEL org.opencontainers.image.title="Diode $SVC"


### PR DESCRIPTION
This pull request updates several Dockerfiles in the `diode-server` project to standardize the build directory structure and adjust file paths accordingly. The changes primarily involve replacing `/diode-server` with `/app` as the working directory and updating related paths.

### Directory structure updates:
* Changed the `WORKDIR` from `/diode-server` to `/app` and updated the `COPY` command to reflect the new directory structure in `Dockerfile-build`, `Dockerfile-build.auth`, `Dockerfile-build.ingester`, and `Dockerfile-build.reconciler`. [[1]](diffhunk://#diff-8515511e0d541c06fb4d4f37e30d48249e5ded4e801b70e2b7e904b5f92a5113L5-R6) [[2]](diffhunk://#diff-e0d6ee70e9f6f939273a84c6edaf3b2a6a2b7c36d289a856149fae31832fa56cL5-R6) [[3]](diffhunk://#diff-8515511e0d541c06fb4d4f37e30d48249e5ded4e801b70e2b7e904b5f92a5113L5-R6) [[4]](diffhunk://#diff-b7ea1a2e2a50e01bd94630121d42f119077e46e63276e9f2d57acd15b392205aL5-R6)

### Path adjustments:
* Updated the path for `bootstrap-clients.sh` in `Dockerfile-build.auth` to align with the new directory structure (`/app/docker/oauth2/bootstrap-clients.sh` instead of `/docker/oauth2/bootstrap-clients.sh`).
* Adjusted the path for database migrations in `Dockerfile-build.reconciler` to use `/app/dbstore/postgres/migrations` instead of `/dbstore/postgres/migrations`.