### PR TITLE
🚚 release

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.6.1
-appVersion: "1.2.0"
+version: 1.6.2
+appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:
   - https://github.com/netboxlabs/diode

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -240,7 +240,7 @@ helm show values diode/diode
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuth.image.tag | string | `"1.2.0"` | image tag |
+| diodeAuth.image.tag | string | `"1.5.0"` | image tag |
 | diodeAuth.replicaCount | int | `1` | replica count |
 | diodeAuth.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeAuth.serviceAccount.create | bool | `true` | create service account |
@@ -248,7 +248,7 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuthBootstrap.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuthBootstrap.image.tag | string | `"1.2.0"` | image tag |
+| diodeAuthBootstrap.image.tag | string | `"1.5.0"` | image tag |
 | diodeAuthBootstrap.job.annotations | object | `{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-weight":"2"}` | annotations to add to the auth bootstrap job |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
 | diodeAuthBootstrap.job.extraInitContainers | string or list | `""` | additional initContainers to run during bootstrap (may contain templating instructions) |
@@ -268,7 +268,7 @@ helm show values diode/diode
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeIngester.image.repository | string | `"docker.io/netboxlabs/diode-ingester"` | image repository |
-| diodeIngester.image.tag | string | `"1.2.0"` | image tag |
+| diodeIngester.image.tag | string | `"1.5.0"` | image tag |
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
@@ -300,7 +300,7 @@ helm show values diode/diode
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.image.repository | string | `"docker.io/netboxlabs/diode-reconciler"` | image repository |
-| diodeReconciler.image.tag | string | `"1.2.0"` | image tag |
+| diodeReconciler.image.tag | string | `"1.5.0"` | image tag |
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeReconciler.serviceAccount.create | bool | `true` | create service account |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -43,7 +43,7 @@ diodeAuth:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.2.0
+    tag: 1.5.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -89,7 +89,7 @@ diodeAuthBootstrap:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.2.0
+    tag: 1.5.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -112,7 +112,7 @@ diodeIngester:
     # -- image repository
     repository: docker.io/netboxlabs/diode-ingester
     # -- image tag
-    tag: 1.2.0
+    tag: 1.5.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -165,7 +165,7 @@ diodeReconciler:
     # -- image repository
     repository: docker.io/netboxlabs/diode-reconciler
     # -- image tag
-    tag: 1.2.0
+    tag: 1.5.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy


### PR DESCRIPTION
- chore: bump chart version to 1.6.2 and diode image to 1.5.0 (#393)