### PR TITLE
chore: update appVersion and image tags to 1.1.0 in Helm chart

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -3,7 +3,7 @@ name: diode
 description: A Helm chart for Diode
 type: application
 version: 1.4.0
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 home: https://github.com/netboxlabs/diode
 sources:
   - https://github.com/netboxlabs/diode

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -236,7 +236,7 @@ helm show values diode/diode
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuth.image.tag | string | `"1.0.0"` | image tag |
+| diodeAuth.image.tag | string | `"1.1.0"` | image tag |
 | diodeAuth.replicaCount | int | `1` | replica count |
 | diodeAuth.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeAuth.serviceAccount.create | bool | `true` | create service account |
@@ -244,7 +244,7 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuthBootstrap.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuthBootstrap.image.tag | string | `"1.0.0"` | image tag |
+| diodeAuthBootstrap.image.tag | string | `"1.1.0"` | image tag |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
 | diodeIngester.config.loggingLevel | string | `"INFO"` | logging level |
 | diodeIngester.config.redisStreamDb | int | `1` | redis stream db |
@@ -259,7 +259,7 @@ helm show values diode/diode
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeIngester.image.repository | string | `"docker.io/netboxlabs/diode-ingester"` | image repository |
-| diodeIngester.image.tag | string | `"1.0.0"` | image tag |
+| diodeIngester.image.tag | string | `"1.1.0"` | image tag |
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
@@ -288,7 +288,7 @@ helm show values diode/diode
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.image.repository | string | `"docker.io/netboxlabs/diode-reconciler"` | image repository |
-| diodeReconciler.image.tag | string | `"1.0.0"` | image tag |
+| diodeReconciler.image.tag | string | `"1.1.0"` | image tag |
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeReconciler.serviceAccount.create | bool | `true` | create service account |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -36,7 +36,7 @@ diodeAuth:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.0.0
+    tag: 1.1.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy
@@ -76,7 +76,7 @@ diodeAuthBootstrap:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.0.0
+    tag: 1.1.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy
@@ -93,7 +93,7 @@ diodeIngester:
     # -- image repository
     repository: docker.io/netboxlabs/diode-ingester
     # -- image tag
-    tag: 1.0.0
+    tag: 1.1.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy
@@ -140,7 +140,7 @@ diodeReconciler:
     # -- image repository
     repository: docker.io/netboxlabs/diode-reconciler
     # -- image tag
-    tag: 1.0.0
+    tag: 1.1.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy


### PR DESCRIPTION
This pull request updates the Diode Helm chart to use version 1.1.0 of its component images, reflecting an upgrade from version 1.0.0. The changes ensure consistency across the chart metadata, documentation, and configuration files.

### Version Updates:

* Updated the `appVersion` in `charts/diode/Chart.yaml` from `1.0.0` to `1.1.0` to reflect the new application version.
* Updated the version badge in `charts/diode/README.md` to display `AppVersion: 1.1.0`.

### Image Tag Updates:

* Updated the `diodeAuth.image.tag` in `charts/diode/README.md` and `charts/diode/values.yaml` to `1.1.0`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L239-R247) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L39-R39)
* Updated the `diodeAuthBootstrap.image.tag` in `charts/diode/README.md` and `charts/diode/values.yaml` to `1.1.0`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L239-R247) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L79-R79)
* Updated the `diodeIngester.image.tag` in `charts/diode/README.md` and `charts/diode/values.yaml` to `1.1.0`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L262-R262) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L96-R96)
* Updated the `diodeReconciler.image.tag` in `charts/diode/README.md` and `charts/diode/values.yaml` to `1.1.0`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L291-R291) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L143-R143)