### PR TITLE
fix: Use ctx in keyfunc

### DIFF
--- a/diode-server/auth/server.go
+++ b/diode-server/auth/server.go
@@ -119,14 +119,14 @@ type ClientInfoDecorator interface {
 }
 
 // NewServer creates a new auth server
-func NewServer(_ context.Context, logger *slog.Logger, tokenParser TokenParser, clientManager ClientManager, tokenOwnership TokenOwnershipProvider) (*Server, error) {
+func NewServer(ctx context.Context, logger *slog.Logger, tokenParser TokenParser, clientManager ClientManager, tokenOwnership TokenOwnershipProvider) (*Server, error) {
 	var cfg Config
 	envconfig.MustProcess("", &cfg)
 
 	mux := http.NewServeMux()
 
 	jwkSetURL := cfg.OAuth2.PublicServerURL + "/.well-known/jwks.json"
-	k, err := keyfunc.NewDefault([]string{jwkSetURL})
+	k, err := keyfunc.NewDefaultCtx(ctx, []string{jwkSetURL})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create keyfunc: %w", err)
 	}

--- a/diode-server/auth/server_hydra_integration_test.go
+++ b/diode-server/auth/server_hydra_integration_test.go
@@ -19,14 +19,15 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
-	testcontainers "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/netboxlabs/diode/diode-server/auth"
 )
 
 func TestServerHydraIntegration(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	creq := testcontainers.ContainerRequest{
 		Image:        "oryd/hydra:v2.3.0",

--- a/diode-server/auth/server_test.go
+++ b/diode-server/auth/server_test.go
@@ -54,7 +54,8 @@ func (o ownerInvalid) ValidateTokenOwnership(_ auth.TokenOwnershipValidationData
 }
 
 func TestNewServer(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	setupEnv()
 	defer teardownEnv()
@@ -76,7 +77,8 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestIntrospectForInvalidTokens(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	setupEnv()
 	defer teardownEnv()
@@ -279,7 +281,8 @@ func TestIntrospectForValidTokens(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			var ownerProvider auth.TokenOwnershipProvider = &auth.DefaultTokenOwner{}
 			if test.invalidOwner {
@@ -424,7 +427,8 @@ func TestCreateClient(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	setupEnv()
 	defer teardownEnv()
 
@@ -614,7 +618,8 @@ func TestListClients(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	setupEnv()
 	defer teardownEnv()
 
@@ -769,7 +774,8 @@ func TestDeleteClient(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	setupEnv()
 	defer teardownEnv()
 
@@ -905,7 +911,8 @@ func TestGetClient(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	setupEnv()
 	defer teardownEnv()
 

--- a/diode-server/cmd/auth/main.go
+++ b/diode-server/cmd/auth/main.go
@@ -23,7 +23,8 @@ const (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	s := server.New(ctx, applicationName, version.Release())
 
 	defer s.Recover(sentry.CurrentHub())


### PR DESCRIPTION
This pull request changes some `context.Background()` to cancellable ones. The most practical effect will be that tests do not leak goroutines.