### PR TITLE
feat: add support for existing secrets in diode chart

### DIFF
--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -168,7 +168,11 @@ Create the name of the ingester configmap to use
 Create the name of the ingester secret to use
 */}}
 {{- define "diode.ingester.secret" -}}
+{{- if .Values.diodeIngester.existingSecret }}
+{{- .Values.diodeIngester.existingSecret }}
+{{- else }}
 {{- printf "%s-ingester-secret" (include "diode.name" .) }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -207,7 +211,11 @@ Create the name of the reconciler configmap to use
 Create the name of the reconciler secret to use
 */}}
 {{- define "diode.reconciler.secret" -}}
+{{- if .Values.diodeReconciler.existingSecret }}
+{{- .Values.diodeReconciler.existingSecret }}
+{{- else }}
 {{- printf "%s-reconciler-secret" (include "diode.name" .) }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This pull request updates the Helm chart for Diode to version 1.1.0 and introduces support for using existing Kubernetes secrets for the ingester and reconciler components. These changes enhance flexibility in secret management and improve the chart's usability.

### Version Update:
* [`charts/diode/README.md`](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5): Updated the chart version from `1.0.0` to `1.1.0` to reflect the new changes.

### Secret Management Enhancements:
* [`charts/diode/templates/_helpers.tpl`](diffhunk://#diff-c3cd7b699e0e30f7ebc966d7b7981bfd3e92fa834007f10765bf25ca7ac169d0R171-R176): Modified the `diode.ingester.secret` template to allow the use of an existing secret (`.Values.diodeIngester.existingSecret`) if specified, falling back to the default generated secret name otherwise.
* [`charts/diode/templates/_helpers.tpl`](diffhunk://#diff-c3cd7b699e0e30f7ebc966d7b7981bfd3e92fa834007f10765bf25ca7ac169d0R214-R219): Modified the `diode.reconciler.secret` template to allow the use of an existing secret (`.Values.diodeReconciler.existingSecret`) if specified, falling back to the default generated secret name otherwise.