### PR TITLE
fix: GHA - add condition to post comment for PRs from the same repo

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -56,6 +56,7 @@ jobs:
           body-includes: Go test coverage
       - name: Post comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           comment-id: ${{ steps.existing-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/go-test.yaml` file. The change adds a conditional check to ensure that the repository of the pull request head matches the current repository before posting a comment.

* [`.github/workflows/go-test.yaml`](diffhunk://#diff-459772e2288eadce428ea0649a84579e92ebb7ac501a4b06b99415d3bc892314R59): Added a condition (`if: github.event.pull_request.head.repo.full_name == github.repository`) to the "Post comment" step to prevent comments from being posted for pull requests originating from forks.