### PR TITLE
fix: Resilient redis client

### DIFF
--- a/diode-server/go.mod
+++ b/diode-server/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/MicahParks/keyfunc/v3 v3.3.11
 	github.com/alicebob/miniredis/v2 v2.34.0
 	github.com/andybalholm/brotli v1.1.1
+	github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0
 	github.com/envoyproxy/protoc-gen-validate v1.2.1
 	github.com/getsentry/sentry-go v0.33.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
@@ -22,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.36.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0
@@ -104,7 +106,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect

--- a/diode-server/go.sum
+++ b/diode-server/go.sum
@@ -28,6 +28,8 @@ github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0 h1:pRcxfaAlK0vR6nOeQs7eAEvjJzdGXl8+KaBlcvpQTyQ=
+github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0/go.mod h1:rzgs2ZOiguV6/NpiDgADjRLPNyZlApIWxKpkT+X8SdY=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -167,6 +167,7 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 				continue
 			}
 		}
+		p.logger.WarnContext(ctx, "Read from Redis stream.")
 		for _, msg := range streams[0].Messages {
 			_, err := p.handleStreamMessage(ctx, msg)
 			if err != nil {

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -158,6 +159,7 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 				}
 				cancel()
 			}
+			p.logger.WarnContext(ctx, "Redis stream client ping")
 		}
 	}()
 
@@ -179,6 +181,12 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 			p.logger.WarnContext(ctx, "Failed to read from Redis stream.",
 				"error", err,
 			)
+			if strings.Contains(err.Error(), "NOGROUP") {
+				err := p.redisStreamClient.XGroupCreateMkStream(ctx, redisStreamID, redisConsumerGroup, "$").Err()
+				if err != nil && err.Error() != RedisConsumerGroupExistsErrMsg {
+					p.logger.Debug("Failed to recreate Redis consumer group.")
+				}
+			}
 			select {
 			case <-ctx.Done():
 				p.logger.Debug("ingestion processor exiting consumer loop on request")

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"time"
 
+	"github.com/cloudflare/backoff"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/attribute"
@@ -139,6 +141,7 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 		return err
 	}
 
+	b := backoff.New(10*time.Second, time.Second)
 	for {
 		select {
 		case <-ctx.Done():
@@ -153,7 +156,13 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 			Count:    100,
 		}).Result()
 		if err != nil || len(streams) == 0 {
-			continue
+			select {
+			case <-ctx.Done():
+				p.logger.Debug("ingestion processor exiting consumer loop on request")
+				return nil
+			case <-time.After(b.Duration()):
+				continue
+			}
 		}
 		for _, msg := range streams[0].Messages {
 			_, err := p.handleStreamMessage(ctx, msg)

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -142,27 +142,6 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 		return err
 	}
 
-	go func() {
-		ticker := time.NewTicker(5 * time.Second)
-		for {
-			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			select {
-			case <-ctx.Done():
-				cancel()
-				return
-			case <-ticker.C:
-				err := p.redisStreamClient.Ping(ctx).Err()
-				if err != nil {
-					p.logger.ErrorContext(ctx, "Failed to ping Redis stream client.",
-						"error", err,
-					)
-				}
-				cancel()
-			}
-			p.logger.WarnContext(ctx, "Redis stream client ping")
-		}
-	}()
-
 	b := backoff.New(10*time.Second, time.Second)
 	for {
 		select {
@@ -178,9 +157,6 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 			Count:    100,
 		}).Result()
 		if err != nil || len(streams) == 0 {
-			p.logger.WarnContext(ctx, "Failed to read from Redis stream.",
-				"error", err,
-			)
 			if strings.Contains(err.Error(), "NOGROUP") {
 				err := p.redisStreamClient.XGroupCreateMkStream(ctx, redisStreamID, redisConsumerGroup, "$").Err()
 				if err != nil && err.Error() != RedisConsumerGroupExistsErrMsg {
@@ -195,7 +171,6 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 				continue
 			}
 		}
-		p.logger.WarnContext(ctx, "Read from Redis stream.")
 		for _, msg := range streams[0].Messages {
 			_, err := p.handleStreamMessage(ctx, msg)
 			if err != nil {

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -171,6 +171,8 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 				continue
 			}
 		}
+		b.Reset()
+
 		for _, msg := range streams[0].Messages {
 			_, err := p.handleStreamMessage(ctx, msg)
 			if err != nil {

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -141,6 +141,26 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 		return err
 	}
 
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		for {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			select {
+			case <-ctx.Done():
+				cancel()
+				return
+			case <-ticker.C:
+				err := p.redisStreamClient.Ping(ctx).Err()
+				if err != nil {
+					p.logger.ErrorContext(ctx, "Failed to ping Redis stream client.",
+						"error", err,
+					)
+				}
+				cancel()
+			}
+		}
+	}()
+
 	b := backoff.New(10*time.Second, time.Second)
 	for {
 		select {

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -156,6 +156,9 @@ func (p *IngestionProcessor) consumeIngestionStream(ctx context.Context, redisSt
 			Count:    100,
 		}).Result()
 		if err != nil || len(streams) == 0 {
+			p.logger.WarnContext(ctx, "Failed to read from Redis stream.",
+				"error", err,
+			)
 			select {
 			case <-ctx.Done():
 				p.logger.Debug("ingestion processor exiting consumer loop on request")


### PR DESCRIPTION
When Redis goes offline then comes back online, the reconciler does not automatically reconnect and read from the relevant stream as expected. These changes should have the reconciler automatically reconnect and read from the relevant stream.