### PR TITLE
fix: exit processor loop when stop is called

### DIFF
--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
@@ -62,6 +63,8 @@ type IngestionProcessor struct {
 	redisConsumerGroup string
 	ops                IngestionProcessorOps
 	metrics            IngestionProcessorMetrics
+	cancel             context.CancelFunc
+	mx                 sync.Mutex
 }
 
 // IngestionLogToProcess represents an ingestion log to process
@@ -120,12 +123,22 @@ func (p *IngestionProcessor) Name() string {
 // Start starts the component
 func (p *IngestionProcessor) Start(ctx context.Context) error {
 	p.logger.Info("starting component", "name", p.Name())
+	p.mx.Lock()
+	ctx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+	p.mx.Unlock()
 	return p.consumeIngestionStream(ctx, p.redisStreamID, p.redisConsumerGroup, fmt.Sprintf("%s-%s", p.redisConsumerGroup, p.hostname))
 }
 
 // Stop stops the component
 func (p *IngestionProcessor) Stop() error {
 	p.logger.Info("stopping component", "name", p.Name())
+	p.mx.Lock()
+	if p.cancel != nil {
+		p.cancel()
+		p.cancel = nil
+	}
+	p.mx.Unlock()
 	redisClientErr := p.redisClient.Close()
 	redisStreamErr := p.redisStreamClient.Close()
 
@@ -139,6 +152,12 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 	}
 
 	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Debug("ingestion processor exiting consumer loop on request")
+			return nil
+		default:
+		}
 		streams, err := p.redisStreamClient.XReadGroup(ctx, &redis.XReadGroupArgs{
 			Group:    redisConsumerGroup,
 			Consumer: redisConsumer,

--- a/diode-server/reconciler/ingestion_processor_test.go
+++ b/diode-server/reconciler/ingestion_processor_test.go
@@ -286,7 +286,7 @@ func TestIngestionProcessorStart(t *testing.T) {
 
 	// Start processor in a separate goroutine
 	go func() {
-		err = processor.Start(ctx)
+		err := processor.Start(ctx)
 		assert.NoError(t, err)
 	}()
 	// Wait server


### PR DESCRIPTION
Stop() on ingestion processor previously just closed redis clients.
The processor loop continues when encountering redis errors.
This change makes it check/respect context cancelation

*etc* 

This pull request enhances the `IngestionProcessor` in `diode-server/reconciler/ingestion_processor.go` by adding support for graceful shutdown and thread safety. Key changes include introducing a `context.CancelFunc` for cancellation, a mutex for synchronization, and modifying the consumer loop to respect context cancellation. Additionally, a minor fix was made in the test file to improve variable scope.

### Enhancements for graceful shutdown:

* Added a `cancel` field of type `context.CancelFunc` to the `IngestionProcessor` struct to manage cancellation.
* Updated the `Start` method to initialize a cancellable context and store the `CancelFunc` in the processor, ensuring proper cleanup during shutdown.
* Modified the `Stop` method to invoke the `CancelFunc` and clear it, allowing the processor to stop gracefully.
* Updated the `consumeIngestionStream` method to exit the consumer loop when the context is canceled, ensuring responsiveness to shutdown signals.

### Thread safety improvements:

* Added a `sync.Mutex` field (`mx`) to the `IngestionProcessor` struct to synchronize access to shared resources like `cancel`.
* Incorporated locking and unlocking in the `Start` and `Stop` methods to ensure thread-safe operations on the `cancel` field.

### Test file improvement:

* Fixed variable scoping in the `TestIngestionProcessorStart` test by declaring `err` inside the goroutine, preventing unintended reuse of the variable.