### PR TITLE
fix: return gRPC error when failure to write to Redis stream

### DIFF
--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -174,7 +174,7 @@ func (c *Component) Ingest(ctx context.Context, in *diodepb.IngestRequest) (*dio
 	}).Err(); err != nil {
 		c.metrics.RecordIngestRequest(ctx, false)
 		c.logger.Error("failed to add element to the stream", "error", err, "streamID", streamID, "value", msg)
-		return nil, status.Error(codes.Internal, "unable to accept")
+		return nil, status.Error(codes.Internal, "")
 	} else {
 		entityCount := int64(len(in.GetEntities()))
 		c.metrics.RecordIngestRequest(ctx, true)

--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -168,18 +168,19 @@ func (c *Component) Ingest(ctx context.Context, in *diodepb.IngestRequest) (*dio
 	}
 	ctx = telemetry.ContextWithMetricAttributes(ctx, attrs...)
 
-	if err := c.redisStreamClient.XAdd(ctx, &redis.XAddArgs{
+	err = c.redisStreamClient.XAdd(ctx, &redis.XAddArgs{
 		Stream: streamID,
 		Values: msg,
-	}).Err(); err != nil {
+	}).Err()
+	if err != nil {
 		c.metrics.RecordIngestRequest(ctx, false)
 		c.logger.Error("failed to add element to the stream", "error", err, "streamID", streamID, "value", msg)
 		return nil, status.Error(codes.Internal, "")
-	} else {
-		entityCount := int64(len(in.GetEntities()))
-		c.metrics.RecordIngestRequest(ctx, true)
-		c.metrics.RecordIngestEntities(ctx, entityCount)
 	}
+
+	entityCount := int64(len(in.GetEntities()))
+	c.metrics.RecordIngestRequest(ctx, true)
+	c.metrics.RecordIngestEntities(ctx, entityCount)
 
 	return &diodepb.IngestResponse{Errors: errs}, nil
 }

--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -176,7 +176,7 @@ func (c *Component) Ingest(ctx context.Context, in *diodepb.IngestRequest) (*dio
 		c.metrics.RecordIngestRequest(ctx, false)
 		c.logger.Error("failed to add element to the stream", "error", err, "streamID", streamID, "value", msg)
 		return nil, status.Error(codes.Internal, "")
-	} // GHA incident
+	}
 
 	entityCount := int64(len(in.GetEntities()))
 	c.metrics.RecordIngestRequest(ctx, true)

--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -12,7 +12,9 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
@@ -172,6 +174,7 @@ func (c *Component) Ingest(ctx context.Context, in *diodepb.IngestRequest) (*dio
 	}).Err(); err != nil {
 		c.metrics.RecordIngestRequest(ctx, false)
 		c.logger.Error("failed to add element to the stream", "error", err, "streamID", streamID, "value", msg)
+		return nil, status.Error(codes.Internal, "unable to accept")
 	} else {
 		entityCount := int64(len(in.GetEntities()))
 		c.metrics.RecordIngestRequest(ctx, true)

--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -176,7 +176,7 @@ func (c *Component) Ingest(ctx context.Context, in *diodepb.IngestRequest) (*dio
 		c.metrics.RecordIngestRequest(ctx, false)
 		c.logger.Error("failed to add element to the stream", "error", err, "streamID", streamID, "value", msg)
 		return nil, status.Error(codes.Internal, "")
-	}
+	} // GHA incident
 
 	entityCount := int64(len(in.GetEntities()))
 	c.metrics.RecordIngestRequest(ctx, true)


### PR DESCRIPTION
This pull request returns a gRPC error to the requester when it fails to write the ingestion log to the Redis stream.

Clients should retry with backoff if this occurs.

The error returned should be the [`INTERNAL` status code](https://grpc.io/docs/guides/status-codes/#the-full-list-of-status-codes).