### PR TITLE
reconciler+ingester init configuration changes

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.7.0
+version: 1.8.0
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -310,10 +310,13 @@ helm show values diode/diode
 | externalRedis.port | int | `6379` | port |
 | global.commonAnnotations | object | `{}` | common annotations for all resources |
 | global.commonLabels | object | `{}` | common labels for all resources |
-| global.diode | object | `{"busybox":{"image":"busybox:latest","imagePullPolicy":"IfNotPresent"},"hydra":{"waitForPostgres":true}}` | diode global configuration |
+| global.diode | object | `{"busybox":{"image":"busybox:latest","imagePullPolicy":"IfNotPresent"},"hydra":{"waitForPostgres":true},"ingester":{"waitForRedis":true},"reconciler":{"waitForPostgres":true,"waitForRedis":true}}` | diode global configuration |
 | global.diode.busybox | object | `{"image":"busybox:latest","imagePullPolicy":"IfNotPresent"}` | busybox image configuration |
 | global.diode.hydra | object | `{"waitForPostgres":true}` | hydra additional init containers configuration |
-| global.diode.hydra.waitForPostgres | bool | `true` | wait for PostgreSQL |
+| global.diode.hydra.waitForPostgres | bool | `true` | wait for PostgreSQL to be reachable |
+| global.diode.ingester.waitForRedis | bool | `true` | wait for Redis to be reachable |
+| global.diode.reconciler.waitForPostgres | bool | `true` | wait for PostgreSQL to be reachable |
+| global.diode.reconciler.waitForRedis | bool | `true` | wait for Redis to be reachable |
 | hydra | object | `{"deployment":{"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}},"enabled":true,"fullnameOverride":"diode-hydra","hydra":{"automigration":{"enabled":true},"config":{"oidc":{"subject_identifiers":{"supported_types":["public"]}},"strategies":{"access_token":"jwt","jwt":{"scope_claim":"both"}},"ttl":{"access_token":"1h"},"urls":{"self":{"issuer":"http://diode-hydra-public.{{ .Release.Namespace }}.svc.cluster.local:4444"}}},"dev":true,"ingress":{"admin":{"enabled":false},"public":{"enabled":false}},"service":{"admin":{"enabled":true,"port":4445,"type":"ClusterIP"},"public":{"enabled":true,"port":4444,"type":"ClusterIP"}}},"job":{"annotations":{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-delete-policy":"hook-succeeded","helm.sh/hook-weight":"1"},"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}"},"secret":{"enabled":false,"nameOverride":"diode-hydra-secret"}}` | ref: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml |
 | hydra.deployment.extraInitContainers | string or list | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.deployment.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- toYaml .Values.diodeIngester.image.imagePullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- if .Values.redis.enabled }}
+        {{- if .Values.global.diode.ingester.waitForRedis | default true }}
         - name: wait-for-redis
           image: {{ include "diode.busybox.image" . }}
           imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- toYaml .Values.diodeIngester.image.imagePullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- if .Values.global.diode.ingester.waitForRedis | default true }}
+        {{- if .Values.global.diode.ingester.waitForRedis }}
         - name: wait-for-redis
           image: {{ include "diode.busybox.image" . }}
           imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -53,8 +53,8 @@ spec:
               done;
               echo "Redis server is up and running";
         {{- end }}
-        {{- if .Values.diodeAuth.extraInitContainers }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeAuth.extraInitContainers "context" $ ) | nindent 8 }}
+        {{- if .Values.diodeIngester.extraInitContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeIngester.extraInitContainers "context" $ ) | nindent 8 }}
         {{- end }}
       containers:
         - name: {{ include "diode.ingester.servicename" . }}

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- toYaml .Values.diodeReconciler.image.imagePullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- if .Values.redis.enabled }}
+        {{- if .Values.global.diode.reconciler.waitForRedis }}
         - name: wait-for-redis
           image: {{ include "diode.busybox.image" . }}
           imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}
@@ -53,7 +53,7 @@ spec:
               done;
               echo "Redis server is up and running";
         {{- end }}
-        {{- if .Values.postgresql.enabled }}
+        {{- if .Values.global.diode.reconciler.waitForPostgres }}
         - name: wait-for-postgres
           image: {{ include "diode.busybox.image" . }}
           imagePullPolicy: {{ include "diode.busybox.imagepullpolicy" . }}

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -67,8 +67,8 @@ spec:
               done;
               echo "PostgreSQL server is up and running";
         {{- end }}
-        {{- if .Values.diodeAuth.extraInitContainers }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeAuth.extraInitContainers "context" $ ) | nindent 8 }}
+        {{- if .Values.diodeReconciler.extraInitContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.diodeReconciler.extraInitContainers "context" $ ) | nindent 8 }}
         {{- end }}
       containers:
         - name: {{ include "diode.reconciler.servicename" . }}

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -7,8 +7,16 @@ global:
       imagePullPolicy: IfNotPresent
     # -- hydra additional init containers configuration
     hydra:
-      # -- wait for PostgreSQL
+      # -- wait for PostgreSQL to be reachable
       waitForPostgres: true
+    ingester:
+      # -- wait for Redis to be reachable
+      waitForRedis: true
+    reconciler:
+      # -- wait for PostgreSQL to be reachable
+      waitForPostgres: true
+      # -- wait for Redis to be reachable
+      waitForRedis: true
 
   # -- common annotations for all resources
   commonAnnotations: {}


### PR DESCRIPTION
TL;DR:

* fix a cut-and-paste issue with the `extraInitContainers` config and the ingester and reconciler deployments
* allow "wait for" to work with external databases as well, since the template macros map whether or not you are using internal or external

---

This pull request updates the Diode Helm chart to version 1.8.0 and introduces improved configuration for init containers, allowing finer control over waiting for dependent services (Redis and PostgreSQL) before starting the ingester and reconciler components. The changes also fix extra init container references and enhance documentation to reflect the new options.

**Version and documentation updates:**

* Bumped chart version to `1.8.0` in `Chart.yaml` and updated the version badge in `README.md`. [[1]](diffhunk://#diff-b886313e1c0741f2c72a92382362d33b52e225680751f83cd06d7f1e542d8bc5L5-R5) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5)
* Expanded documentation in `README.md` to describe new global configuration options for waiting on Redis and PostgreSQL for `ingester` and `reconciler` components.

**Configuration improvements:**

* Added `waitForRedis` and `waitForPostgres` options under `global.diode.ingester` and `global.diode.reconciler` in `values.yaml` for more granular control of init containers.

**Template logic fixes:**

* Updated `diode-ingester-deployment.yaml` and `diode-reconciler-deployment.yaml` to use the new global config flags for conditional init containers instead of relying solely on service enablement. [[1]](diffhunk://#diff-8bed87c066be5a33d2a20ef23520641413633a704e236fb966cfff3050c62885L42-R42) [[2]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78L42-R42) [[3]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78L56-R56)
* Corrected references to extra init containers to use the appropriate component (`diodeIngester` and `diodeReconciler` instead of `diodeAuth`) in deployment templates. [[1]](diffhunk://#diff-8bed87c066be5a33d2a20ef23520641413633a704e236fb966cfff3050c62885L56-R57) [[2]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78L70-R71)