### PR TITLE
chore: exclude files from gha server-release trigger

### DIFF
--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - "diode-server/**"
       - "!diode-server/docker/**"
+      - "!diode-server/Makefile"
+      - "!diode-server/README.md"
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to exclude additional files from triggering the workflow.

Workflow configuration updates:

* [`.github/workflows/server-release.yaml`](diffhunk://#diff-99ac821f1014ee4b214339baa517b7b747d78a8ea51ddf2d734ca0d8d831dc1fR9-R10): Added `diode-server/Makefile` and `diode-server/README.md` to the list of excluded paths, ensuring changes to these files do not trigger the workflow.