### PR TITLE
fix: deviation name "created" -> "discovered"

### DIFF
--- a/diode-server/reconciler/differ/differ.go
+++ b/diode-server/reconciler/differ/differ.go
@@ -63,43 +63,65 @@ func Diff(ctx context.Context, entity IngestEntity, branchID string, netboxAPI n
 	return cs, nil
 }
 
-func genDeviationName(objects []changeset.Change, objectType string) *string {
-	if len(objects) == 0 {
-		typeName, err := netbox.GetObjectTypeName(objectType)
-		if err != nil {
-			deviationName := fmt.Sprintf("Unknown %s discovered", objectType)
-			return &deviationName
+// FindPrimaryChange attempts to find the earliest change that refers to the primary object.
+func FindPrimaryChange(changes []changeset.Change, objectType string) *changeset.Change {
+	// The main complexity is that there is no identifier that binds the entities to the
+	// changes that are about them.  Additionally, a change may create an entity, then a later
+	// change may update it (this should still be considered a discovery/create).
+
+	firstRefID := make(map[string]*changeset.Change)
+	for _, change := range changes {
+		if change.ObjectType == objectType && change.RefID != nil {
+			if _, ok := firstRefID[*change.RefID]; !ok {
+				firstRefID[*change.RefID] = &change
+			}
 		}
+	}
+
+	for i := len(changes) - 1; i >= 0; i-- {
+		change := &changes[i]
+		if change.ObjectType == objectType {
+			// if the object was created in a previous change in the change set
+			if change.RefID != nil {
+				// return the change that created it.
+				return firstRefID[*change.RefID]
+			}
+			// update to a specific existing object
+			return change
+		}
+	}
+	return nil
+}
+
+func genDeviationName(changes []changeset.Change, objectType string) *string {
+	typeName, err := netbox.GetObjectTypeName(objectType)
+	if err != nil {
+		typeName = objectType
+	}
+
+	primaryChange := FindPrimaryChange(changes, objectType)
+	if primaryChange == nil {
 		deviationName := fmt.Sprintf("%s unchanged", typeName)
 		return &deviationName
 	}
 
-	primaryObject := objects[len(objects)-1]
-	objectTypeName, err := netbox.GetObjectTypeName(primaryObject.ObjectType)
-	if err != nil {
-		objectTypeName = "<unrecognized type " + primaryObject.ObjectType + ">"
+	deviationName := typeName
+	if primaryChange.ObjectPrimaryValue != "" {
+		deviationName += " " + primaryChange.ObjectPrimaryValue
 	}
 
-	deviationName := fmt.Sprintf("%s %s", objectTypeName, primaryObject.ObjectPrimaryValue)
-
-	switch primaryObject.ChangeType {
+	switch primaryChange.ChangeType {
 	case changeset.ChangeTypeUpdate:
-		if primaryObject.RefID != nil {
-			// this is an update of a new object created
-			// earlier in the change set (ref id)
-			deviationName += " created"
-		} else {
-			deviationName += " modified"
-		}
+		deviationName += " modified"
 	case changeset.ChangeTypeCreate:
-		deviationName += " created"
+		deviationName += " discovered"
 	case changeset.ChangeTypeNoop:
-		// TODO: this means some subbordinate object was modified,
+		// TODO: this means some subbordinate or related object was modified,
 		// but the primary object itself was not modified.
 		// for now we consider this a modification of the primary object.
 		deviationName += " modified"
 	default:
-		deviationName += " (unrecognized change type " + primaryObject.ChangeType + ")"
+		deviationName += " (unrecognized change type " + primaryChange.ChangeType + ")"
 	}
 
 	return &deviationName
@@ -109,18 +131,18 @@ func deviationNameForDiffFailure(entity IngestEntity) string {
 	objectType := entity.ObjectType
 	objectTypeName, err := netbox.GetObjectTypeName(objectType)
 	if err != nil {
-		return fmt.Sprintf("Unknown %s discovered", objectType)
+		return fmt.Sprintf("Unresolved %s reported", objectType)
 	}
 
 	if e, ok := entity.Entity.(*diodepb.Entity); ok {
 		primaryValue, err := netbox.GetPrimaryValue(e)
 		if err != nil {
-			return fmt.Sprintf("Unknown %s discovered", objectType)
+			return fmt.Sprintf("Unresolved %s reported", objectType)
 		}
-		return fmt.Sprintf("%s %s discovered", objectTypeName, primaryValue)
+		return fmt.Sprintf("%s %s reported", objectTypeName, primaryValue)
 	}
 
-	return fmt.Sprintf("Unknown %s discovered", objectType)
+	return fmt.Sprintf("Unresolved %s reported", objectType)
 }
 
 // FailedDiffChangeSet generates a placeholder change set for a failed diff

--- a/diode-server/reconciler/differ/differ_test.go
+++ b/diode-server/reconciler/differ/differ_test.go
@@ -81,7 +81,7 @@ func TestGenDeviationName(t *testing.T) {
 						After:              json.RawMessage(`{"name": "Site A"}`),
 					},
 				},
-				DeviationName: strPtr("Site Site A created"),
+				DeviationName: strPtr("Site Site A discovered"),
 			},
 			wantErr: false,
 		},
@@ -254,7 +254,7 @@ func TestGenDeviationName(t *testing.T) {
 				},
 				// this is still a create because the ref id is set
 				// and the object was created in the same change set
-				DeviationName: strPtr("Site Site A created"),
+				DeviationName: strPtr("Site Site A discovered"),
 			},
 			wantErr: false,
 		},

--- a/diode-server/reconciler/ops_test.go
+++ b/diode-server/reconciler/ops_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/netboxlabs/diode/diode-server/reconciler/mocks"
 )
 
-func TestProOpsGenerateChangeSet(t *testing.T) {
+func TestOpsGenerateChangeSet(t *testing.T) {
 	type mockGenerateDiff struct {
 		changeSet []netboxdiodeplugin.Change
 		branchID  string
@@ -84,7 +84,7 @@ func TestProOpsGenerateChangeSet(t *testing.T) {
 			createChangeSets: []mockCreateChangeSet{
 				{
 					ingestionLogDBID: 1234,
-					deviationName:    strPtr("Site test-site-1 discovered"),
+					deviationName:    strPtr("Site test-site-1 reported"),
 					id:               1235,
 				},
 			},
@@ -122,7 +122,7 @@ func TestProOpsGenerateChangeSet(t *testing.T) {
 			createChangeSets: []mockCreateChangeSet{
 				{
 					ingestionLogDBID: 1234,
-					deviationName:    strPtr("Site test-site-1 discovered"),
+					deviationName:    strPtr("Site test-site-1 reported"),
 					id:               1235,
 				},
 			},
@@ -157,6 +157,7 @@ func TestProOpsGenerateChangeSet(t *testing.T) {
 			for _, m := range tt.createChangeSets {
 				mockRepository.EXPECT().CreateChangeSet(ctx, mock.MatchedBy(func(c changeset.ChangeSet) bool {
 					if !strPtrEq(c.DeviationName, m.deviationName) {
+						t.Logf("deviation name mismatch: %v != %v", *c.DeviationName, *m.deviationName)
 						return false
 					}
 					if tt.branchID != "" && !strPtrEq(c.BranchID, &tt.branchID) {


### PR DESCRIPTION
* Adjusts deviations "X created" to "X discovered" (create happens on apply)
* Adjusts unknown diff names "X discovered" -> "X reported" (eg reported, but could not determine diff)
* Reworks logic for picking primary change (choose outermost reported entity)