### PR TITLE
fix: the filenames don't change, so don't parameterize them

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: "1.2.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/diode/templates/diode-auth-deployment.yaml
+++ b/charts/diode/templates/diode-auth-deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-auth: {{ include (printf "%s/%s-auth-configmap.yaml" $.Template.BasePath (include "diode.name" .)) . | sha256sum }}
+        checksum/config-auth: {{ include (printf "%s/diode-auth-configmap.yaml" $.Template.BasePath) . | sha256sum }}
       labels:
         {{- include "diode.selectorlabels" . | nindent 8 }}
         app: {{ include "diode.auth.servicename" . }}

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-ingester: {{ include (printf "%s/%s-ingester-configmap.yaml" $.Template.BasePath (include "diode.name" .)) . | sha256sum }}
+        checksum/config-ingester: {{ include (printf "%s/diode-ingester-configmap.yaml" $.Template.BasePath) . | sha256sum }}
       labels:
         {{- include "diode.selectorlabels" . | nindent 8 }}
         app: {{ include "diode.ingester.servicename" . }}

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-reconciler: {{ include (printf "%s/%s-reconciler-configmap.yaml" $.Template.BasePath (include "diode.name" .)) . | sha256sum }}
+        checksum/config-reconciler: {{ include (printf "%s/diode-reconciler-configmap.yaml" $.Template.BasePath) . | sha256sum }}
       labels:
         {{- include "diode.selectorlabels" . | nindent 8 }}
         app: {{ include "diode.reconciler.servicename" . }}


### PR DESCRIPTION
If you include diode using an `alias` in your `Chart.yaml`, the template checksums won't render because the filenames are, eg, `diode-auth-configmap.yaml` but it would try checksumming `<alias>-auth-configmap.yaml` instead.