### PR TITLE
fix: reduce noise when calling dev authmanager

### DIFF
--- a/diode-server/docker/scripts/dev-authmanager.sh
+++ b/diode-server/docker/scripts/dev-authmanager.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -x
+#!/usr/bin/env bash
 
 quote_args() {
     local result=""


### PR DESCRIPTION
don't print command line when calling dev auth manager 