### PR TITLE
feat: helm chart - add imagePullSecrets configuration options

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.1.1
+version: 1.2.0
 appVersion: "1.0.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -233,6 +233,7 @@ helm show values diode/diode
 | diodeAuth.config.telemetryTracesExporter | string | `"none"` | telemetry traces exporter |
 | diodeAuth.containerPort | int | `8080` | port to listen on |
 | diodeAuth.enabled | bool | `true` | enabled |
+| diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
 | diodeAuth.image.tag | string | `"1.0.0"` | image tag |
@@ -240,6 +241,7 @@ helm show values diode/diode
 | diodeAuth.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeAuth.serviceAccount.create | bool | `true` | create service account |
 | diodeAuthBootstrap.enabled | bool | `true` | enabled |
+| diodeAuthBootstrap.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuthBootstrap.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
 | diodeAuthBootstrap.image.tag | string | `"1.0.0"` | image tag |
@@ -254,6 +256,7 @@ helm show values diode/diode
 | diodeIngester.enabled | bool | `true` | enabled |
 | diodeIngester.existingSecret | string | `"diode-ingester-secret"` | existing secret name |
 | diodeIngester.grpc.serviceName | string | `"diode.v1.IngesterService"` | grpc service name |
+| diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeIngester.image.repository | string | `"docker.io/netboxlabs/diode-ingester"` | image repository |
 | diodeIngester.image.tag | string | `"1.0.0"` | image tag |
@@ -282,9 +285,10 @@ helm show values diode/diode
 | diodeReconciler.enabled | bool | `true` | enabled |
 | diodeReconciler.existingSecret | string | `"diode-reconciler-secret"` | existing secret name |
 | diodeReconciler.grpc.serviceName | string | `"diode.v1.ReconcilerService"` | grpc service name |
+| diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
+| diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.image.repository | string | `"docker.io/netboxlabs/diode-reconciler"` | image repository |
 | diodeReconciler.image.tag | string | `"1.0.0"` | image tag |
-| diodeReconciler.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeReconciler.serviceAccount.create | bool | `true` | create service account |

--- a/charts/diode/templates/diode-auth-bootstrap-job.yaml
+++ b/charts/diode/templates/diode-auth-bootstrap-job.yaml
@@ -16,6 +16,10 @@ spec:
         app.kubernetes.io/component: {{ include "diode.auth.bootstrapjobname" . }}
     spec:
       serviceAccountName: {{ include "diode.auth.serviceaccountname" . }}
+      {{- if .Values.diodeAuthBootstrap.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.diodeAuthBootstrap.image.imagePullSecrets | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- if .Values.hydra.enabled }}
         - name: wait-for-oauth2-server

--- a/charts/diode/templates/diode-auth-deployment.yaml
+++ b/charts/diode/templates/diode-auth-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: {{ include "diode.auth.servicename" . }}
     spec:
       serviceAccountName: {{ include "diode.auth.serviceaccountname" . }}
+      {{- if .Values.diodeAuth.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.diodeAuth.image.imagePullSecrets | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- if .Values.hydra.enabled }}
         - name: wait-for-oauth2-server

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: {{ include "diode.ingester.servicename" . }}
     spec:
       serviceAccountName: {{ include "diode.ingester.serviceaccountname" . }}
+      {{- if .Values.diodeIngester.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.diodeIngester.image.imagePullSecrets | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: {{ include "diode.reconciler.servicename" . }}
     spec:
       serviceAccountName: {{ include "diode.reconciler.serviceaccountname" . }}
+      {{- if .Values.diodeReconciler.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.diodeReconciler.image.imagePullSecrets | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -36,6 +36,8 @@ diodeAuth:
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
     tag: 1.0.0
+    # -- secrets with credentials to pull images from a private registry
+    imagePullSecrets: [ ]
     # -- pull policy
     pullPolicy: IfNotPresent
   # -- replica count
@@ -74,6 +76,8 @@ diodeAuthBootstrap:
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
     tag: 1.0.0
+    # -- secrets with credentials to pull images from a private registry
+    imagePullSecrets: [ ]
     # -- pull policy
     pullPolicy: IfNotPresent
   job:
@@ -89,6 +93,8 @@ diodeIngester:
     repository: docker.io/netboxlabs/diode-ingester
     # -- image tag
     tag: 1.0.0
+    # -- secrets with credentials to pull images from a private registry
+    imagePullSecrets: [ ]
     # -- pull policy
     pullPolicy: IfNotPresent
   # -- replica count
@@ -134,8 +140,10 @@ diodeReconciler:
     repository: docker.io/netboxlabs/diode-reconciler
     # -- image tag
     tag: 1.0.0
-  # -- pull policy
-  pullPolicy: IfNotPresent
+    # -- secrets with credentials to pull images from a private registry
+    imagePullSecrets: [ ]
+    # -- pull policy
+    pullPolicy: IfNotPresent
   # -- replica count
   replicaCount: 1
   serviceAccount:


### PR DESCRIPTION
This pull request updates the Helm chart for Diode to version 1.2.0 and introduces support for specifying `imagePullSecrets` for private image registries. The changes include updates to metadata, documentation, and configuration files, as well as modifications to Kubernetes templates to support the new feature.

### Version Update:
* Updated the chart version to `1.2.0` in `Chart.yaml` and corresponding badge in `README.md`. [[1]](diffhunk://#diff-b886313e1c0741f2c72a92382362d33b52e225680751f83cd06d7f1e542d8bc5L5-R5) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5)

### New Feature: Support for `imagePullSecrets`:
* Added `imagePullSecrets` fields to `values.yaml` for `diodeAuth`, `diodeAuthBootstrap`, `diodeIngester`, and `diodeReconciler` to allow specifying secrets for private registries. [[1]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R39-R40) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R79-R80) [[3]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R96-R97) [[4]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R143-R144)
* Updated Kubernetes templates (`diode-auth-bootstrap-job.yaml`, `diode-auth-deployment.yaml`, `diode-ingester-deployment.yaml`, and `diode-reconciler-deployment.yaml`) to include `imagePullSecrets` in the pod specifications if defined. [[1]](diffhunk://#diff-9837c846428ee54aba4b1d0fec6264a4f6396e9860f58bb28528a908f4e779a1R19-R22) [[2]](diffhunk://#diff-f7aefdf5ce4585299408ce0cacfffda7b0f5d2494b11c306f174c4eb249e5bbdR28-R31) [[3]](diffhunk://#diff-8bed87c066be5a33d2a20ef23520641413633a704e236fb966cfff3050c62885R28-R31) [[4]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78R28-R31)

### Documentation Updates:
* Documented the new `imagePullSecrets` fields in the `README.md` under the `helm show values` section for all relevant components. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R236-R244) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R259) [[3]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R288-L287)