### PR TITLE
fix: corrects opentelemetry exporter configuration value

### DIFF
--- a/diode-server/telemetry/config.go
+++ b/diode-server/telemetry/config.go
@@ -10,13 +10,13 @@ type Config struct {
 	// Environment represents the deployment environment (e.g., prod, staging, dev)
 	Environment string `envconfig:"ENVIRONMENT" default:"dev"`
 
-	// MetricsExporter represents the type of exporter to use. oltp,console and none are supported
+	// MetricsExporter represents the type of exporter to use. otlp,prometheus,console and none are supported
 	MetricsExporter string `envconfig:"METRICS_EXPORTER" default:"none"`
 
 	// MetricsPort is the port to serve the metrics on if MetricsExporter is prometheus
 	MetricsPort int `envconfig:"METRICS_PORT" default:"9090"`
 
-	// TracesExporter represents the type of exporter to use. oltp,console and none are supported
+	// TracesExporter represents the type of exporter to use. otlp,console and none are supported
 	TracesExporter string `envconfig:"TRACES_EXPORTER" default:"none"`
 
 	// Additional environment variables used interally by otel

--- a/diode-server/telemetry/config.go
+++ b/diode-server/telemetry/config.go
@@ -10,13 +10,13 @@ type Config struct {
 	// Environment represents the deployment environment (e.g., prod, staging, dev)
 	Environment string `envconfig:"ENVIRONMENT" default:"dev"`
 
-	// MetricsExporter represents the type of exporter to use. otlp,prometheus,console and none are supported
+	// MetricsExporter represents the type of exporter to use. otlp, prometheus, console and none are supported
 	MetricsExporter string `envconfig:"METRICS_EXPORTER" default:"none"`
 
 	// MetricsPort is the port to serve the metrics on if MetricsExporter is prometheus
 	MetricsPort int `envconfig:"METRICS_PORT" default:"9090"`
 
-	// TracesExporter represents the type of exporter to use. otlp,console and none are supported
+	// TracesExporter represents the type of exporter to use. otlp, console and none are supported
 	TracesExporter string `envconfig:"TRACES_EXPORTER" default:"none"`
 
 	// Additional environment variables used interally by otel

--- a/diode-server/telemetry/setup.go
+++ b/diode-server/telemetry/setup.go
@@ -20,8 +20,8 @@ import (
 // Setup initializes OpenTelemetry with the provided configuration
 // Returns a shutdown function to clean up resources that should be called
 // when the application is shutting down.
-// The OLTP exporters can be further configured using the environment variables
-// specified in the OLTP documentation.
+// The OTLP exporters can be further configured using the environment variables
+// specified in the OTLP documentation.
 func Setup(ctx context.Context, cfg Config) (shutdown func(context.Context) error, err error) {
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
@@ -41,7 +41,7 @@ func Setup(ctx context.Context, cfg Config) (shutdown func(context.Context) erro
 		if err != nil {
 			return nil, fmt.Errorf("failed to create console trace exporter: %w", err)
 		}
-	case "oltp":
+	case "otlp":
 		traceExporter, err = otlptracegrpc.New(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create trace exporter: %w", err)
@@ -61,7 +61,7 @@ func Setup(ctx context.Context, cfg Config) (shutdown func(context.Context) erro
 			return nil, fmt.Errorf("failed to create console metric exporter: %w", err)
 		}
 		metricReader = sdkmetric.NewPeriodicReader(metricExporter)
-	case "oltp":
+	case "otlp":
 		metricExporter, err := otlpmetricgrpc.New(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create metric exporter: %w", err)


### PR DESCRIPTION
This pull request updates the telemetry configuration and setup in the `diode-server` project to support Prometheus as a metrics exporter and corrects the spelling of "OTLP" across the codebase. The changes ensure consistency and expand the functionality of the metrics exporter.

### Telemetry Configuration Updates:
* [`diode-server/telemetry/config.go`](diffhunk://#diff-8583129d2b29c48257111496252c1b4987d7dbfcbddffa77a7a4460d191623b5L13-R19): Updated `MetricsExporter` to include "prometheus" as a supported exporter type. Corrected the spelling of "otlp" in both `MetricsExporter` and `TracesExporter` descriptions.

### Codebase Consistency Improvements:
* [`diode-server/telemetry/setup.go`](diffhunk://#diff-e4d6d0de9da7d04b391f9a7b0ebeb60400ecc44fca4f7fa681cc283363baffe7L23-R24): Corrected the spelling of "OTLP" in the comments describing exporter configuration.
* [`diode-server/telemetry/setup.go`](diffhunk://#diff-e4d6d0de9da7d04b391f9a7b0ebeb60400ecc44fca4f7fa681cc283363baffe7L44-R44): Updated the case labels in the `Setup` function to use "otlp" instead of "oltp" for trace and metric exporters. [[1]](diffhunk://#diff-e4d6d0de9da7d04b391f9a7b0ebeb60400ecc44fca4f7fa681cc283363baffe7L44-R44) [[2]](diffhunk://#diff-e4d6d0de9da7d04b391f9a7b0ebeb60400ecc44fca4f7fa681cc283363baffe7L64-R64)