### PR TITLE
feat: Validate token ownership

### DIFF
--- a/diode-server/auth/mocks/tokenownershipprovider.go
+++ b/diode-server/auth/mocks/tokenownershipprovider.go
@@ -4,6 +4,9 @@ package mocks
 
 import (
 	context "context"
+	http "net/http"
+
+	jwt "github.com/golang-jwt/jwt/v5"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -19,6 +22,53 @@ type TokenOwnershipProvider_Expecter struct {
 
 func (_m *TokenOwnershipProvider) EXPECT() *TokenOwnershipProvider_Expecter {
 	return &TokenOwnershipProvider_Expecter{mock: &_m.Mock}
+}
+
+// HeaderCheck provides a mock function with given fields: headers, claims
+func (_m *TokenOwnershipProvider) HeaderCheck(headers http.Header, claims jwt.MapClaims) error {
+	ret := _m.Called(headers, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HeaderCheck")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(http.Header, jwt.MapClaims) error); ok {
+		r0 = rf(headers, claims)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TokenOwnershipProvider_HeaderCheck_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HeaderCheck'
+type TokenOwnershipProvider_HeaderCheck_Call struct {
+	*mock.Call
+}
+
+// HeaderCheck is a helper method to define mock.On call
+//   - headers http.Header
+//   - claims jwt.MapClaims
+func (_e *TokenOwnershipProvider_Expecter) HeaderCheck(headers interface{}, claims interface{}) *TokenOwnershipProvider_HeaderCheck_Call {
+	return &TokenOwnershipProvider_HeaderCheck_Call{Call: _e.mock.On("HeaderCheck", headers, claims)}
+}
+
+func (_c *TokenOwnershipProvider_HeaderCheck_Call) Run(run func(headers http.Header, claims jwt.MapClaims)) *TokenOwnershipProvider_HeaderCheck_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(http.Header), args[1].(jwt.MapClaims))
+	})
+	return _c
+}
+
+func (_c *TokenOwnershipProvider_HeaderCheck_Call) Return(_a0 error) *TokenOwnershipProvider_HeaderCheck_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TokenOwnershipProvider_HeaderCheck_Call) RunAndReturn(run func(http.Header, jwt.MapClaims) error) *TokenOwnershipProvider_HeaderCheck_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // TokenOwnerID provides a mock function with given fields: ctx, token

--- a/diode-server/auth/mocks/tokenownershipprovider.go
+++ b/diode-server/auth/mocks/tokenownershipprovider.go
@@ -4,7 +4,8 @@ package mocks
 
 import (
 	context "context"
-	http "net/http"
+
+	auth "github.com/netboxlabs/diode/diode-server/auth"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 
@@ -22,53 +23,6 @@ type TokenOwnershipProvider_Expecter struct {
 
 func (_m *TokenOwnershipProvider) EXPECT() *TokenOwnershipProvider_Expecter {
 	return &TokenOwnershipProvider_Expecter{mock: &_m.Mock}
-}
-
-// HeaderCheck provides a mock function with given fields: headers, claims
-func (_m *TokenOwnershipProvider) HeaderCheck(headers http.Header, claims jwt.MapClaims) error {
-	ret := _m.Called(headers, claims)
-
-	if len(ret) == 0 {
-		panic("no return value specified for HeaderCheck")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(http.Header, jwt.MapClaims) error); ok {
-		r0 = rf(headers, claims)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// TokenOwnershipProvider_HeaderCheck_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HeaderCheck'
-type TokenOwnershipProvider_HeaderCheck_Call struct {
-	*mock.Call
-}
-
-// HeaderCheck is a helper method to define mock.On call
-//   - headers http.Header
-//   - claims jwt.MapClaims
-func (_e *TokenOwnershipProvider_Expecter) HeaderCheck(headers interface{}, claims interface{}) *TokenOwnershipProvider_HeaderCheck_Call {
-	return &TokenOwnershipProvider_HeaderCheck_Call{Call: _e.mock.On("HeaderCheck", headers, claims)}
-}
-
-func (_c *TokenOwnershipProvider_HeaderCheck_Call) Run(run func(headers http.Header, claims jwt.MapClaims)) *TokenOwnershipProvider_HeaderCheck_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(http.Header), args[1].(jwt.MapClaims))
-	})
-	return _c
-}
-
-func (_c *TokenOwnershipProvider_HeaderCheck_Call) Return(_a0 error) *TokenOwnershipProvider_HeaderCheck_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *TokenOwnershipProvider_HeaderCheck_Call) RunAndReturn(run func(http.Header, jwt.MapClaims) error) *TokenOwnershipProvider_HeaderCheck_Call {
-	_c.Call.Return(run)
-	return _c
 }
 
 // TokenOwnerID provides a mock function with given fields: ctx, token
@@ -124,6 +78,53 @@ func (_c *TokenOwnershipProvider_TokenOwnerID_Call) Return(_a0 string, _a1 error
 }
 
 func (_c *TokenOwnershipProvider_TokenOwnerID_Call) RunAndReturn(run func(context.Context, string) (string, error)) *TokenOwnershipProvider_TokenOwnerID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ValidateTokenOwnership provides a mock function with given fields: data, claims
+func (_m *TokenOwnershipProvider) ValidateTokenOwnership(data auth.TokenOwnershipValidationData, claims jwt.MapClaims) error {
+	ret := _m.Called(data, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateTokenOwnership")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(auth.TokenOwnershipValidationData, jwt.MapClaims) error); ok {
+		r0 = rf(data, claims)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TokenOwnershipProvider_ValidateTokenOwnership_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateTokenOwnership'
+type TokenOwnershipProvider_ValidateTokenOwnership_Call struct {
+	*mock.Call
+}
+
+// ValidateTokenOwnership is a helper method to define mock.On call
+//   - data auth.TokenOwnershipValidationData
+//   - claims jwt.MapClaims
+func (_e *TokenOwnershipProvider_Expecter) ValidateTokenOwnership(data interface{}, claims interface{}) *TokenOwnershipProvider_ValidateTokenOwnership_Call {
+	return &TokenOwnershipProvider_ValidateTokenOwnership_Call{Call: _e.mock.On("ValidateTokenOwnership", data, claims)}
+}
+
+func (_c *TokenOwnershipProvider_ValidateTokenOwnership_Call) Run(run func(data auth.TokenOwnershipValidationData, claims jwt.MapClaims)) *TokenOwnershipProvider_ValidateTokenOwnership_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(auth.TokenOwnershipValidationData), args[1].(jwt.MapClaims))
+	})
+	return _c
+}
+
+func (_c *TokenOwnershipProvider_ValidateTokenOwnership_Call) Return(_a0 error) *TokenOwnershipProvider_ValidateTokenOwnership_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *TokenOwnershipProvider_ValidateTokenOwnership_Call) RunAndReturn(run func(auth.TokenOwnershipValidationData, jwt.MapClaims) error) *TokenOwnershipProvider_ValidateTokenOwnership_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/diode-server/auth/server.go
+++ b/diode-server/auth/server.go
@@ -99,7 +99,7 @@ type TokenOwnershipProvider interface {
 // DefaultTokenOwner is a default implementation of TokenOwnershipProvider
 type DefaultTokenOwner struct{}
 
-// HeaderCheck is a no-operation in the OSS implementation
+// HeaderCheck is a no-operation implementation
 func (p *DefaultTokenOwner) HeaderCheck(_ http.Header, _ jwt.MapClaims) error {
 	return nil
 }

--- a/diode-server/auth/server.go
+++ b/diode-server/auth/server.go
@@ -91,11 +91,18 @@ func statusFromError(err error) int {
 
 // TokenOwnershipProvider determines the owner of a token
 type TokenOwnershipProvider interface {
+	// HeaderCheck returns an error if the NetBox ID in the JWT claims conflicts with the HTTP headers.
+	HeaderCheck(headers http.Header, claims jwt.MapClaims) error
 	TokenOwnerID(ctx context.Context, token string) (string, error)
 }
 
 // DefaultTokenOwner is a default implementation of TokenOwnershipProvider
 type DefaultTokenOwner struct{}
+
+// HeaderCheck is a no-operation in the OSS implementation
+func (p *DefaultTokenOwner) HeaderCheck(_ http.Header, _ jwt.MapClaims) error {
+	return nil
+}
 
 // TokenOwnerID returns the owner of a token
 func (p *DefaultTokenOwner) TokenOwnerID(_ context.Context, _ string) (string, error) {
@@ -206,6 +213,13 @@ func (s *Server) introspect(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Error("failed to validate token", "error", err)
 		w.WriteHeader(statusFromError(err))
+		return
+	}
+
+	err = s.tokenOwnership.HeaderCheck(r.Header, claims)
+	if err != nil {
+		s.logger.Error("failed to validate token ownership with HTTP headers", "error", err)
+		w.WriteHeader(http.StatusForbidden)
 		return
 	}
 

--- a/diode-server/auth/server.go
+++ b/diode-server/auth/server.go
@@ -89,24 +89,28 @@ func statusFromError(err error) int {
 	return http.StatusInternalServerError
 }
 
+// TokenOwnershipValidationData contains data for validating token ownership
+type TokenOwnershipValidationData struct {
+	Headers http.Header
+}
+
 // TokenOwnershipProvider determines the owner of a token
 type TokenOwnershipProvider interface {
-	// HeaderCheck returns an error if something in the HTTP headers is a mismatch with the JWT claims.
-	HeaderCheck(headers http.Header, claims jwt.MapClaims) error
 	TokenOwnerID(ctx context.Context, token string) (string, error)
+	ValidateTokenOwnership(data TokenOwnershipValidationData, claims jwt.MapClaims) error
 }
 
 // DefaultTokenOwner is a default implementation of TokenOwnershipProvider
 type DefaultTokenOwner struct{}
 
-// HeaderCheck is a no-operation implementation
-func (p *DefaultTokenOwner) HeaderCheck(_ http.Header, _ jwt.MapClaims) error {
-	return nil
-}
-
 // TokenOwnerID returns the owner of a token
 func (p *DefaultTokenOwner) TokenOwnerID(_ context.Context, _ string) (string, error) {
 	return DefaultTokenOwnerID, nil
+}
+
+// ValidateTokenOwnership validates the ownership of a token
+func (p *DefaultTokenOwner) ValidateTokenOwnership(_ TokenOwnershipValidationData, _ jwt.MapClaims) error {
+	return nil
 }
 
 // ClientInfoDecorator attaches additional information to a client info
@@ -216,9 +220,9 @@ func (s *Server) introspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.tokenOwnership.HeaderCheck(r.Header, claims)
+	err = s.tokenOwnership.ValidateTokenOwnership(TokenOwnershipValidationData{Headers: r.Header}, claims)
 	if err != nil {
-		s.logger.Error("failed to validate token ownership with HTTP headers", "error", err)
+		s.logger.Error("failed to validate token ownership", "error", err)
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/diode-server/auth/server.go
+++ b/diode-server/auth/server.go
@@ -91,7 +91,7 @@ func statusFromError(err error) int {
 
 // TokenOwnershipProvider determines the owner of a token
 type TokenOwnershipProvider interface {
-	// HeaderCheck returns an error if the NetBox ID in the JWT claims conflicts with the HTTP headers.
+	// HeaderCheck returns an error if something in the HTTP headers is a mismatch with the JWT claims.
 	HeaderCheck(headers http.Header, claims jwt.MapClaims) error
 	TokenOwnerID(ctx context.Context, token string) (string, error)
 }

--- a/diode-server/auth/server_test.go
+++ b/diode-server/auth/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -40,6 +41,15 @@ func (p MockTokenParser) Parse(token string, _ jwt.Keyfunc) (*jwt.Token, error) 
 		return &tok, nil
 	}
 	return nil, fmt.Errorf("token not found")
+}
+
+type ownerInvalid struct{}
+
+func (o ownerInvalid) TokenOwnerID(_ context.Context, _ string) (string, error) {
+	return auth.DefaultTokenOwnerID, nil
+}
+func (o ownerInvalid) ValidateTokenOwnership(_ auth.TokenOwnershipValidationData, _ jwt.MapClaims) error {
+	return errors.New("invalid token owner")
 }
 
 func TestNewServer(t *testing.T) {
@@ -140,6 +150,7 @@ func TestIntrospectForValidTokens(t *testing.T) {
 		name             string
 		token            string
 		tokenParser      auth.TokenParser
+		invalidOwner     bool
 		expectedStatus   int
 		expectedAudience []string
 		expectedSubject  string
@@ -203,6 +214,35 @@ func TestIntrospectForValidTokens(t *testing.T) {
 			expectedClientID: "client123",
 			expectedUsername: "testuser",
 		},
+		{
+			name:  "Valid Token with invalid owner",
+			token: testToken,
+			tokenParser: &MockTokenParser{
+				tokenMap: map[string]jwt.Token{
+					testToken: {
+						Claims: jwt.MapClaims{
+							"iss":       "https://auth.example.com",
+							"sub":       "user123",
+							"aud":       "api",
+							"exp":       time.Now().Add(time.Hour).Unix(),
+							"iat":       time.Now().Unix(),
+							"client_id": "client123",
+							"scope":     "read write",
+							"username":  "testuser",
+						},
+						Valid: true,
+					},
+				},
+			},
+			invalidOwner:     true,
+			expectedStatus:   http.StatusForbidden,
+			expectedAudience: []string{"api"},
+			expectedSubject:  "user123",
+			expectedScope:    "read write",
+			expectedIssuer:   "https://auth.example.com",
+			expectedClientID: "client123",
+			expectedUsername: "testuser",
+		},
 	}
 
 	// Setup a test server to mock the OAuth2 server
@@ -240,8 +280,11 @@ func TestIntrospectForValidTokens(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			defaultOwnership := &auth.DefaultTokenOwner{}
-			server, err := auth.NewServer(ctx, logger, test.tokenParser, nil, defaultOwnership)
+			var ownerProvider auth.TokenOwnershipProvider = &auth.DefaultTokenOwner{}
+			if test.invalidOwner {
+				ownerProvider = ownerInvalid{}
+			}
+			server, err := auth.NewServer(ctx, logger, test.tokenParser, nil, ownerProvider)
 			require.NoError(t, err)
 			require.NotNil(t, server)
 
@@ -255,7 +298,10 @@ func TestIntrospectForValidTokens(t *testing.T) {
 			resp, err := makeIntrospectRequest(testServer.URL, test.token)
 
 			require.NoError(t, err)
-			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Equal(t, test.expectedStatus, resp.StatusCode)
+			if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+				return
+			}
 
 			defer func() {
 				_ = resp.Body.Close()

--- a/diode-server/auth/server_test.go
+++ b/diode-server/auth/server_test.go
@@ -49,7 +49,8 @@ func TestNewServer(t *testing.T) {
 	defer teardownEnv()
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
-	server, err := auth.NewServer(ctx, logger, InvalidParser{}, nil, nil)
+	defaultOwnership := &auth.DefaultTokenOwner{}
+	server, err := auth.NewServer(ctx, logger, InvalidParser{}, nil, defaultOwnership)
 	require.NoError(t, err)
 	require.NotNil(t, server)
 
@@ -96,7 +97,8 @@ func TestIntrospectForInvalidTokens(t *testing.T) {
 	}()
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
-	server, err := auth.NewServer(ctx, logger, InvalidParser{}, nil, nil)
+	defaultOwnership := &auth.DefaultTokenOwner{}
+	server, err := auth.NewServer(ctx, logger, InvalidParser{}, nil, defaultOwnership)
 	require.NoError(t, err)
 	require.NotNil(t, server)
 
@@ -238,7 +240,8 @@ func TestIntrospectForValidTokens(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			server, err := auth.NewServer(ctx, logger, test.tokenParser, nil, nil)
+			defaultOwnership := &auth.DefaultTokenOwner{}
+			server, err := auth.NewServer(ctx, logger, test.tokenParser, nil, defaultOwnership)
 			require.NoError(t, err)
 			require.NotNil(t, server)
 

--- a/diode-server/auth/server_test.go
+++ b/diode-server/auth/server_test.go
@@ -48,6 +48,7 @@ type ownerInvalid struct{}
 func (o ownerInvalid) TokenOwnerID(_ context.Context, _ string) (string, error) {
 	return auth.DefaultTokenOwnerID, nil
 }
+
 func (o ownerInvalid) ValidateTokenOwnership(_ auth.TokenOwnershipValidationData, _ jwt.MapClaims) error {
 	return errors.New("invalid token owner")
 }


### PR DESCRIPTION
This pull request allows the `/introspect` endpoint to fail if the HTTP headers are mismatched with the JWT claims.

### Updates to interfaces:
* The `ValidateTokenOwnership` method has been added to the `TokenOwnershipProvider` interface with a no-operation implementation
