### PR TITLE
feat: separate enabling controller from resources

### DIFF
--- a/charts/diode/Chart.lock
+++ b/charts/diode/Chart.lock
@@ -17,5 +17,5 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.12.0
-digest: sha256:61907df8f8ab4bd2fd67195670bb6f920392f6af0655f22dce06a68fd381a1ba
-generated: "2025-05-30T12:44:47.769834-04:00"
+digest: sha256:2856fe78498db6124a167e5716405777af9b72b2995b0e0cb3a92e23fca8996e
+generated: "2025-08-25T12:49:19.940917-04:00"

--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.6.2
+version: 1.7.0
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:
@@ -34,7 +34,7 @@ dependencies:
   - name: ingress-nginx
     version: 4.12.1
     repository: https://kubernetes.github.io/ingress-nginx
-    condition: ingressNginx.enabled
+    condition: ingressNginx.controller.enabled
   - name: cert-manager
     version: v1.12.0
     repository: https://charts.jetstack.io

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -339,9 +339,10 @@ helm show values diode/diode
 | hydra.job.extraInitContainers | string or list | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.secret.enabled | bool | `false` | secret enabled |
 | hydra.secret.nameOverride | string | `"diode-hydra-secret"` | existing secret name |
-| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true},"enabled":true,"extraHttpPaths":[],"grpcAnnotations":{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":"true"},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/ssl-redirect":"true"},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
-| ingressNginx.controller | object | `{"allowSnippetAnnotations":true}` | ingress annotations |
+| ingressNginx | object | `{"annotations":{},"controller":{"allowSnippetAnnotations":true,"enabled":true},"enabled":true,"extraHttpPaths":[],"grpcAnnotations":{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":"true"},"hostname":"","httpAnnotations":{"nginx.ingress.kubernetes.io/ssl-redirect":"true"},"ingressClass":"nginx","pathPrefix":"/diode","tls":{}}` | ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml |
+| ingressNginx.controller | object | `{"allowSnippetAnnotations":true,"enabled":true}` | ingress annotations |
 | ingressNginx.controller.allowSnippetAnnotations | bool | `true` | allow snippet annotations |
+| ingressNginx.controller.enabled | bool | `true` | deploy an ingress-nginx controller chart in addition to `Ingress` resources |
 | ingressNginx.enabled | bool | `true` | ingress-nginx enabled |
 | ingressNginx.extraHttpPaths | list | `[]` | ingress extra http paths |
 | ingressNginx.grpcAnnotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"25m","nginx.ingress.kubernetes.io/ssl-redirect":"true"}` | ingress grpc annotations |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -401,6 +401,8 @@ ingressNginx:
   ingressClass: nginx
   # -- ingress annotations
   controller:
+    # -- deploy an ingress-nginx controller chart in addition to `Ingress` resources
+    enabled: true
     # -- allow snippet annotations
     allowSnippetAnnotations: true
   annotations: {}


### PR DESCRIPTION
If the user has their own ingress controller, my changes from https://github.com/netboxlabs/diode/pull/376 keep it from exporting the ingress resources to register with that controller. (oops)

Instead, this PR puts a separate `enable` under the `ingressNginx.controller:` section, and considers the top-level `ingressNginx.enable` to be _only_ about enabling the resources.

Since this is technically a "feature" and also could cause a surprise to users who have turned things off previously, I bumped it to a new minor version, although arguably by semver I should probably bump the major. Thoughts?

Also, I can't find where the `controller:` section is even used, is `ingressNginx.controller.allowSnippetAnnotations` vestigial from some old config that didn't end up happening?