### PR TITLE
chore: upgrade semantic release

### DIFF
--- a/.github/workflows/reusable_semantic_release.yaml
+++ b/.github/workflows/reusable_semantic_release.yaml
@@ -88,7 +88,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/.github/workflows/reusable_semantic_release.yaml
+++ b/.github/workflows/reusable_semantic_release.yaml
@@ -42,6 +42,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }

--- a/.github/workflows/reusable_semantic_release_get_next_version.yaml
+++ b/.github/workflows/reusable_semantic_release_get_next_version.yaml
@@ -95,7 +95,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/.github/workflows/reusable_semantic_release_get_next_version.yaml
+++ b/.github/workflows/reusable_semantic_release_get_next_version.yaml
@@ -46,6 +46,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/commit-analyzer": "^9.0.2",
                 "@semantic-release/github": "^8.0.0",


### PR DESCRIPTION
This pull request updates the semantic release configuration in two GitHub Actions workflow files to address compatibility issues and ensure the correct version of dependencies is used. The most important changes are grouped below:

**Dependency Updates:**

* Added an explicit dependency on `semantic-release` version `25.0.0-beta.6` in both `.github/workflows/reusable_semantic_release.yaml` and `.github/workflows/reusable_semantic_release_get_next_version.yaml` to ensure consistent release tooling. [[1]](diffhunk://#diff-9e8960dc00dd3d6f18d42e50bf9a8e89b8273759d83eb38504efaae3ff091e49R45) [[2]](diffhunk://#diff-1910d3a5a12c77bb4295e64ce34833f3cda1a473edeb78ac7b610710712c32a7R49)

**Installation Command Changes:**

* Changed the npm install command from `npm i` to `npm install --legacy-peer-deps` in both workflow files to resolve peer dependency conflicts during setup. [[1]](diffhunk://#diff-9e8960dc00dd3d6f18d42e50bf9a8e89b8273759d83eb38504efaae3ff091e49L90-R91) [[2]](diffhunk://#diff-1910d3a5a12c77bb4295e64ce34833f3cda1a473edeb78ac7b610710712c32a7L97-R98)