### PR TITLE
fix: helm chart values small fixes

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   - name: postgresql
     version: 16.6.3
     repository: https://charts.bitnami.com/bitnami
-    condition: postgres.enabled
+    condition: postgresql.enabled
   - name: hydra
     version: 0.53.0
     repository: https://k8s.ory.sh/helm/charts

--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "1.1.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -263,12 +263,12 @@ helm show values diode/diode
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
-| diodeReconciler.config.autoApplyChangesets | bool | `true` | auto apply changesets |
+| diodeReconciler.config.autoApplyChangesets | string | `"true"` | auto apply changesets |
 | diodeReconciler.config.diodeToNetBoxClientId | string | `"diode-to-netbox"` | diode to netbox client id |
 | diodeReconciler.config.diodeToNetboxRateLimiterBurst | int | `1` | diode to netbox rate limiter burst |
 | diodeReconciler.config.diodeToNetboxRateLimiterRps | int | `20` | diode to netbox rate limiter rps |
 | diodeReconciler.config.loggingLevel | string | `"INFO"` | logging level |
-| diodeReconciler.config.migrationEnabled | bool | `true` | migration enabled |
+| diodeReconciler.config.migrationEnabled | string | `"true"` | migration enabled |
 | diodeReconciler.config.netboxDiodePluginApiBaseUrl | string | `"http://localhost:8000/netbox/api/plugins/diode"` | netbox diode plugin api base url |
 | diodeReconciler.config.netboxDiodePluginSkipTlsVerify | bool | `false` | netbox diode plugin skip tls verify |
 | diodeReconciler.config.postgresDbName | string | `"diode"` | postgres db name |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -175,9 +175,9 @@ diodeReconciler:
     # -- sentry DSN
     sentryDsn: ""
     # -- migration enabled
-    migrationEnabled: true
+    migrationEnabled: "true"
     # -- auto apply changesets
-    autoApplyChangesets: true
+    autoApplyChangesets: "true"
     # -- reconciler rate limiter rps
     reconcilerRateLimiterRps: 20
     # -- reconciler rate limiter burst


### PR DESCRIPTION
* some boolean values passed to the diode reconciler end up in the environment and thus should be treated as strings in `values.yaml`
* `postgresql:` is used in values and templates, but the chart dependency only checks for `postgres.enabled`