### PR TITLE
chore: add jajeffries to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @leoparente @ltucker @mfiedorowicz
+* @jajeffries @leoparente @ltucker @mfiedorowicz


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to reflect a change in code ownership.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Added `@jajeffries` to the list of code owners.