### PR TITLE
fix: extraHttpPaths is a list, not a dictionary

### DIFF
--- a/charts/diode/.gitignore
+++ b/charts/diode/.gitignore
@@ -1,0 +1,1 @@
+/charts/*.tgz

--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: "1.2.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -325,11 +325,11 @@ helm show values diode/diode
 | hydra.job.extraInitContainers | string | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.secret.enabled | bool | `false` | secret enabled |
 | hydra.secret.nameOverride | string | `"diode-hydra-secret"` | existing secret name |
-| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":{},"grpcAnnotations":{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":"true"},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/ssl-redirect":"true"},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
+| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":[],"grpcAnnotations":{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":"true"},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/ssl-redirect":"true"},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
 | ingressNginx.controller | object | `{"allowSnippetAnnotations":true}` | ingress annotations |
 | ingressNginx.controller.allowSnippetAnnotations | bool | `true` | allow snippet annotations |
 | ingressNginx.enabled | bool | `true` | ingress-nginx enabled |
-| ingressNginx.extraHttpPaths | object | `{}` | ingress extra http paths |
+| ingressNginx.extraHttpPaths | list | `[]` | ingress extra http paths |
 | ingressNginx.grpcAnnotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":"true"}` | ingress grpc annotations |
 | ingressNginx.hostname | string | `""` | hostname |
 | ingressNginx.httpAnnotations | object | `{"nginx.ingress.kubernetes.io/ssl-redirect":"true"}` | ingress http annotations |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -388,7 +388,7 @@ ingressNginx:
   # -- ingress path prefix
   pathPrefix: /diode
   # -- ingress extra http paths
-  extraHttpPaths: {}
+  extraHttpPaths: []
     # - path: /
     #   pathType: Prefix
     #   serviceName: netbox


### PR DESCRIPTION
This resolves the following Helm warning when setting paths:

coalesce.go:298: warning: cannot overwrite table with non table for diode.ingressNginx.extraHttpPaths (map[])
coalesce.go:298: warning: cannot overwrite table with non table for diode.ingressNginx.extraHttpPaths (map[])
coalesce.go:298: warning: cannot overwrite table with non table for diode.ingressNginx.extraHttpPaths (map[])