### PR TITLE
feat: update image configuration in diode chart 

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.0.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -207,7 +207,6 @@ helm show values diode/diode
 | certManager.prometheus | object | `{"enabled":false}` | prometheus enabled |
 | certManager.webhook | object | `{"enabled":true}` | webhook enabled |
 | diode.environment | string | `"development"` | environment name |
-| diode.image.registry | string | `"docker.io"` | image registry |
 | diodeAuth.config.httpPort | int | `8080` | http port |
 | diodeAuth.config.sentryDsn | string | `""` | sentry DSN  |
 | diodeAuth.config.telemetryEnvironment | string | `"dev"` | telemetry environment |
@@ -215,14 +214,16 @@ helm show values diode/diode
 | diodeAuth.config.telemetryTracesExporter | string | `"none"` | telemetry traces exporter |
 | diodeAuth.containerPort | int | `8080` | port to listen on |
 | diodeAuth.enabled | bool | `true` | enabled |
-| diodeAuth.image.name | string | `"netboxlabs/diode-auth:1.0.0"` | image name |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
+| diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
+| diodeAuth.image.tag | string | `"1.0.0"` | image tag |
 | diodeAuth.replicaCount | int | `1` | replica count |
 | diodeAuth.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeAuth.serviceAccount.create | bool | `true` | create service account |
 | diodeAuthBootstrap.enabled | bool | `true` | enabled |
-| diodeAuthBootstrap.image.name | string | `"netboxlabs/diode-auth:1.0.0"` | image name |
 | diodeAuthBootstrap.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
+| diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
+| diodeAuthBootstrap.image.tag | string | `"1.0.0"` | image tag |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
 | diodeIngester.config.sentryDsn | string | `""` | sentry DSN  |
 | diodeIngester.config.telemetryEnvironment | string | `"dev"` | telemetry environment |
@@ -232,8 +233,9 @@ helm show values diode/diode
 | diodeIngester.enabled | bool | `true` | enabled |
 | diodeIngester.existingSecret | string | `"diode-ingester-secret"` | existing secret name |
 | diodeIngester.grpc.serviceName | string | `"diode.v1.IngesterService"` | grpc service name |
-| diodeIngester.image.name | string | `"netboxlabs/diode-ingester:1.0.0"` | image name |
-| diodeIngester.pullPolicy | string | `"IfNotPresent"` | pull policy |
+| diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
+| diodeIngester.image.repository | string | `"docker.io/netboxlabs/diode-ingester"` | image repository |
+| diodeIngester.image.tag | string | `"1.0.0"` | image tag |
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
@@ -256,7 +258,8 @@ helm show values diode/diode
 | diodeReconciler.enabled | bool | `true` | enabled |
 | diodeReconciler.existingSecret | string | `"diode-reconciler-secret"` | existing secret name |
 | diodeReconciler.grpc.serviceName | string | `"diode.v1.ReconcilerService"` | grpc service name |
-| diodeReconciler.image.name | string | `"netboxlabs/diode-reconciler:1.0.0"` | image name |
+| diodeReconciler.image.repository | string | `"docker.io/netboxlabs/diode-reconciler"` | image repository |
+| diodeReconciler.image.tag | string | `"1.0.0"` | image tag |
 | diodeReconciler.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |

--- a/charts/diode/templates/diode-auth-bootstrap-job.yaml
+++ b/charts/diode/templates/diode-auth-bootstrap-job.yaml
@@ -34,7 +34,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ include "diode.auth.bootstrapjobname" . }}
-          image: "{{ .Values.diode.image.registry }}/{{ .Values.diodeAuthBootstrap.image.name }}"
+          image: "{{ .Values.diodeAuthBootstrap.image.repository }}:{{ .Values.diodeAuthBootstrap.image.tag }}"
           imagePullPolicy: {{ .Values.diodeAuthBootstrap.image.pullPolicy | default "IfNotPresent" }}
           command: ["/bin/sh", "/etc/config/oauth2/bootstrap-clients.sh"]
           env:

--- a/charts/diode/templates/diode-auth-deployment.yaml
+++ b/charts/diode/templates/diode-auth-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ include "diode.auth.servicename" . }}
-          image: "{{ .Values.diode.image.registry }}/{{ .Values.diodeAuth.image.name }}"
+          image: "{{ .Values.diodeAuth.image.repository }}:{{ .Values.diodeAuth.image.tag }}"
           imagePullPolicy: {{ .Values.diodeAuth.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: {{ .Values.diodeAuth.containerPort }}

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ include "diode.ingester.servicename" . }}
-          image: "{{ .Values.diode.image.registry }}/{{ .Values.diodeIngester.image.name }}"
+          image: "{{ .Values.diodeIngester.image.repository }}:{{ .Values.diodeIngester.image.tag }}"
           imagePullPolicy: {{ .Values.diodeIngester.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: {{ .Values.diodeIngester.containerPort | default 8081 }}

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ include "diode.reconciler.servicename" . }}
-          image: "{{ .Values.diode.image.registry }}/{{ .Values.diodeReconciler.image.name }}"
+          image: "{{ .Values.diodeReconciler.image.repository }}:{{ .Values.diodeReconciler.image.tag }}"
           imagePullPolicy: {{ .Values.diodeReconciler.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: {{ .Values.diodeReconciler.containerPort | default 8081 }}

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -12,9 +12,6 @@ global:
 diode:
   # -- environment name
   environment: development
-  image:
-    # -- image registry
-    registry: docker.io
 
 # External PostgreSQL configuration (optional)
 externalPostgresql:
@@ -35,8 +32,10 @@ diodeAuth:
   # -- enabled
   enabled: true
   image:
-    # -- image name
-    name: netboxlabs/diode-auth:1.0.0
+    # -- image repository
+    repository: docker.io/netboxlabs/diode-auth
+    # -- image tag
+    tag: 1.0.0
     # -- pull policy
     pullPolicy: IfNotPresent
   # -- replica count
@@ -71,8 +70,10 @@ diodeAuthBootstrap:
   # -- enabled
   enabled: true
   image:
-    # -- image name
-    name: netboxlabs/diode-auth:1.0.0
+    # -- image repository
+    repository: docker.io/netboxlabs/diode-auth
+    # -- image tag
+    tag: 1.0.0
     # -- pull policy
     pullPolicy: IfNotPresent
   job:
@@ -84,10 +85,12 @@ diodeIngester:
   # -- enabled
   enabled: true
   image:
-    # -- image name
-    name: netboxlabs/diode-ingester:1.0.0
-  # -- pull policy
-  pullPolicy: IfNotPresent
+    # -- image repository
+    repository: docker.io/netboxlabs/diode-ingester
+    # -- image tag
+    tag: 1.0.0
+    # -- pull policy
+    pullPolicy: IfNotPresent
   # -- replica count
   replicaCount: 1
   serviceAccount:
@@ -123,8 +126,10 @@ diodeReconciler:
   # -- enabled
   enabled: true
   image:
-    # -- image name
-    name: netboxlabs/diode-reconciler:1.0.0
+    # -- image repository
+    repository: docker.io/netboxlabs/diode-reconciler
+    # -- image tag
+    tag: 1.0.0
   # -- pull policy
   pullPolicy: IfNotPresent
   # -- replica count


### PR DESCRIPTION
This pull request updates the Diode Helm chart to improve image configuration and versioning. Key changes include replacing the `image.name` and `image.registry` fields with `image.repository` and `image.tag`, updating deployment templates to use the new image fields, and incrementing the chart version to `1.1.0`.

### Chart Version Update:
* Updated the chart version from `1.0.0` to `1.1.0` in `charts/diode/Chart.yaml` to reflect the changes.

### Image Configuration Refactoring:
* Replaced `image.name` and `image.registry` fields with `image.repository` and `image.tag` in `charts/diode/values.yaml` for `diodeAuth`, `diodeAuthBootstrap`, `diodeIngester`, and `diodeReconciler`. [[1]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L38-R38) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L74-R76) [[3]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L87-R91) [[4]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L126-R132) [[5]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L15-L17)
* Updated `charts/diode/templates` deployment and job templates to use `image.repository` and `image.tag` for constructing image paths. [[1]](diffhunk://#diff-9837c846428ee54aba4b1d0fec6264a4f6396e9860f58bb28528a908f4e779a1L37-R37) [[2]](diffhunk://#diff-f7aefdf5ce4585299408ce0cacfffda7b0f5d2494b11c306f174c4eb249e5bbdL46-R46) [[3]](diffhunk://#diff-8bed87c066be5a33d2a20ef23520641413633a704e236fb966cfff3050c62885L44-R44) [[4]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78L57-R57)

### Documentation Updates:
* Updated `charts/diode/README.md` to reflect the new image configuration fields (`image.repository` and `image.tag`) in the Helm values table. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L210-R226) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L235-R238) [[3]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L259-R262)