### PR TITLE
chore: add JFrog integration

### DIFF
--- a/.github/workflows/server-develop.yaml
+++ b/.github/workflows/server-develop.yaml
@@ -1,8 +1,8 @@
-name: Server - release
+name: Server - build and push develop
 on:
   workflow_dispatch:
   push:
-    branches: [ release ]
+    branches: [ develop ]
     paths:
       - "diode-server/**"
       - "!diode-server/docker/**"
@@ -15,7 +15,6 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
   GO_VERSION: '1.23'
 
 permissions:
@@ -36,31 +35,17 @@ jobs:
         run: |
           echo 'apps=["auth", "ingester", "reconciler"]' >> "$GITHUB_OUTPUT"
 
-  get-next-version:
-    name: Get next version - ${{ matrix.app }}
-    needs: [ setup ]
-    uses: netboxlabs/diode/.github/workflows/reusable_semantic_release_get_next_version.yaml@develop
-    strategy:
-      fail-fast: false
-      matrix:
-        app: ${{ fromJSON(needs.setup.outputs.apps) }}
-    with:
-      app_name: diode-${{ matrix.app }}
-      app_dir: diode-server
-    secrets: inherit
-
   build:
     name: Build - ${{ matrix.app }}
-    needs: [ setup, get-next-version ]
+    needs: [ setup ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         app: ${{ fromJSON(needs.setup.outputs.apps) }}
-    if: needs.get-next-version.outputs.new-release-published == 'true'
     env:
-      BUILD_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
-      BUILD_COMMIT: ${{ needs.get-next-version.outputs.short-sha }}
+      BUILD_VERSION: 0.0.0
+      BUILD_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,11 +56,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set build info
+        run: |
+          echo $BUILD_COMMIT > ./server/version/BUILD_COMMIT.txt
+          echo $BUILD_VERSION > ./server/version/BUILD_VERSION.txt
 
       - name: Setup JFrog CLI
         id: setup-jfrog-cli
@@ -93,38 +77,17 @@ jobs:
           username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
           password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
 
-      - name: Set build info
-        run: |
-          echo $BUILD_COMMIT > ./diode-server/version/BUILD_COMMIT.txt
-          echo $BUILD_VERSION > ./diode-server/version/BUILD_VERSION.txt
-
       - name: Build image and push
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6
         with:
-          context: diode-server
-          file: diode-server/docker/Dockerfile-build.${{ matrix.app }}
+          context: .
+          file: docker/Dockerfile-build.${{ matrix.app }}
           platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            netboxlabs/diode-${{ matrix.app }}:latest
-            netboxlabs/diode-${{ matrix.app }}:${{ env.BUILD_VERSION }}
-            netboxlabs.jfrog.io/obs-builds/diode-${{ matrix.app }}:latest
-            netboxlabs.jfrog.io/obs-builds/diode-${{ matrix.app }}:${{ env.BUILD_VERSION }}
+            netboxlabs.jfrog.io/obs-builds/diode-${{ matrix.app }}:develop
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
             SVC=${{ matrix.app }}
-
-  semantic-release:
-    name: Semantic release - ${{ matrix.app }}
-    uses: netboxlabs/diode/.github/workflows/reusable_semantic_release.yaml@develop
-    needs: [ setup, build ]
-    strategy:
-      fail-fast: false
-      matrix:
-        app: ${{ fromJSON(needs.setup.outputs.apps) }}
-    with:
-      app_name: diode-${{ matrix.app }}
-      app_dir: diode-server
-    secrets: inherit


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and pushing images for the `develop` branch and updates the existing `server-release.yaml` workflow to include JFrog Artifactory integration and additional image tagging. These changes enhance CI/CD capabilities by supporting multiple registries and improving build automation.

### New Workflow for `develop` Branch:
* Added `.github/workflows/server-develop.yaml` to define a new workflow for building and pushing Docker images for the `develop` branch. This workflow includes steps for setting up build environments, configuring JFrog CLI, logging into JFrog Artifactory, and building/pushing images to multiple platforms.

### Updates to `server-release.yaml`:
* **Permissions Update**: Added `id-token: write` permission to enable OIDC-based authentication for JFrog CLI.
* **JFrog Artifactory Integration**: Introduced steps to set up JFrog CLI and log in to JFrog Artifactory in the release workflow. This ensures artifacts are pushed to JFrog alongside Docker Hub.
* **Additional Image Tags**: Updated the `docker/build-push-action` step to include JFrog Artifactory-specific tags (`netboxlabs.jfrog.io/obs-builds/diode-${{ matrix.app }}`) for both `latest` and versioned images.