### PR TITLE
fix: add missing configuration options in helm chart

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.0.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -226,7 +226,7 @@ helm show values diode/diode
 | certManager.prometheus | object | `{"enabled":false}` | prometheus enabled |
 | certManager.webhook | object | `{"enabled":true}` | webhook enabled |
 | diode.environment | string | `"development"` | environment name |
-| diodeAuth.config.httpPort | int | `8080` | http port |
+| diodeAuth.config.loggingLevel | string | `"INFO"` | logging level |
 | diodeAuth.config.sentryDsn | string | `""` | sentry DSN  |
 | diodeAuth.config.telemetryEnvironment | string | `"dev"` | telemetry environment |
 | diodeAuth.config.telemetryMetricsExporter | string | `"prometheus"` | telemetry metrics exporter |
@@ -244,6 +244,8 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
 | diodeAuthBootstrap.image.tag | string | `"1.0.0"` | image tag |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
+| diodeIngester.config.loggingLevel | string | `"INFO"` | logging level |
+| diodeIngester.config.redisStreamDb | int | `1` | redis stream db |
 | diodeIngester.config.sentryDsn | string | `""` | sentry DSN  |
 | diodeIngester.config.telemetryEnvironment | string | `"dev"` | telemetry environment |
 | diodeIngester.config.telemetryMetricsExporter | string | `"prometheus"` | telemetry metrics exporter |
@@ -258,10 +260,11 @@ helm show values diode/diode
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
+| diodeReconciler.config.autoApplyChangesets | bool | `true` | auto apply changesets |
 | diodeReconciler.config.diodeToNetBoxClientId | string | `"diode-to-netbox"` | diode to netbox client id |
 | diodeReconciler.config.diodeToNetboxRateLimiterBurst | int | `1` | diode to netbox rate limiter burst |
 | diodeReconciler.config.diodeToNetboxRateLimiterRps | int | `20` | diode to netbox rate limiter rps |
-| diodeReconciler.config.loggingLevel | string | `"DEBUG"` | logging level |
+| diodeReconciler.config.loggingLevel | string | `"INFO"` | logging level |
 | diodeReconciler.config.migrationEnabled | bool | `true` | migration enabled |
 | diodeReconciler.config.netboxDiodePluginApiBaseUrl | string | `"http://localhost:8000/netbox/api/plugins/diode"` | netbox diode plugin api base url |
 | diodeReconciler.config.netboxDiodePluginSkipTlsVerify | bool | `false` | netbox diode plugin skip tls verify |
@@ -269,7 +272,9 @@ helm show values diode/diode
 | diodeReconciler.config.postgresUser | string | `"diode"` | postgres user |
 | diodeReconciler.config.reconcilerRateLimiterBurst | int | `1` | reconciler rate limiter burst |
 | diodeReconciler.config.reconcilerRateLimiterRps | int | `20` | reconciler rate limiter rps |
-| diodeReconciler.config.sentryDsn | string | `""` | sentry DSN  |
+| diodeReconciler.config.redisDb | int | `0` | redis db |
+| diodeReconciler.config.redisStreamDb | int | `1` | redis stream db |
+| diodeReconciler.config.sentryDsn | string | `""` | sentry DSN |
 | diodeReconciler.config.telemetryEnvironment | string | `"dev"` | telemetry environment |
 | diodeReconciler.config.telemetryMetricsExporter | string | `"prometheus"` | telemetry metrics exporter |
 | diodeReconciler.config.telemetryTracesExporter | string | `"none"` | telemetry traces exporter |

--- a/charts/diode/templates/diode-auth-configmap.yaml
+++ b/charts/diode/templates/diode-auth-configmap.yaml
@@ -9,6 +9,8 @@ metadata:
     {{- include "diode.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "diode.auth.servicename" . }}
 data:
+  HTTP_PORT: {{ .Values.diodeAuth.containerPort | default "8080" | quote }}
+  LOGGING_LEVEL: {{ $config.loggingLevel | default "INFO" | quote }}
   OAUTH2_PUBLIC_SERVER_URL: {{ include "diode.hydra.public.url" . | quote }}
   OAUTH2_ADMIN_SERVER_URL: {{ include "diode.hydra.admin.url" . | quote }}
   SENTRY_DSN: {{ $config.sentryDsn | quote }}

--- a/charts/diode/templates/diode-ingester-configmap.yaml
+++ b/charts/diode/templates/diode-ingester-configmap.yaml
@@ -9,9 +9,12 @@ metadata:
     {{- include "diode.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "diode.ingester.servicename" . }}
 data:
+  GRPC_PORT: {{ .Values.diodeIngester.containerPort | default "8081" | quote }}
+  LOGGING_LEVEL: {{ $config.loggingLevel | default "INFO" | quote }}
+  SENTRY_DSN: {{ $config.sentryDsn | quote }}
   REDIS_HOST: {{ include "diode.redis.hostname" . | quote }}
   REDIS_PORT: {{ include "diode.redis.port" . | quote }}
-  SENTRY_DSN: {{ $config.sentryDsn | quote }}
+  REDIS_STREAM_DB: {{ $config.redisStreamDb | default "1" | quote }}
   TELEMETRY_METRICS_EXPORTER: {{ $config.telemetryMetricsExporter | quote }}
   TELEMETRY_TRACES_EXPORTER: {{ $config.telemetryTracesExporter | default "none" | quote }}
   TELEMETRY_ENVIRONMENT: {{ $config.telemetryEnvironment | default .Values.diode.environment | quote }}

--- a/charts/diode/templates/diode-reconciler-configmap.yaml
+++ b/charts/diode/templates/diode-reconciler-configmap.yaml
@@ -9,10 +9,15 @@ metadata:
     {{- include "diode.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "diode.reconciler.servicename" . }}
 data:
-  NETBOX_DIODE_PLUGIN_API_BASE_URL: {{ $config.netboxDiodePluginApiBaseUrl | quote }}
-  NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY: {{ $config.netboxDiodePluginSkipTlsVerify | quote }}
+  GRPC_PORT: {{ .Values.diodeReconciler.containerPort | default "8081" | quote }}
   LOGGING_LEVEL: {{ $config.loggingLevel | default "INFO" | quote }}
+  SENTRY_DSN: {{ $config.sentryDsn | quote }}
+  REDIS_HOST: {{ include "diode.redis.hostname" . | quote }}
+  REDIS_PORT: {{ include "diode.redis.port" . | quote }}
+  REDIS_DB: {{ $config.redisDb | default "0" | quote }}
+  REDIS_STREAM_DB: {{ $config.redisStreamDb | default "1" | quote }}
   MIGRATION_ENABLED: {{ $config.migrationEnabled | default "true" | quote }}
+  AUTO_APPLY_CHANGESETS: {{ $config.autoApplyChangesets | default "true" | quote }}
   RECONCILER_RATE_LIMITER_RPS: {{ $config.reconcilerRateLimiterRps | default "20" | quote }}
   RECONCILER_RATE_LIMITER_BURST: {{ $config.reconcilerRateLimiterBurst | default "1" | quote }}
   DIODE_TO_NETBOX_RATE_LIMITER_RPS: {{ $config.diodeToNetboxRateLimiterRps | default "20" | quote }}
@@ -21,12 +26,11 @@ data:
   POSTGRES_PORT: {{ include "diode.postgresql.port" . | quote }}
   POSTGRES_DB_NAME: {{ $config.postgresDbName | default "diode" | quote }}
   POSTGRES_USER: {{ $config.postgresUser | default "diode" | quote }}
-  REDIS_HOST: {{ include "diode.redis.hostname" . | quote }}
-  REDIS_PORT: {{ include "diode.redis.port" . | quote }}
-  SENTRY_DSN: {{ $config.sentryDsn | quote }}
+  NETBOX_DIODE_PLUGIN_API_BASE_URL: {{ $config.netboxDiodePluginApiBaseUrl | quote }}
+  NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY: {{ $config.netboxDiodePluginSkipTlsVerify | quote }}
+  DIODE_AUTH_TOKEN_URL: {{ printf "%s/token" (include "diode.auth.url" .) | quote }}
+  DIODE_TO_NETBOX_CLIENT_ID: {{ $config.diodeToNetBoxClientId | quote }}
   TELEMETRY_METRICS_EXPORTER: {{ $config.telemetryMetricsExporter | quote }}
   TELEMETRY_TRACES_EXPORTER: {{ $config.telemetryTracesExporter | default "none" | quote }}
   TELEMETRY_ENVIRONMENT: {{ $config.telemetryEnvironment | default .Values.diode.environment | quote }}
-  DIODE_AUTH_TOKEN_URL: {{ printf "%s/token" (include "diode.auth.url" .) | quote }}
-  DIODE_TO_NETBOX_CLIENT_ID: {{ $config.diodeToNetBoxClientId | quote }}
 {{- end }}

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -54,8 +54,8 @@ diodeAuth:
       cpu: 500m
       memory: 512Mi
   config:
-    # -- http port
-    httpPort: 8080
+    # -- logging level
+    loggingLevel: INFO
     # -- sentry DSN 
     sentryDsn: ""
     # -- telemetry metrics exporter
@@ -112,8 +112,12 @@ diodeIngester:
     # -- grpc service name
     serviceName: diode.v1.IngesterService
   config:
+    # -- logging level
+    loggingLevel: INFO
     # -- sentry DSN 
     sentryDsn: ""
+    # -- redis stream db
+    redisStreamDb: 1
     # -- telemetry metrics exporter
     telemetryMetricsExporter: prometheus
     # -- telemetry traces exporter
@@ -158,9 +162,13 @@ diodeReconciler:
     # -- netbox diode plugin skip tls verify
     netboxDiodePluginSkipTlsVerify: false
     # -- logging level
-    loggingLevel: DEBUG
+    loggingLevel: INFO
+    # -- sentry DSN
+    sentryDsn: ""
     # -- migration enabled
     migrationEnabled: true
+    # -- auto apply changesets
+    autoApplyChangesets: true
     # -- reconciler rate limiter rps
     reconcilerRateLimiterRps: 20
     # -- reconciler rate limiter burst
@@ -173,8 +181,10 @@ diodeReconciler:
     postgresDbName: diode
     # -- postgres user
     postgresUser: diode
-    # -- sentry DSN 
-    sentryDsn: ""
+    # -- redis db
+    redisDb: 0
+    # -- redis stream db
+    redisStreamDb: 1
     # -- telemetry metrics exporter
     telemetryMetricsExporter: prometheus
     # -- telemetry traces exporter


### PR DESCRIPTION
This pull request introduces several updates to the Helm chart for Diode, including a version bump, configuration enhancements, and updates to ConfigMaps and values files. These changes improve configurability and logging across various components of the application.

### Version Update:
* Updated the chart version from `1.1.0` to `1.1.1` in `Chart.yaml` and `README.md` to reflect the new changes. [[1]](diffhunk://#diff-b886313e1c0741f2c72a92382362d33b52e225680751f83cd06d7f1e542d8bc5L5-R5) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5)

### Configuration Enhancements:
* Added new configuration options for `loggingLevel` and `redisStreamDb` across multiple components (`diodeAuth`, `diodeIngester`, and `diodeReconciler`) in `values.yaml` and corresponding ConfigMaps. [[1]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L57-R58) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R115-R120) [[3]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L161-R171) [[4]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L176-R187) [[5]](diffhunk://#diff-cb9f10dadefb56ea31e9602b6a945e6d506dfa1cb880b19939f88608618ad28eR12-R13) [[6]](diffhunk://#diff-4adcbdcae517a1ca8d9c1dbc04e4e36457bca3ebcb33f1f47c0d676dcebe36c8R12-R17) [[7]](diffhunk://#diff-9b6a32571cca4c2c9fd914f36404ed2f153ff31f304ac70a6eb05135f646975cL12-R20)
* Introduced the `autoApplyChangesets` option for `diodeReconciler` to enable automatic changeset application. [[1]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L161-R171) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R263-R276) [[3]](diffhunk://#diff-9b6a32571cca4c2c9fd914f36404ed2f153ff31f304ac70a6eb05135f646975cL12-R20)

### Logging Improvements:
* Standardized the default `loggingLevel` to `"INFO"` across all components (previously `"DEBUG"` for `diodeReconciler`). [[1]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L161-R171) [[2]](diffhunk://#diff-cb9f10dadefb56ea31e9602b6a945e6d506dfa1cb880b19939f88608618ad28eR12-R13) [[3]](diffhunk://#diff-4adcbdcae517a1ca8d9c1dbc04e4e36457bca3ebcb33f1f47c0d676dcebe36c8R12-R17) [[4]](diffhunk://#diff-9b6a32571cca4c2c9fd914f36404ed2f153ff31f304ac70a6eb05135f646975cL12-R20)

### ConfigMap Updates:
* Updated ConfigMaps for `diode-auth`, `diode-ingester`, and `diode-reconciler` to include new configuration fields such as `GRPC_PORT`, `REDIS_DB`, and `AUTO_APPLY_CHANGESETS`. [[1]](diffhunk://#diff-cb9f10dadefb56ea31e9602b6a945e6d506dfa1cb880b19939f88608618ad28eR12-R13) [[2]](diffhunk://#diff-4adcbdcae517a1ca8d9c1dbc04e4e36457bca3ebcb33f1f47c0d676dcebe36c8R12-R17) [[3]](diffhunk://#diff-9b6a32571cca4c2c9fd914f36404ed2f153ff31f304ac70a6eb05135f646975cL12-R20) [[4]](diffhunk://#diff-9b6a32571cca4c2c9fd914f36404ed2f153ff31f304ac70a6eb05135f646975cL24-L31)

### Documentation Updates:
* Updated the `README.md` to reflect the new chart version and added descriptions for the new configuration fields in the Helm chart values table. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L229-R229) [[3]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R247-R248) [[4]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R263-R276)