### PR TITLE
fix: don't try to create kind:Ingress files if ingress disabled

### DIFF
--- a/charts/diode/templates/ingress-grpc.yaml
+++ b/charts/diode/templates/ingress-grpc.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.ingressNginx .Values.ingressNginx.enabled -}}
 {{- $ingressNginx := index .Values.ingressNginx -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -43,3 +44,4 @@ spec:
                 name: {{ include "diode.reconciler.servicename" . }}
                 port:
                   number: {{ .Values.diodeReconciler.containerPort }}
+{{- end }}

--- a/charts/diode/templates/ingress-http.yaml
+++ b/charts/diode/templates/ingress-http.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.ingressNginx .Values.ingressNginx.enabled -}}
 {{- $ingressNginx := index .Values.ingressNginx -}}
 {{- $certManager := index .Values.certManager -}}
 {{- $certIssuer := index .Values.certIssuer -}}
@@ -58,3 +59,4 @@ spec:
                 port:
                   number: {{ $path.servicePort }}
           {{- end }}
+{{- end }}


### PR DESCRIPTION
This pull request introduces conditional logic to enable or disable the configuration of NGINX ingress resources in the `diode` Helm chart based on the `ingressNginx.enabled` value. The changes ensure that ingress resources are only created when explicitly enabled in the values file.