### PR TITLE
feat: customize ingress annotations

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: "1.0.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -325,14 +325,14 @@ helm show values diode/diode
 | hydra.job.extraInitContainers | string | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.secret.enabled | bool | `false` | secret enabled |
 | hydra.secret.nameOverride | string | `"diode-hydra-secret"` | existing secret name |
-| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":{},"grpcAnnotations":{"nginx.ingress.kubernetes.io/proxy-body-size":"25m"},"hostname":"","httpAnnotations":{},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
+| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":{},"grpcAnnotations":{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":false},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/ssl-redirect":false},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
 | ingressNginx.controller | object | `{"allowSnippetAnnotations":true}` | ingress annotations |
 | ingressNginx.controller.allowSnippetAnnotations | bool | `true` | allow snippet annotations |
 | ingressNginx.enabled | bool | `true` | ingress-nginx enabled |
 | ingressNginx.extraHttpPaths | object | `{}` | ingress extra http paths |
-| ingressNginx.grpcAnnotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"25m"}` | ingress grpc annotations |
+| ingressNginx.grpcAnnotations | object | `{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":false}` | ingress grpc annotations |
 | ingressNginx.hostname | string | `""` | hostname |
-| ingressNginx.httpAnnotations | object | `{}` | ingress http annotations |
+| ingressNginx.httpAnnotations | object | `{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/ssl-redirect":false}` | ingress http annotations |
 | ingressNginx.ingressClass | string | `"nginx"` | ingress class |
 | ingressNginx.pathPrefix | string | `"/diode"` | ingress path prefix |
 | ingressNginx.tls | object | `{}` | ingress tls |

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -325,14 +325,14 @@ helm show values diode/diode
 | hydra.job.extraInitContainers | string | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.secret.enabled | bool | `false` | secret enabled |
 | hydra.secret.nameOverride | string | `"diode-hydra-secret"` | existing secret name |
-| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":{},"grpcAnnotations":{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":false},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/ssl-redirect":false},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
+| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":{},"grpcAnnotations":{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":true},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/ssl-redirect":true},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
 | ingressNginx.controller | object | `{"allowSnippetAnnotations":true}` | ingress annotations |
 | ingressNginx.controller.allowSnippetAnnotations | bool | `true` | allow snippet annotations |
 | ingressNginx.enabled | bool | `true` | ingress-nginx enabled |
 | ingressNginx.extraHttpPaths | object | `{}` | ingress extra http paths |
-| ingressNginx.grpcAnnotations | object | `{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":false}` | ingress grpc annotations |
+| ingressNginx.grpcAnnotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":true}` | ingress grpc annotations |
 | ingressNginx.hostname | string | `""` | hostname |
-| ingressNginx.httpAnnotations | object | `{"nginx.ingress.kubernetes.io/force-ssl-redirect":false,"nginx.ingress.kubernetes.io/ssl-redirect":false}` | ingress http annotations |
+| ingressNginx.httpAnnotations | object | `{"nginx.ingress.kubernetes.io/ssl-redirect":true}` | ingress http annotations |
 | ingressNginx.ingressClass | string | `"nginx"` | ingress class |
 | ingressNginx.pathPrefix | string | `"/diode"` | ingress path prefix |
 | ingressNginx.tls | object | `{}` | ingress tls |

--- a/charts/diode/templates/ingress-grpc.yaml
+++ b/charts/diode/templates/ingress-grpc.yaml
@@ -1,5 +1,4 @@
 {{- $ingressNginx := index .Values.ingressNginx -}}
-{{- if $ingressNginx.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,10 +10,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-url: "http://{{ include "diode.auth.hostname" . }}:{{ .Values.diodeAuth.containerPort }}/introspect"
     nginx.ingress.kubernetes.io/auth-method: "POST"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
-    nginx.ingress.kubernetes.io/custom-http-errors: "401,403"
     {{- with $ingressNginx.grpcAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -40,4 +37,3 @@ spec:
                 name: {{ include "diode.reconciler.servicename" . }}
                 port:
                   number: {{ .Values.diodeReconciler.containerPort }}
-{{- end }}

--- a/charts/diode/templates/ingress-http.yaml
+++ b/charts/diode/templates/ingress-http.yaml
@@ -1,7 +1,6 @@
 {{- $ingressNginx := index .Values.ingressNginx -}}
 {{- $certManager := index .Values.certManager -}}
 {{- $certIssuer := index .Values.certIssuer -}}
-{{- if $ingressNginx.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,7 +10,6 @@ metadata:
     {{- include "diode.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "diode.ingress.name" . }}
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- with $ingressNginx.httpAnnotations }}
@@ -54,4 +52,3 @@ spec:
                 port:
                   number: {{ $path.servicePort }}
           {{- end }}
-{{- end }}

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -379,12 +379,10 @@ ingressNginx:
     #     - diode.example.com
   # -- ingress http annotations
   httpAnnotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: false
-    nginx.ingress.kubernetes.io/force-ssl-redirect: false
+    nginx.ingress.kubernetes.io/ssl-redirect: true
   # -- ingress grpc annotations
   grpcAnnotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: false
-    nginx.ingress.kubernetes.io/force-ssl-redirect: false
+    nginx.ingress.kubernetes.io/ssl-redirect: true
     nginx.ingress.kubernetes.io/proxy-body-size: "25m"
   # -- ingress path prefix
   pathPrefix: /diode

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -378,9 +378,13 @@ ingressNginx:
     #   hosts:
     #     - diode.example.com
   # -- ingress http annotations
-  httpAnnotations: {}
+  httpAnnotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: false
+    nginx.ingress.kubernetes.io/force-ssl-redirect: false
   # -- ingress grpc annotations
   grpcAnnotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: false
+    nginx.ingress.kubernetes.io/force-ssl-redirect: false
     nginx.ingress.kubernetes.io/proxy-body-size: "25m"
   # -- ingress path prefix
   pathPrefix: /diode


### PR DESCRIPTION
- always create diode ingress regardless of ingress-nginx controller enabled or not
- add default annotations: ssl-redirect 
- remove redundant custom-http-errors annotation