### PR TITLE
chore: bump diode images to 1.2.0 and fix chart lock

### DIFF
--- a/charts/diode/Chart.lock
+++ b/charts/diode/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.12.0
-digest: sha256:4c2a148051fe71f62a1d53ad163b0ece13013544cf7c29c72405813a9d957296
-generated: "2025-04-17T20:05:02.485698+02:00"
+digest: sha256:befc72d9e6eedfe03a16a502fecb33478a4e8bc94acc2497d12b758405561f6e
+generated: "2025-05-16T17:12:36.330502+02:00"

--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -3,7 +3,7 @@ name: diode
 description: A Helm chart for Diode
 type: application
 version: 1.4.1
-appVersion: "1.1.0"
+appVersion: "1.2.0"
 home: https://github.com/netboxlabs/diode
 sources:
   - https://github.com/netboxlabs/diode

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -236,7 +236,7 @@ helm show values diode/diode
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuth.image.tag | string | `"1.1.0"` | image tag |
+| diodeAuth.image.tag | string | `"1.2.0"` | image tag |
 | diodeAuth.replicaCount | int | `1` | replica count |
 | diodeAuth.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeAuth.serviceAccount.create | bool | `true` | create service account |
@@ -244,7 +244,7 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuthBootstrap.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuthBootstrap.image.tag | string | `"1.1.0"` | image tag |
+| diodeAuthBootstrap.image.tag | string | `"1.2.0"` | image tag |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
 | diodeIngester.config.loggingLevel | string | `"INFO"` | logging level |
 | diodeIngester.config.redisStreamDb | int | `1` | redis stream db |
@@ -259,7 +259,7 @@ helm show values diode/diode
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeIngester.image.repository | string | `"docker.io/netboxlabs/diode-ingester"` | image repository |
-| diodeIngester.image.tag | string | `"1.1.0"` | image tag |
+| diodeIngester.image.tag | string | `"1.2.0"` | image tag |
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
@@ -288,7 +288,7 @@ helm show values diode/diode
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.image.repository | string | `"docker.io/netboxlabs/diode-reconciler"` | image repository |
-| diodeReconciler.image.tag | string | `"1.1.0"` | image tag |
+| diodeReconciler.image.tag | string | `"1.2.0"` | image tag |
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeReconciler.serviceAccount.create | bool | `true` | create service account |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -36,7 +36,7 @@ diodeAuth:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.1.0
+    tag: 1.2.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy
@@ -76,7 +76,7 @@ diodeAuthBootstrap:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.1.0
+    tag: 1.2.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy
@@ -93,7 +93,7 @@ diodeIngester:
     # -- image repository
     repository: docker.io/netboxlabs/diode-ingester
     # -- image tag
-    tag: 1.1.0
+    tag: 1.2.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy
@@ -140,7 +140,7 @@ diodeReconciler:
     # -- image repository
     repository: docker.io/netboxlabs/diode-reconciler
     # -- image tag
-    tag: 1.1.0
+    tag: 1.2.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: [ ]
     # -- pull policy


### PR DESCRIPTION
This pull request updates the `diode` Helm chart to use version `1.2.0` of its application images, ensuring consistency across all components. The changes include updates to metadata, documentation, and configuration files.

### Metadata Updates:
* Updated the `appVersion` in `charts/diode/Chart.yaml` from `1.1.0` to `1.2.0`.

### Documentation Updates:
* Updated the `AppVersion` badge in `charts/diode/README.md` to reflect the new version `1.2.0`.
* Updated image tags in the `helm show values` section of `charts/diode/README.md` for `diodeAuth`, `diodeAuthBootstrap`, `diodeIngester`, and `diodeReconciler` to version `1.2.0`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L239-R247) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L262-R262) [[3]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L291-R291)

### Configuration Updates:
* Updated image tags in `charts/diode/values.yaml` for:
  - `diodeAuth` to `1.2.0`.
  - `diodeAuthBootstrap` to `1.2.0`.
  - `diodeIngester` to `1.2.0`.
  - `diodeReconciler` to `1.2.0`.