### PR TITLE
chore: update GHA with new JFROG OIDC provider

### DIFF
--- a/.github/workflows/server-develop.yaml
+++ b/.github/workflows/server-develop.yaml
@@ -68,7 +68,7 @@ jobs:
           JF_URL: https://netboxlabs.jfrog.io
           JF_PROJECT: obs
         with:
-          oidc-provider-name: platform-setup-jfrog-cli
+          oidc-provider-name: github-ci
 
       - name: Login to JFrog Artifactory
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -84,7 +84,7 @@ jobs:
           JF_URL: https://netboxlabs.jfrog.io
           JF_PROJECT: obs
         with:
-          oidc-provider-name: platform-setup-jfrog-cli
+          oidc-provider-name: github-ci
 
       - name: Login to JFrog Artifactory
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3


### PR DESCRIPTION
This pull request updates the OIDC provider name for JFrog Artifactory login in GitHub Actions workflows. The change ensures consistency in the provider name across the workflows.

### Workflow updates:

* [`.github/workflows/server-develop.yaml`](diffhunk://#diff-1bacdfa021f599056e1d945b8225a10734e175fde91861f1578f3e6b45c2bcceL71-R71): Changed the `oidc-provider-name` from `platform-setup-jfrog-cli` to `github-ci` in the `jobs:` section.
* [`.github/workflows/server-release.yaml`](diffhunk://#diff-99ac821f1014ee4b214339baa517b7b747d78a8ea51ddf2d734ca0d8d831dc1fL87-R87): Changed the `oidc-provider-name` from `platform-setup-jfrog-cli` to `github-ci` in the `jobs:` section.