### PR TITLE
feat: add release version to server initialization

### DIFF
--- a/diode-server/cmd/auth/main.go
+++ b/diode-server/cmd/auth/main.go
@@ -24,7 +24,7 @@ const (
 
 func main() {
 	ctx := context.Background()
-	s := server.New(ctx, applicationName)
+	s := server.New(ctx, applicationName, version.Release())
 
 	defer s.Recover(sentry.CurrentHub())
 

--- a/diode-server/cmd/ingester/main.go
+++ b/diode-server/cmd/ingester/main.go
@@ -28,7 +28,7 @@ const (
 
 func main() {
 	ctx := context.Background()
-	s := server.New(ctx, applicationName)
+	s := server.New(ctx, applicationName, version.Release())
 
 	defer s.Recover(sentry.CurrentHub())
 

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -34,7 +34,7 @@ const (
 
 func main() {
 	ctx := context.Background()
-	s := server.New(ctx, applicationName)
+	s := server.New(ctx, applicationName, version.Release())
 
 	defer s.Recover(sentry.CurrentHub())
 

--- a/diode-server/server/server.go
+++ b/diode-server/server/server.go
@@ -12,8 +12,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/oklog/run"
-
-	"github.com/netboxlabs/diode/diode-server/version"
 )
 
 // A Server is a diode Server
@@ -38,7 +36,7 @@ type Component interface {
 }
 
 // New returns a new Server
-func New(ctx context.Context, name string) *Server {
+func New(ctx context.Context, name, release string) *Server {
 	var cfg Config
 	envconfig.MustProcess("", &cfg)
 
@@ -55,7 +53,7 @@ func New(ctx context.Context, name string) *Server {
 			TracesSampleRate: cfg.SentryTracesSampleRate,
 			AttachStacktrace: cfg.SentryAttachStacktrace,
 			ServerName:       name,
-			Release:          fmt.Sprintf("v%s", version.GetBuildVersion()),
+			Release:          release,
 		}); err != nil {
 			logger.Error("failed to initialize sentry", "error", err)
 		}
@@ -65,7 +63,7 @@ func New(ctx context.Context, name string) *Server {
 		ctx:            ctx,
 		name:           name,
 		environment:    cfg.Environment,
-		release:        fmt.Sprintf("v%s-%s", version.GetBuildVersion(), version.GetBuildCommit()),
+		release:        release,
 		logger:         logger,
 		components:     make(map[string]Component),
 		componentGroup: run.Group{},

--- a/diode-server/server/server_test.go
+++ b/diode-server/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/diode/diode-server/server"
+	"github.com/netboxlabs/diode/diode-server/version"
 )
 
 func TestNewServer(t *testing.T) {
@@ -89,7 +90,7 @@ func TestNewServer(t *testing.T) {
 			err = os.Setenv("SENTRY_DSN", tt.sentryDSN)
 			require.NoError(t, err)
 
-			s := server.New(ctx, tt.serverName)
+			s := server.New(ctx, tt.serverName, version.Release())
 
 			assert.Equal(t, tt.serverName, s.Name())
 			require.NotNil(t, s.Logger())
@@ -126,7 +127,7 @@ func TestRegisterComponent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx := context.Background()
-			s := server.New(ctx, "diode-test-server")
+			s := server.New(ctx, "diode-test-server", version.Release())
 
 			var err error
 			for i := 0; i < tt.registrationsNum; i++ {
@@ -162,7 +163,7 @@ func TestRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx := context.Background()
-			s := server.New(ctx, "diode-test-server")
+			s := server.New(ctx, "diode-test-server", version.Release())
 
 			require.NoError(t, s.RegisterComponent(tt.component))
 			err := s.Run()

--- a/diode-server/version/version.go
+++ b/diode-server/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	_ "embed"
+	"fmt"
 	"strings"
 )
 
@@ -23,4 +24,9 @@ func GetBuildVersion() string {
 // GetBuildCommit returns the build commit of the diode-server
 func GetBuildCommit() string {
 	return strings.TrimSpace(buildCommit)
+}
+
+// Release returns the release information
+func Release() string {
+	return fmt.Sprintf("v%s-%s", GetBuildVersion(), GetBuildCommit())
 }

--- a/diode-server/version/version_test.go
+++ b/diode-server/version/version_test.go
@@ -15,3 +15,7 @@ func TestVersion(t *testing.T) {
 	c := version.GetBuildCommit()
 	assert.Equal(t, "unknown", c)
 }
+
+func TestRelease(t *testing.T) {
+	assert.Equal(t, "v0.0.0-unknown", version.Release())
+}


### PR DESCRIPTION
This pull request refactors how release information is handled across the `diode-server` codebase by introducing a centralized `Release()` function in the `version` package. It simplifies the server initialization process and ensures consistent release data is used throughout the application. Additionally, tests have been updated to reflect these changes.

### Refactoring release information:

* [`diode-server/version/version.go`](diffhunk://#diff-dc3c2d385c2c056df12f694cda2822846431e37079e767435b210ad0ecb84b38R28-R32): Introduced a new `Release()` function that combines build version and commit into a single release string.
* [`diode-server/server/server.go`](diffhunk://#diff-a4ee510a94c2c10830b30124792b54e3bba60f2ca9a4d29ce9ea721d68faecd0L41-R39): Updated the `New` function to accept a `release` parameter instead of constructing it internally. This ensures the release information is passed explicitly. [[1]](diffhunk://#diff-a4ee510a94c2c10830b30124792b54e3bba60f2ca9a4d29ce9ea721d68faecd0L41-R39) [[2]](diffhunk://#diff-a4ee510a94c2c10830b30124792b54e3bba60f2ca9a4d29ce9ea721d68faecd0L58-R56) [[3]](diffhunk://#diff-a4ee510a94c2c10830b30124792b54e3bba60f2ca9a4d29ce9ea721d68faecd0L68-R66)

### Updates to server initialization:

* `diode-server/cmd/auth/main.go`, `diode-server/cmd/ingester/main.go`, `diode-server/cmd/reconciler/main.go`: Modified the server initialization to pass `version.Release()` as the release parameter. [[1]](diffhunk://#diff-e4c3f2581bc60f3336000978d7a8eb3a701f964644d982fee72a48bd25cbd030L27-R27) [[2]](diffhunk://#diff-ed79f43ff833b1e4e52f4d7217139499e7a39bcd7150b20300a00cf984899fa7L31-R31) [[3]](diffhunk://#diff-cd86f7227f1786d5281fbb95507b9c82c88ffe79117211d8104c2b871b5f62c9L37-R37)

### Test updates:

* [`diode-server/server/server_test.go`](diffhunk://#diff-25e4159ee1c5567e760c6a4aeccd88935825a47eb94a318e68e8af3b248c9690L92-R93): Updated tests to include the `release` parameter when initializing the server. [[1]](diffhunk://#diff-25e4159ee1c5567e760c6a4aeccd88935825a47eb94a318e68e8af3b248c9690L92-R93) [[2]](diffhunk://#diff-25e4159ee1c5567e760c6a4aeccd88935825a47eb94a318e68e8af3b248c9690L129-R130) [[3]](diffhunk://#diff-25e4159ee1c5567e760c6a4aeccd88935825a47eb94a318e68e8af3b248c9690L165-R166)
* [`diode-server/version/version_test.go`](diffhunk://#diff-8575aa70802037b08d3e3bdc63ce630cec0bb3806363aad1572552301340baceR18-R21): Added a new test for the `Release()` function to validate its output.

### Code cleanup:

* [`diode-server/server/server.go`](diffhunk://#diff-a4ee510a94c2c10830b30124792b54e3bba60f2ca9a4d29ce9ea721d68faecd0L15-L16): Removed redundant import of the `version` package since release information is now passed as a parameter.