### PR TITLE
docs: link docs readme to root readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,1 @@
-# Diode documentation
-
-TBD
+../README.md


### PR DESCRIPTION
This pull request updates the `docs/README.md` file to remove placeholder text and replace it with a link to the main `README.md` file for better documentation organization.