### PR TITLE
fix: add auth endpoint for getting a client by id, back links

### DIFF
--- a/diode-server/auth/manager.go
+++ b/diode-server/auth/manager.go
@@ -32,6 +32,7 @@ type RetrieveClientsRequest struct {
 type RetrieveClientsResponse struct {
 	Clients       []ClientInfo
 	NextPageToken string
+	PrevPageToken string
 }
 
 // ClientManager is an interface for managing oauth2 clients.

--- a/diode-server/auth/manager_hydra.go
+++ b/diode-server/auth/manager_hydra.go
@@ -168,7 +168,7 @@ func (h *HydraClientManager) RetrieveClients(ctx context.Context, q RetrieveClie
 		out.Clients = append(out.Clients, clientInfoFromHydraClient(&client))
 	}
 
-	out.NextPageToken = getHydraNextPageToken(response, h.logger)
+	out.NextPageToken, out.PrevPageToken = getHydraPagingTokens(response, h.logger)
 	return out, nil
 }
 
@@ -199,7 +199,10 @@ func clientInfoFromHydraClient(client *hydra.OAuth2Client) ClientInfo {
 	return clientInfo
 }
 
-func getHydraNextPageToken(response *http.Response, logger *slog.Logger) string {
+// getHydraPagingLinks returns the next and previous page tokens from the response header
+func getHydraPagingTokens(response *http.Response, logger *slog.Logger) (string, string) {
+	next := ""
+	prev := ""
 	for _, linkHeader := range response.Header.Values("Link") {
 		links := strings.Split(linkHeader, ",")
 		for _, link := range links {
@@ -209,33 +212,40 @@ func getHydraNextPageToken(response *http.Response, logger *slog.Logger) string 
 			}
 			link := params[0]
 			params = params[1:]
-			// search for rel="next"
 			for _, param := range params {
 				vs := strings.Split(param, "=")
 				if len(vs) != 2 {
 					continue
 				}
 				k, v := strings.TrimSpace(vs[0]), strings.TrimSpace(vs[1])
-				if k == "rel" && (v == "next" || v == "\"next\"") {
-					link = strings.TrimPrefix(link, "<")
-					link = strings.TrimSuffix(link, ">")
-					parsedURL, err := url.Parse(link)
-					if err != nil {
-						logger.Warn("failed to parse url in rel=next link", "error", err, "link", linkHeader)
-						return ""
+				if k == "rel" {
+					if v == "next" || v == "\"next\"" {
+						next = getHydraPageToken(link, logger)
+					} else if v == "prev" || v == "\"prev\"" {
+						prev = getHydraPageToken(link, logger)
 					}
-					queryParams := parsedURL.Query()
-					for key, values := range queryParams {
-						if key == "page_token" {
-							logger.Info("found next page token", "token", values[0])
-							return values[0]
-						}
-					}
-					logger.Warn("failed to find next page token in rel=next url", "link", linkHeader)
-					return ""
 				}
 			}
 		}
 	}
+	return next, prev
+}
+
+func getHydraPageToken(link string, logger *slog.Logger) string {
+	link = strings.TrimPrefix(link, "<")
+	link = strings.TrimSuffix(link, ">")
+	parsedURL, err := url.Parse(link)
+	if err != nil {
+		logger.Warn("failed to parse url in hydra paging link", "error", err, "link", link)
+		return ""
+	}
+	queryParams := parsedURL.Query()
+	for key, values := range queryParams {
+		if key == "page_token" {
+			logger.Debug("found page token", "token", values[0])
+			return values[0]
+		}
+	}
+	logger.Warn("failed to find page_token in hydra paging link", "link", link)
 	return ""
 }

--- a/diode-server/auth/server.go
+++ b/diode-server/auth/server.go
@@ -68,6 +68,7 @@ type ClientResponse struct {
 type ListClientsResponse struct {
 	Data          []ClientResponse `json:"data"`
 	NextPageToken string           `json:"next_page_token,omitempty"`
+	PrevPageToken string           `json:"prev_page_token,omitempty"`
 }
 
 // ClientErrorResponse error response to client requests
@@ -158,6 +159,7 @@ func (s *Server) RegisterHandlers() {
 	s.mux.HandleFunc("POST /token", s.token)
 	s.mux.HandleFunc("POST /clients", s.createClient)
 	s.mux.HandleFunc("GET /clients", s.listClients)
+	s.mux.HandleFunc("GET /clients/{clientID}", s.getClient)
 	s.mux.HandleFunc("DELETE /clients/{clientID}", s.deleteClient)
 }
 
@@ -492,6 +494,7 @@ func (s *Server) listClients(w http.ResponseWriter, r *http.Request) {
 	out := ListClientsResponse{
 		Data:          make([]ClientResponse, 0, len(clients.Clients)),
 		NextPageToken: clients.NextPageToken,
+		PrevPageToken: clients.PrevPageToken,
 	}
 	for _, client := range clients.Clients {
 		out.Data = append(out.Data, ClientResponse{
@@ -556,4 +559,48 @@ func (s *Server) deleteClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) getClient(w http.ResponseWriter, r *http.Request) {
+	jwtToken, _, ok := s.authorizeCall(w, r, []string{authutil.ScopeDiodeRead})
+	if !ok {
+		return
+	}
+
+	ownerID, err := s.tokenOwnership.TokenOwnerID(r.Context(), jwtToken)
+	if err != nil {
+		s.logger.Error("failed to get token owner ID", "error", err)
+		w.WriteHeader(statusFromError(err))
+		return
+	}
+
+	clientID := r.PathValue("clientID")
+	if clientID == "" {
+		err = writeJSON(w, http.StatusBadRequest, ClientErrorResponse{Error: "client ID is required"})
+		if err != nil {
+			s.logger.Error("failed to write response", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// get the client and verify ownership
+	client, err := s.clientManager.RetrieveClientByID(r.Context(), clientID)
+	if err != nil {
+		s.logger.Error("failed to get client", "error", err)
+		w.WriteHeader(statusFromError(err))
+		return
+	}
+
+	if client.Owner != ownerID {
+		s.logger.Error("client does not belong to requestor", "client_id", clientID, "owner_id", ownerID)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	err = writeJSON(w, http.StatusOK, client)
+	if err != nil {
+		s.logger.Error("failed to write response", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
 }

--- a/diode-server/auth/server_hydra_integration_test.go
+++ b/diode-server/auth/server_hydra_integration_test.go
@@ -150,18 +150,38 @@ func TestServerHydraIntegration(t *testing.T) {
 	require.Equal(t, 10, len(result.Data))
 	require.Equal(t, result.NextPageToken, "")
 
-	// page through the clients in pages of size 3
-	pageSize := 3
+	// get the first client
+	firstClient := client.getClient(t, result.Data[0].ClientID)
+	require.Equal(t, result.Data[0].ClientID, firstClient.ClientID)
+	require.Equal(t, result.Data[0].ClientName, firstClient.ClientName)
+	require.Equal(t, result.Data[0].Scope, firstClient.Scope)
+
+	// delete the first client
+	client.deleteClient(t, result.Data[0].ClientID)
+
+	// list clients, should include the 9 remaining test clients
+	result = client.listClients(t, "", 100)
+	require.Equal(t, 9, len(result.Data))
+
+	// page through the 9 remaining clients in pages of size 2
+	var priorResult auth.ListClientsResponse
+	pageSize := 2
 	nextToken := ""
 	seen := make(map[string]bool)
 	pages := 0
-	for range 5 { // should be 4 pages, stop after 5
+	for range 6 { // should be 5 pages, stop after 6
 		result = client.listClients(t, nextToken, pageSize)
+		// previous page should be the same as the prior result
+		if pages > 0 {
+			prevPage := client.listClients(t, result.PrevPageToken, pageSize)
+			require.Equal(t, priorResult.Data, prevPage.Data)
+		}
+		priorResult = result
+
 		pages++
 		for _, c := range result.Data {
 			seen[c.ClientID] = true
 		}
-
 		nextToken = result.NextPageToken
 		if nextToken == "" {
 			break
@@ -170,9 +190,9 @@ func TestServerHydraIntegration(t *testing.T) {
 		}
 	}
 
-	// verify that we saw all 10 clients
-	require.Equal(t, 10, len(seen))
-	require.Equal(t, 4, pages)
+	// verify that we saw all 9 clients
+	require.Equal(t, 9, len(seen))
+	require.Equal(t, 5, pages)
 }
 
 type authTestClient struct {
@@ -231,6 +251,37 @@ func (c *authTestClient) createClient(t *testing.T, clientName string, scope str
 	err = json.NewDecoder(resp.Body).Decode(&createdClient)
 	require.NoError(t, err)
 	return createdClient
+}
+
+func (c *authTestClient) getClient(t *testing.T, clientID string) auth.ClientResponse {
+	req, err := http.NewRequest(http.MethodGet, c.endpoint+"/clients/"+clientID, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result auth.ClientResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	return result
+}
+
+func (c *authTestClient) deleteClient(t *testing.T, clientID string) {
+	req, err := http.NewRequest(http.MethodDelete, c.endpoint+"/clients/"+clientID, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func (c *authTestClient) authenticate(t *testing.T, clientID string, clientSecret string, scope string) {

--- a/diode-server/auth/server_test.go
+++ b/diode-server/auth/server_test.go
@@ -726,6 +726,136 @@ func TestDeleteClient(t *testing.T) {
 	}
 }
 
+func TestGetClient(t *testing.T) {
+	readOnlyToken := jwt.Token{
+		Claims: jwt.MapClaims{
+			"exp":       time.Now().Add(time.Hour).Unix(),
+			"iat":       time.Now().Unix(),
+			"client_id": "client123",
+			"scope":     "diode:read",
+		},
+		Valid: true,
+	}
+	invalidToken := jwt.Token{
+		Valid: false,
+	}
+
+	validAccessToken := "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5IiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2F1dGguZXhhbXBsZS5jb20iLCJzdWIiOiJ1c2VyMTIzIiwiYXVkIjoiYXBpIiwiZXhwIjoxNjUwMDAwMDAwLCJpYXQiOjE1MDAwMDAwMDAsImNsaWVudF9pZCI6ImNsaWVudDEyMyIsInNjb3BlIjoicmVhZCB3cml0ZSIsInVzZXJuYW1lIjoidGVzdHVzZXIifQ.WcPGXClpKD7Bc1C0CCDA1060E2GGlTfamrd8-W0ghBE"
+	invalidAccessToken := "invalid.token.string"
+
+	tests := []struct {
+		name         string
+		accessToken  string
+		clientID     string
+		parsedToken  jwt.Token
+		lookupResult auth.ClientInfo
+		lookupErr    error
+		expectStatus int
+		expect       auth.ClientResponse
+	}{
+		{
+			name:        "can get client",
+			accessToken: validAccessToken,
+			clientID:    "test-client-1-abcdef0123567890",
+			parsedToken: readOnlyToken,
+			lookupResult: auth.ClientInfo{
+				ClientID:   "test-client-1-abcdef0123567890",
+				ClientName: "Test Client 1",
+				Scope:      "diode:ingest",
+				Owner:      "diode/user",
+				CreatedAt:  "2021-01-01T00:00:00Z",
+			},
+			expect: auth.ClientResponse{
+				ClientID:   "test-client-1-abcdef0123567890",
+				ClientName: "Test Client 1",
+				Scope:      "diode:ingest",
+				CreatedAt:  "2021-01-01T00:00:00Z",
+			},
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "cannot get client with invalid access token",
+			accessToken:  invalidAccessToken,
+			clientID:     "test-client-1-abcdef0123567890",
+			parsedToken:  invalidToken,
+			expectStatus: http.StatusUnauthorized,
+		},
+		{
+			name:         "cannot get client that does not exist",
+			accessToken:  validAccessToken,
+			clientID:     "test-client-1-abcdef0123567890",
+			parsedToken:  readOnlyToken,
+			lookupErr:    auth.NewAuthError("client not found", http.StatusNotFound),
+			expectStatus: http.StatusNotFound,
+		},
+		{
+			name:        "cannot get a client with the wrong owner",
+			accessToken: validAccessToken,
+			clientID:    "test-client-1-abcdef0123567890",
+			parsedToken: readOnlyToken,
+			lookupResult: auth.ClientInfo{
+				ClientID:   "test-client-1-abcdef0123567890",
+				ClientName: "Test Client 1",
+				Owner:      "diode/system",
+				Scope:      "diode:read diode:write",
+				CreatedAt:  "2021-01-01T00:00:00Z",
+			},
+			expectStatus: http.StatusNotFound,
+		},
+	}
+
+	ctx := context.Background()
+	setupEnv()
+	defer teardownEnv()
+
+	// Setup a test server to mock the OAuth2 server
+	mockJWKSServer := mockJWKSServer()
+	defer mockJWKSServer.Close()
+
+	_ = os.Setenv("OAUTH2_PUBLIC_SERVER_URL", mockJWKSServer.URL)
+	defer func() {
+		_ = os.Unsetenv("OAUTH2_PUBLIC_SERVER_URL")
+	}()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defaultOwnership := &auth.DefaultTokenOwner{}
+			accessToken := test.accessToken
+			if accessToken == "" {
+				accessToken = validAccessToken
+			}
+			mockTokenParser := &MockTokenParser{
+				tokenMap: map[string]jwt.Token{
+					accessToken: test.parsedToken,
+				},
+			}
+			mockClientManager := &mocks.ClientManager{}
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+			server, err := auth.NewServer(ctx, logger, mockTokenParser, mockClientManager, defaultOwnership)
+			require.NoError(t, err)
+			require.NotNil(t, server)
+
+			testServer := httptest.NewServer(server.GetMux())
+			defer testServer.Close()
+
+			if test.lookupResult != (auth.ClientInfo{}) || test.lookupErr != nil {
+				mockClientManager.EXPECT().RetrieveClientByID(mock.Anything, test.clientID).Return(test.lookupResult, test.lookupErr)
+			}
+
+			req, _ := http.NewRequest("GET", testServer.URL+"/clients/"+test.clientID, nil)
+			req.Header.Set("Authorization", "Bearer "+accessToken)
+			req.Header.Set("Content-Type", "application/json")
+			client := &http.Client{}
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			require.Equal(t, test.expectStatus, resp.StatusCode)
+		})
+	}
+}
+
 func makeIntrospectRequest(serverURL, token string) (*http.Response, error) {
 	req, _ := http.NewRequest(
 		"POST",


### PR DESCRIPTION
* adds an endpoint to get a client by id
* adds previous page token link in client list result
* tests

*etc* 
This pull request introduces enhancements to the client management functionality in the `diode-server` project. The changes include adding support for retrieving the previous page token in paginated responses, implementing a new `GET /clients/{clientID}` endpoint to fetch individual client details, and updating tests to cover the new functionality.

### Enhancements to Pagination:
* Added `PrevPageToken` to the `RetrieveClientsResponse` and `ListClientsResponse` structs to support backward navigation in paginated responses (`diode-server/auth/manager.go`, `diode-server/auth/server.go`). [[1]](diffhunk://#diff-c2e508fa8c0872b1548387c4ad027097989882eb80a181085c99f37b3b1f6032R35) [[2]](diffhunk://#diff-55f7180a60b6af83fb87ce5fac8743489b7fe8983a8784ac2913ec1d574f60e4R71)
* Updated the `RetrieveClients` method to extract both next and previous page tokens from the Hydra response using the new `getHydraPagingTokens` function (`diode-server/auth/manager_hydra.go`). [[1]](diffhunk://#diff-41d59f823309f781ab251fafd5e020350d03bc39a63a273459f0a9379561da7eL171-R171) [[2]](diffhunk://#diff-41d59f823309f781ab251fafd5e020350d03bc39a63a273459f0a9379561da7eL202-R205) [[3]](diffhunk://#diff-41d59f823309f781ab251fafd5e020350d03bc39a63a273459f0a9379561da7eL212-R249)

### New Endpoint for Retrieving Individual Clients:
* Introduced a `GET /clients/{clientID}` endpoint in the `Server` struct to fetch details of a specific client, including authorization and ownership verification (`diode-server/auth/server.go`). [[1]](diffhunk://#diff-55f7180a60b6af83fb87ce5fac8743489b7fe8983a8784ac2913ec1d574f60e4R162) [[2]](diffhunk://#diff-55f7180a60b6af83fb87ce5fac8743489b7fe8983a8784ac2913ec1d574f60e4R563-R606)

### Test Suite Updates:
* Added integration tests to verify the behavior of the new `GET /clients/{clientID}` endpoint, including scenarios for valid requests, invalid tokens, non-existent clients, and ownership mismatches (`diode-server/auth/server_hydra_integration_test.go`, `diode-server/auth/server_test.go`). [[1]](diffhunk://#diff-cfe98ccbc9d59bcb2376e5d94a4625e328e884328b17a180f6de8475a81e213dL153-L164) [[2]](diffhunk://#diff-548723f5ad44191fe457bd5513367fbd54277b96f8e6f33e09c150a65e097c30R729-R858)
* Enhanced pagination tests to validate `PrevPageToken` functionality and ensure consistency when navigating between pages (`diode-server/auth/server_hydra_integration_test.go`).

These changes improve the flexibility of the API by enabling backward pagination and providing a way to retrieve individual client details securely.