### PR TITLE
docs: adds docs for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For a quick step-by-step guide, see our [Getting Started Guide](./GET_STARTED.md
 ## Documentation
 
 - [Diode Protocol Documentation](https://github.com/netboxlabs/diode/blob/develop/docs/diode-proto.md)
+- [Metrics](https://github.com/netboxlabs/diode/blob/develop/docs/metrics.md)
 
 ## Related Projects
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,7 +47,7 @@ Diode's telemetry implementation supports multiple configuration methods and exp
 |----------|-------------|---------|----------|---------|
 | `TELEMETRY_SERVICE_NAME` | Service identifier | Auto-detected | No | `netboxlabs/diode/auth` |
 | `TELEMETRY_ENVIRONMENT` | Deployment environment | `dev` | No | `production` |
-| `TELEMETRY_METRICS_EXPORTER` | Metrics export type | `none` | No | `prometheus` |
+| `TELEMETRY_METRICS_EXPORTER` | Metrics export type | `none` | No | `prometheus`, `otlp`, `console` or `none` |
 | `TELEMETRY_METRICS_PORT` | Prometheus metrics port | `9090` | No | `9090` |
 
 ### OTLP Configuration
@@ -98,7 +98,7 @@ services:
 ## Troubleshooting
 
 ### Metrics Not Appearing
-1. Check `TELEMETRY_METRICS_EXPORTER=prometheus`
+1. Check `TELEMETRY_METRICS_EXPORTER` value. E.g. `TELEMETRY_METRICS_EXPORTER=prometheus`.
 2. Verify endpoint accessibility
 3. Check service logs for errors
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,108 @@
+# Metrics
+
+## Available Metrics
+
+### Core Metrics (All Services)
+- `diode_{service}_service_info` - Service information
+- `diode_{service}_service_startup_attempts_total` - Startup attempts
+
+### Service-Specific Metrics
+
+#### Auth Service
+- `diode_auth_service_info` - Service information
+- `diode_auth_service_startup_attempts_total` - Startup attempts
+
+#### Ingester Service
+- `diode_ingester_service_info` - Service information
+- `diode_ingester_service_startup_attempts_total` - Startup attempts
+- `diode_ingester_ingest_requests_total` - Ingest requests (success)
+- `diode_ingester_ingest_entities_total` - Entities ingested
+
+#### Reconciler Service
+- `diode_reconciler_service_info` - Service information
+- `diode_reconciler_service_startup_attempts_total` - Startup attempts
+- `diode_reconciler_handle_message_total` - Messages handled (success)
+- `diode_reconciler_ingestion_log_create_total` - Ingestion logs created (success)
+- `diode_reconciler_change_set_create_total` - Change sets created (success)
+- `diode_reconciler_change_set_apply_total` - Change sets applied (success)
+- `diode_reconciler_change_create_total` - Individual changes created
+- `diode_reconciler_change_apply_total` - Individual changes applied
+
+
+## Configuration Overview
+
+Diode's telemetry implementation supports multiple configuration methods and exporters.
+
+### Exporters
+- **prometheus**: Serve metrics on `/metrics` endpoint
+- **otlp**: Send to OpenTelemetry Collector
+- **console**: Output to stdout (debugging)
+- **none**: Disable metrics
+
+## Environment Variables
+
+### Core Configuration
+
+| Variable | Description | Default | Required | Example |
+|----------|-------------|---------|----------|---------|
+| `TELEMETRY_SERVICE_NAME` | Service identifier | Auto-detected | No | `netboxlabs/diode/auth` |
+| `TELEMETRY_ENVIRONMENT` | Deployment environment | `dev` | No | `production` |
+| `TELEMETRY_METRICS_EXPORTER` | Metrics export type | `none` | No | `prometheus` |
+| `TELEMETRY_METRICS_PORT` | Prometheus metrics port | `9090` | No | `9090` |
+
+### OTLP Configuration
+
+If the otlp
+
+| Variable | Description | Default | Required | Example |
+|----------|-------------|---------|----------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint | `http://localhost:4317` | No | `http://collector:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP protocol | `grpc` | No | `grpc` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | OTLP headers | None | No | `authorization=Bearer token` |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | OTLP timeout | `10s` | No | `30s` |
+
+For further details refer to the [OpenTelemetry Environment Variable Specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration).
+
+## Docker Compose Example
+```yaml
+# docker-compose.yaml
+services:
+  diode-auth:
+    environment:
+      - TELEMETRY_METRICS_EXPORTER=prometheus
+      - TELEMETRY_METRICS_PORT=9090
+      - TELEMETRY_ENVIRONMENT=dev
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+
+  diode-ingester:
+    environment:
+      - TELEMETRY_METRICS_EXPORTER=prometheus
+      - TELEMETRY_METRICS_PORT=9090
+      - TELEMETRY_ENVIRONMENT=dev
+    ports:
+      - "8081:8081"
+      - "9091:9090"
+
+  diode-reconciler:
+    environment:
+      - TELEMETRY_METRICS_EXPORTER=prometheus
+      - TELEMETRY_METRICS_PORT=9090
+      - TELEMETRY_ENVIRONMENT=dev
+    ports:
+      - "8082:8081"
+      - "9092:9090"
+```
+
+## Troubleshooting
+
+### Metrics Not Appearing
+1. Check `TELEMETRY_METRICS_EXPORTER=prometheus`
+2. Verify endpoint accessibility
+3. Check service logs for errors
+
+### Debug using console exporter
+```bash
+export TELEMETRY_METRICS_EXPORTER=console
+```


### PR DESCRIPTION
This pull request introduces a new metrics documentation page and updates the `README.md` to include a link to it. The metrics documentation provides a comprehensive overview of available metrics, configuration options, and troubleshooting steps.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35): Added a link to the new metrics documentation under the "Documentation" section.

### Metrics Documentation:

* `docs/metrics.md`: Created a new metrics documentation page detailing:
  - Core and service-specific metrics, including examples such as `diode_auth_service_info` and `diode_ingester_ingest_requests_total`.
  - Configuration options for telemetry exporters (e.g., Prometheus, OpenTelemetry, Console) and environment variables like `TELEMETRY_METRICS_EXPORTER` and `OTEL_EXPORTER_OTLP_ENDPOINT`.
  - A Docker Compose example for configuring metrics exporters across services (`diode-auth`, `diode-ingester`, and `diode-reconciler`).
  - Troubleshooting steps for common issues, such as verifying exporter configuration and debugging using the console exporter.