### PR TITLE
feat: add support for configuring extra initContainers

### DIFF
--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -235,8 +235,8 @@ helm show values diode/diode
 | diodeAuth.config.telemetryTracesExporter | string | `"none"` | telemetry traces exporter |
 | diodeAuth.containerPort | int | `8080` | port to listen on |
 | diodeAuth.enabled | bool | `true` | enabled |
-| diodeAuth.extraEnvs | list | `[]` | extra environment variables to be set on containers' `env` section |
-| diodeAuth.extraInitContainers | string | `""` | additional containers to run before auth finishes initializing (may contain templating instructions) |
+| diodeAuth.extraEnvs | string or list | `[]` | extra environment variables to be set on containers' `env` section |
+| diodeAuth.extraInitContainers | string or list | `""` | additional containers to run before auth finishes initializing (may contain templating instructions) |
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
@@ -251,7 +251,7 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.tag | string | `"1.2.0"` | image tag |
 | diodeAuthBootstrap.job.annotations | object | `{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-weight":"2"}` | annotations to add to the auth bootstrap job |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
-| diodeAuthBootstrap.job.extraInitContainers | string | `""` | additional initContainers to run during bootstrap (may contain templating instructions) |
+| diodeAuthBootstrap.job.extraInitContainers | string or list | `""` | additional initContainers to run during bootstrap (may contain templating instructions) |
 | diodeIngester.annotations | object | `{}` | annotations to add to the ingester deployment |
 | diodeIngester.config.loggingLevel | string | `"INFO"` | logging level |
 | diodeIngester.config.redisStreamDb | int | `1` | redis stream db |
@@ -262,8 +262,8 @@ helm show values diode/diode
 | diodeIngester.containerPort | int | `8081` | port to listen on |
 | diodeIngester.enabled | bool | `true` | enabled |
 | diodeIngester.existingSecret | string | `"diode-ingester-secret"` | existing secret name |
-| diodeIngester.extraEnvs | list | `[]` | extra environment variables to be set on containers' `env` section |
-| diodeIngester.extraInitContainers | string | `""` | additional containers to run before the ingester finishes initializing (may contain templating instructions) |
+| diodeIngester.extraEnvs | string or list | `[]` | extra environment variables to be set on containers' `env` section |
+| diodeIngester.extraInitContainers | string or list | `""` | additional containers to run before the ingester finishes initializing (may contain templating instructions) |
 | diodeIngester.grpc.serviceName | string | `"diode.v1.IngesterService"` | grpc service name |
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
@@ -294,8 +294,8 @@ helm show values diode/diode
 | diodeReconciler.containerPort | int | `8081` | port to listen on |
 | diodeReconciler.enabled | bool | `true` | enabled |
 | diodeReconciler.existingSecret | string | `"diode-reconciler-secret"` | existing secret name |
-| diodeReconciler.extraEnvs | list | `[]` | extra environment variables to be set on containers' `env` section |
-| diodeReconciler.extraInitContainers | string | `""` | additional containers to run before the reconciler finishes initializing (may contain templating instructions) |
+| diodeReconciler.extraEnvs | string or list | `[]` | extra environment variables to be set on containers' `env` section |
+| diodeReconciler.extraInitContainers | string or list | `""` | additional containers to run before the reconciler finishes initializing (may contain templating instructions) |
 | diodeReconciler.grpc.serviceName | string | `"diode.v1.ReconcilerService"` | grpc service name |
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
@@ -315,7 +315,7 @@ helm show values diode/diode
 | global.diode.hydra | object | `{"waitForPostgres":true}` | hydra additional init containers configuration |
 | global.diode.hydra.waitForPostgres | bool | `true` | wait for PostgreSQL |
 | hydra | object | `{"deployment":{"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}},"enabled":true,"fullnameOverride":"diode-hydra","hydra":{"automigration":{"enabled":true},"config":{"oidc":{"subject_identifiers":{"supported_types":["public"]}},"strategies":{"access_token":"jwt","jwt":{"scope_claim":"both"}},"ttl":{"access_token":"1h"},"urls":{"self":{"issuer":"http://diode-hydra-public.{{ .Release.Namespace }}.svc.cluster.local:4444"}}},"dev":true,"ingress":{"admin":{"enabled":false},"public":{"enabled":false}},"service":{"admin":{"enabled":true,"port":4445,"type":"ClusterIP"},"public":{"enabled":true,"port":4444,"type":"ClusterIP"}}},"job":{"annotations":{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-delete-policy":"hook-succeeded","helm.sh/hook-weight":"1"},"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}"},"secret":{"enabled":false,"nameOverride":"diode-hydra-secret"}}` | ref: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml |
-| hydra.deployment.extraInitContainers | string | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
+| hydra.deployment.extraInitContainers | string or list | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.deployment.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | hydra.enabled | bool | `true` | enabled |
 | hydra.fullnameOverride | string | `"diode-hydra"` | fullname override |
@@ -336,7 +336,7 @@ helm show values diode/diode
 | hydra.hydra.service.public.port | int | `4444` | public service port |
 | hydra.hydra.service.public.type | string | `"ClusterIP"` | public service type |
 | hydra.job.annotations | object | `{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-delete-policy":"hook-succeeded","helm.sh/hook-weight":"1"}` | job annotations |
-| hydra.job.extraInitContainers | string | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
+| hydra.job.extraInitContainers | string or list | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.secret.enabled | bool | `false` | secret enabled |
 | hydra.secret.nameOverride | string | `"diode-hydra-secret"` | existing secret name |
 | ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":[],"grpcAnnotations":{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":"true"},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/ssl-redirect":"true"},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -236,6 +236,7 @@ helm show values diode/diode
 | diodeAuth.containerPort | int | `8080` | port to listen on |
 | diodeAuth.enabled | bool | `true` | enabled |
 | diodeAuth.extraEnvs | list | `[]` | extra environment variables to be set on containers' `env` section |
+| diodeAuth.extraInitContainers | string | `""` | additional containers to run before auth finishes initializing (may contain templating instructions) |
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
@@ -250,6 +251,7 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.tag | string | `"1.2.0"` | image tag |
 | diodeAuthBootstrap.job.annotations | object | `{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-weight":"2"}` | annotations to add to the auth bootstrap job |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
+| diodeAuthBootstrap.job.extraInitContainers | string | `""` | additional initContainers to run during bootstrap (may contain templating instructions) |
 | diodeIngester.annotations | object | `{}` | annotations to add to the ingester deployment |
 | diodeIngester.config.loggingLevel | string | `"INFO"` | logging level |
 | diodeIngester.config.redisStreamDb | int | `1` | redis stream db |
@@ -261,6 +263,7 @@ helm show values diode/diode
 | diodeIngester.enabled | bool | `true` | enabled |
 | diodeIngester.existingSecret | string | `"diode-ingester-secret"` | existing secret name |
 | diodeIngester.extraEnvs | list | `[]` | extra environment variables to be set on containers' `env` section |
+| diodeIngester.extraInitContainers | string | `""` | additional containers to run before the ingester finishes initializing (may contain templating instructions) |
 | diodeIngester.grpc.serviceName | string | `"diode.v1.IngesterService"` | grpc service name |
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
@@ -292,6 +295,7 @@ helm show values diode/diode
 | diodeReconciler.enabled | bool | `true` | enabled |
 | diodeReconciler.existingSecret | string | `"diode-reconciler-secret"` | existing secret name |
 | diodeReconciler.extraEnvs | list | `[]` | extra environment variables to be set on containers' `env` section |
+| diodeReconciler.extraInitContainers | string | `""` | additional containers to run before the reconciler finishes initializing (may contain templating instructions) |
 | diodeReconciler.grpc.serviceName | string | `"diode.v1.ReconcilerService"` | grpc service name |
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |

--- a/charts/diode/templates/diode-auth-bootstrap-job.yaml
+++ b/charts/diode/templates/diode-auth-bootstrap-job.yaml
@@ -46,6 +46,9 @@ spec:
               done;
               echo "OAuth2 server is up and running";
         {{- end }}
+        {{- if .Values.diodeAuthBootstrap.job.extraInitContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeAuthBootstrap.job.extraInitContainers "context" $ ) | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ include "diode.auth.bootstrapjobname" . }}
           image: "{{ .Values.diodeAuthBootstrap.image.repository }}:{{ .Values.diodeAuthBootstrap.image.tag }}"

--- a/charts/diode/templates/diode-auth-deployment.yaml
+++ b/charts/diode/templates/diode-auth-deployment.yaml
@@ -55,6 +55,9 @@ spec:
               done;
               echo "OAuth2 server is up and running";
         {{- end }}
+        {{- if .Values.diodeAuth.extraInitContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeAuth.extraInitContainers "context" $ ) | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ include "diode.auth.servicename" . }}
           image: "{{ .Values.diodeAuth.image.repository }}:{{ .Values.diodeAuth.image.tag }}"

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -53,6 +53,9 @@ spec:
               done;
               echo "Redis server is up and running";
         {{- end }}
+        {{- if .Values.diodeAuth.extraInitContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeAuth.extraInitContainers "context" $ ) | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ include "diode.ingester.servicename" . }}
           image: "{{ .Values.diodeIngester.image.repository }}:{{ .Values.diodeIngester.image.tag }}"

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -67,6 +67,9 @@ spec:
               done;
               echo "PostgreSQL server is up and running";
         {{- end }}
+        {{- if .Values.diodeAuth.extraInitContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeAuth.extraInitContainers "context" $ ) | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ include "diode.reconciler.servicename" . }}
           image: "{{ .Values.diodeReconciler.image.repository }}:{{ .Values.diodeReconciler.image.tag }}"

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -65,6 +65,8 @@ diodeAuth:
       memory: 512Mi
   # -- extra environment variables to be set on containers' `env` section
   extraEnvs: []
+  # -- additional containers to run before auth finishes initializing (may contain templating instructions)
+  extraInitContainers: ""
   # -- annotations to add to the auth deployment
   annotations: {}
   config:
@@ -99,6 +101,8 @@ diodeAuthBootstrap:
     annotations:
       "helm.sh/hook": post-install, post-upgrade
       "helm.sh/hook-weight": "2"
+    # -- additional initContainers to run during bootstrap (may contain templating instructions)
+    extraInitContainers: ""
 
 # Diode Ingester configuration
 diodeIngester:
@@ -135,6 +139,8 @@ diodeIngester:
     serviceName: diode.v1.IngesterService
   # -- extra environment variables to be set on containers' `env` section
   extraEnvs: []
+  # -- additional containers to run before the ingester finishes initializing (may contain templating instructions)
+  extraInitContainers: ""
   # -- annotations to add to the ingester deployment
   annotations: {}
   config:
@@ -186,6 +192,8 @@ diodeReconciler:
     serviceName: diode.v1.ReconcilerService
   # -- extra environment variables to be set on containers' `env` section
   extraEnvs: []
+  # -- additional containers to run before the reconciler finishes initializing (may contain templating instructions)
+  extraInitContainers: ""
   # -- annotations to add to the reconciler deployment
   annotations: {}
   config:

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -63,9 +63,9 @@ diodeAuth:
     limits:
       cpu: 500m
       memory: 512Mi
-  # -- extra environment variables to be set on containers' `env` section
+  # -- (string or list) extra environment variables to be set on containers' `env` section
   extraEnvs: []
-  # -- additional containers to run before auth finishes initializing (may contain templating instructions)
+  # -- (string or list) additional containers to run before auth finishes initializing (may contain templating instructions)
   extraInitContainers: ""
   # -- annotations to add to the auth deployment
   annotations: {}
@@ -101,7 +101,7 @@ diodeAuthBootstrap:
     annotations:
       "helm.sh/hook": post-install, post-upgrade
       "helm.sh/hook-weight": "2"
-    # -- additional initContainers to run during bootstrap (may contain templating instructions)
+    # -- (string or list) additional initContainers to run during bootstrap (may contain templating instructions)
     extraInitContainers: ""
 
 # Diode Ingester configuration
@@ -137,9 +137,9 @@ diodeIngester:
   grpc:
     # -- grpc service name
     serviceName: diode.v1.IngesterService
-  # -- extra environment variables to be set on containers' `env` section
+  # -- (string or list) extra environment variables to be set on containers' `env` section
   extraEnvs: []
-  # -- additional containers to run before the ingester finishes initializing (may contain templating instructions)
+  # -- (string or list) additional containers to run before the ingester finishes initializing (may contain templating instructions)
   extraInitContainers: ""
   # -- annotations to add to the ingester deployment
   annotations: {}
@@ -190,9 +190,9 @@ diodeReconciler:
   grpc:
     # -- grpc service name
     serviceName: diode.v1.ReconcilerService
-  # -- extra environment variables to be set on containers' `env` section
+  # -- (string or list) extra environment variables to be set on containers' `env` section
   extraEnvs: []
-  # -- additional containers to run before the reconciler finishes initializing (may contain templating instructions)
+  # -- (string or list) additional containers to run before the reconciler finishes initializing (may contain templating instructions)
   extraInitContainers: ""
   # -- annotations to add to the reconciler deployment
   annotations: {}
@@ -369,7 +369,7 @@ hydra:
     # -- dev mode
     dev: true  # Hydra is not exposed to the public internet
   deployment:
-    # -- extra init containers
+    # -- (string or list) extra init containers
     extraInitContainers: |-
       {{ include "diode.hydra.extrainitcontainers" . }}
     # -- resources
@@ -386,7 +386,7 @@ hydra:
       "helm.sh/hook": post-install, post-upgrade
       "helm.sh/hook-weight": "1"
       "helm.sh/hook-delete-policy": hook-succeeded
-    # -- extra init containers
+    # -- (string or list) extra init containers
     extraInitContainers: |-
       {{ include "diode.hydra.extrainitcontainers" . }}
 


### PR DESCRIPTION
This pull request introduces enhancements to the `diode` Helm chart by adding support for `extraInitContainers` and updating the type of `extraEnvs` across multiple components. These changes improve flexibility in container initialization and environment variable configuration. Additionally, corresponding updates were made to the templates and values files to reflect these enhancements.