### PR TITLE
chore: inject config into ingestion processor rather than reparsing

### DIFF
--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -134,7 +134,7 @@ func main() {
 		s.Logger().Error("failed to create ingestion processor metrics", "error", err)
 		os.Exit(1)
 	}
-	ingestionProcessor, err := reconciler.NewIngestionProcessor(ctx, s.Logger(), redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, ops, ingestionMetrics)
+	ingestionProcessor, err := reconciler.NewIngestionProcessor(ctx, s.Logger(), cfg, redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, ops, ingestionMetrics)
 	if err != nil {
 		s.Logger().Error("failed to instantiate ingestion processor", "error", err)
 		os.Exit(1)

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
-	"github.com/kelseyhightower/envconfig"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/time/rate"
@@ -91,10 +90,7 @@ type IngestionProcessorMetrics interface {
 }
 
 // NewIngestionProcessor creates a new ingestion processor
-func NewIngestionProcessor(_ context.Context, logger *slog.Logger, redisClient, redisStreamClient RedisClient, redisStreamID string, redisConsumerGroup string, ops IngestionProcessorOps, metrics IngestionProcessorMetrics) (*IngestionProcessor, error) {
-	var cfg Config
-	envconfig.MustProcess("", &cfg)
-
+func NewIngestionProcessor(_ context.Context, logger *slog.Logger, cfg Config, redisClient, redisStreamClient RedisClient, redisStreamID string, redisConsumerGroup string, ops IngestionProcessorOps, metrics IngestionProcessorMetrics) (*IngestionProcessor, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %v", err)

--- a/diode-server/reconciler/ingestion_processor_test.go
+++ b/diode-server/reconciler/ingestion_processor_test.go
@@ -76,7 +76,7 @@ func TestNewIngestionProcessor(t *testing.T) {
 		_ = redisStreamClient.Close()
 	}()
 
-	processor, err := reconciler.NewIngestionProcessor(ctx, logger, redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, reconciler.NewOps(mockRepository, nbClient, logger), metrics)
+	processor, err := reconciler.NewIngestionProcessor(ctx, logger, cfg, redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, reconciler.NewOps(mockRepository, nbClient, logger), metrics)
 	require.NoError(t, err)
 	require.NotNil(t, processor)
 
@@ -140,7 +140,7 @@ func TestIngestionProcessorStart(t *testing.T) {
 		_ = redisStreamClient.Close()
 	}()
 
-	processor, err := reconciler.NewIngestionProcessor(ctx, logger, redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, reconciler.NewOps(mockRepository, nbClient, logger), mockMetrics)
+	processor, err := reconciler.NewIngestionProcessor(ctx, logger, cfg, redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, reconciler.NewOps(mockRepository, nbClient, logger), mockMetrics)
 	require.NoError(t, err)
 	require.NotNil(t, processor)
 


### PR DESCRIPTION
* Allows providing a specific configuration to an ingestion processor rather than always parsing from the environment in the constructor
* Pass already parsed environment configuration to ingestion processor on startup

*etc* 

This pull request refactors the `NewIngestionProcessor` function to accept a `Config` parameter instead of relying on environment variable processing within the function. This change improves modularity and testability by externalizing configuration handling. Additionally, the `envconfig` dependency has been removed as it is no longer required.

### Refactoring for configuration handling:

* [`diode-server/reconciler/ingestion_processor.go`](diffhunk://#diff-498d60e586633c715555ff8c5225006b014994c43445ddf2b2b5b4f9e728beedL94-R93): Updated `NewIngestionProcessor` to accept a `Config` parameter directly, removing the internal environment variable processing logic.
* [`diode-server/cmd/reconciler/main.go`](diffhunk://#diff-cd86f7227f1786d5281fbb95507b9c82c88ffe79117211d8104c2b871b5f62c9L137-R137): Modified the instantiation of `NewIngestionProcessor` to pass the `cfg` object instead of relying on environment variable processing.
* [`diode-server/reconciler/ingestion_processor_test.go`](diffhunk://#diff-2714f6eab1cdf426fe54db7ecd4da87025796c52c5bfb7bcedf2e060948804e3L79-R79): Updated test cases (`TestNewIngestionProcessor` and `TestIngestionProcessorStart`) to pass the `cfg` parameter when creating the ingestion processor. [[1]](diffhunk://#diff-2714f6eab1cdf426fe54db7ecd4da87025796c52c5bfb7bcedf2e060948804e3L79-R79) [[2]](diffhunk://#diff-2714f6eab1cdf426fe54db7ecd4da87025796c52c5bfb7bcedf2e060948804e3L143-R143)

### Dependency cleanup:

* [`diode-server/reconciler/ingestion_processor.go`](diffhunk://#diff-498d60e586633c715555ff8c5225006b014994c43445ddf2b2b5b4f9e728beedL13): Removed the `envconfig` dependency from the imports as it is no longer needed.