### PR TITLE
feat: add image pull policy for init containers in helm chart

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: "1.0.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -296,8 +296,8 @@ helm show values diode/diode
 | externalPostgresql.port | int | `5432` | port |
 | externalRedis.hostname | string | `"localhost"` | hostname |
 | externalRedis.port | int | `6379` | port |
-| global.diode | object | `{"busybox":{"image":"busybox:latest"},"hydra":{"waitForPostgres":true}}` | diode global configuration |
-| global.diode.busybox | object | `{"image":"busybox:latest"}` | busybox image configuration |
+| global.diode | object | `{"busybox":{"image":"busybox:latest","imagePullPolicy":"IfNotPresent"},"hydra":{"waitForPostgres":true}}` | diode global configuration |
+| global.diode.busybox | object | `{"image":"busybox:latest","imagePullPolicy":"IfNotPresent"}` | busybox image configuration |
 | global.diode.hydra | object | `{"waitForPostgres":true}` | hydra additional init containers configuration |
 | global.diode.hydra.waitForPostgres | bool | `true` | wait for PostgreSQL |
 | hydra | object | `{"deployment":{"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}},"enabled":true,"fullnameOverride":"diode-hydra","hydra":{"automigration":{"enabled":true},"config":{"oidc":{"subject_identifiers":{"supported_types":["public"]}},"strategies":{"access_token":"jwt","jwt":{"scope_claim":"both"}},"ttl":{"access_token":"1h"},"urls":{"self":{"issuer":"http://diode-hydra-public.{{ .Release.Namespace }}.svc.cluster.local:4444"}}},"dev":true,"ingress":{"admin":{"enabled":false},"public":{"enabled":false}},"service":{"admin":{"enabled":true,"port":4445,"type":"ClusterIP"},"public":{"enabled":true,"port":4444,"type":"ClusterIP"}}},"job":{"annotations":{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-delete-policy":"hook-succeeded","helm.sh/hook-weight":"1"},"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}"},"secret":{"enabled":false,"nameOverride":"diode-hydra-secret"}}` | ref: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml |

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -70,6 +70,17 @@ Create the name of the busybox image to use
 {{- end }}
 
 {{/*
+Create the image pull policy of the busybox image to use
+*/}}
+{{- define "diode.busybox.imagepullpolicy" -}}
+{{- if .Values.global.diode.busybox.imagePullPolicy -}}
+{{- .Values.global.diode.busybox.imagePullPolicy | quote -}}
+{{- else -}}
+{{- "IfNotPresent" | quote -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the auth service to use
 */}}
 {{- define "diode.auth.servicename" -}}
@@ -333,6 +344,7 @@ Create the name of the extra Hydra init container configmap to use
 {{- if .Values.global.diode.hydra.waitForPostgres -}}
 - name: wait-for-postgres
   image: {{ .Values.global.diode.busybox.image }}
+  imagePullPolicy: {{ .Values.global.diode.busybox.imagePullPolicy }}
   command: ['sh', '-c', 'until nc -zv $POSTGRES_HOST $POSTGRES_PORT; do echo waiting for PostgreSQL; sleep 2; done;']
   envFrom:
     - configMapRef:

--- a/charts/diode/templates/diode-auth-bootstrap-job.yaml
+++ b/charts/diode/templates/diode-auth-bootstrap-job.yaml
@@ -24,6 +24,7 @@ spec:
         {{- if .Values.hydra.enabled }}
         - name: wait-for-oauth2-server
           image: {{ include "diode.busybox.image" . }}
+          imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}
           command:
             - sh
             - -c

--- a/charts/diode/templates/diode-auth-deployment.yaml
+++ b/charts/diode/templates/diode-auth-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- if .Values.hydra.enabled }}
         - name: wait-for-oauth2-server
           image: {{ include "diode.busybox.image" . }}
+          imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}
           command:
             - sh
             - -c

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis
           image: {{ include "diode.busybox.image" . }}
+          imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}
           command:
             - sh
             - -c

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- if .Values.redis.enabled }}
         - name: wait-for-redis
           image: {{ include "diode.busybox.image" . }}
+          imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}
           command:
             - sh
             - -c
@@ -46,6 +47,7 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgres
           image: {{ include "diode.busybox.image" . }}
+          imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}
           command:
             - sh
             - -c

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -4,6 +4,7 @@ global:
     # -- busybox image configuration
     busybox:
       image: busybox:latest
+      imagePullPolicy: IfNotPresent
     # -- hydra additional init containers configuration
     hydra:
       # -- wait for PostgreSQL


### PR DESCRIPTION
This pull request introduces a version bump for the Helm chart and adds support for configuring the `imagePullPolicy` for the BusyBox image used in various deployments and jobs. The changes ensure better flexibility and customization for image handling.

### Version Update:
* Updated the chart version from `1.3.0` to `1.4.0` in `Chart.yaml` and `README.md`. [[1]](diffhunk://#diff-b886313e1c0741f2c72a92382362d33b52e225680751f83cd06d7f1e542d8bc5L5-R5) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5)

### BusyBox Image Pull Policy Enhancements:
* Added a new `imagePullPolicy` field for BusyBox in `values.yaml` and updated the corresponding documentation in `README.md`. [[1]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R7) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L299-R300)
* Introduced a helper function `diode.busybox.imagepullpolicy` in `_helpers.tpl` to dynamically resolve the `imagePullPolicy` value.
* Updated multiple templates (`diode-auth-bootstrap-job.yaml`, `diode-auth-deployment.yaml`, `diode-ingester-deployment.yaml`, `diode-reconciler-deployment.yaml`) to include the `imagePullPolicy` field for BusyBox containers. [[1]](diffhunk://#diff-c3cd7b699e0e30f7ebc966d7b7981bfd3e92fa834007f10765bf25ca7ac169d0R347) [[2]](diffhunk://#diff-9837c846428ee54aba4b1d0fec6264a4f6396e9860f58bb28528a908f4e779a1R27) [[3]](diffhunk://#diff-f7aefdf5ce4585299408ce0cacfffda7b0f5d2494b11c306f174c4eb249e5bbdR36) [[4]](diffhunk://#diff-8bed87c066be5a33d2a20ef23520641413633a704e236fb966cfff3050c62885R36) [[5]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78R36) [[6]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78R50)