### PR TITLE
feat: improve helm chart postgresql secret handling

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: 1.8.0
+version: 1.9.0
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -304,8 +304,13 @@ helm show values diode/diode
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeReconciler.serviceAccount.create | bool | `true` | create service account |
+| externalPostgresql.database | string | `"diode"` | database name |
+| externalPostgresql.existingSecretKey | string | `"postgresql-password"` | key of password in existing postgresql secret |
+| externalPostgresql.existingSecretName | string | `""` | existing postgresql secret |
 | externalPostgresql.hostname | string | `"localhost"` | hostname |
+| externalPostgresql.password | string | `""` | password |
 | externalPostgresql.port | int | `5432` | port |
+| externalPostgresql.username | string | `"diode"` | username |
 | externalRedis.hostname | string | `"localhost"` | hostname |
 | externalRedis.port | int | `6379` | port |
 | global.commonAnnotations | object | `{}` | common annotations for all resources |

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -292,6 +292,58 @@ Create the port of the Redis database
 {{- end }}
 
 {{/*
+Create the database name for PostgreSQL
+*/}}
+{{- define "diode.postgresql.database" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "diode" }}
+{{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "database") -}}
+{{- .Values.externalPostgresql.database }}
+{{- else -}}
+{{- fail "externalPostgresql.database must be defined when postgresql.enabled is false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the username for PostgreSQL
+*/}}
+{{- define "diode.postgresql.username" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "diode" }}
+{{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "username") -}}
+{{- .Values.externalPostgresql.username }}
+{{- else -}}
+{{- fail "externalPostgresql.username must be defined when postgresql.enabled is false" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the secret name for PostgreSQL credentials
+*/}}
+{{- define "diode.postgresql.secretname" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "diode-postgresql-secret" }}
+{{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "existingSecretName") (not (empty .Values.externalPostgresql.existingSecretName)) -}}
+{{- .Values.externalPostgresql.existingSecretName }}
+{{- else -}}
+{{- printf "diode-external-postgresql-secret" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the secret key for PostgreSQL password
+*/}}
+{{- define "diode.postgresql.secretkey" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "postgres-password" }}
+{{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "existingSecretKey") (not (empty .Values.externalPostgresql.existingSecretKey)) -}}
+{{- .Values.externalPostgresql.existingSecretKey }}
+{{- else -}}
+{{- printf "postgresql-password" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the hostname of the public Hydra service
 */}}
 {{- define "diode.hydra.public.hostname" -}}

--- a/charts/diode/templates/diode-reconciler-configmap.yaml
+++ b/charts/diode/templates/diode-reconciler-configmap.yaml
@@ -27,8 +27,8 @@ data:
   DIODE_TO_NETBOX_RATE_LIMITER_BURST: {{ $config.diodeToNetboxRateLimiterBurst | default "1" | quote }}
   POSTGRES_HOST: {{ include "diode.postgresql.hostname" . | quote }}
   POSTGRES_PORT: {{ include "diode.postgresql.port" . | quote }}
-  POSTGRES_DB_NAME: {{ $config.postgresDbName | default "diode" | quote }}
-  POSTGRES_USER: {{ $config.postgresUser | default "diode" | quote }}
+  POSTGRES_DB_NAME: {{ include "diode.postgresql.database" . | quote }}
+  POSTGRES_USER: {{ include "diode.postgresql.username" . | quote }}
   NETBOX_DIODE_PLUGIN_API_BASE_URL: {{ $config.netboxDiodePluginApiBaseUrl | quote }}
   NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY: {{ $config.netboxDiodePluginSkipTlsVerify | quote }}
   DIODE_AUTH_TOKEN_URL: {{ printf "%s/token" (include "diode.auth.url" .) | quote }}

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -84,9 +84,15 @@ spec:
           resources:
             {{- toYaml .| nindent 12 }}
           {{- end }}
-          {{- if .Values.diodeReconciler.extraEnvs }}
-          env: {{- include "common.tplvalues.render" (dict "value" .Values.diodeReconciler.extraEnvs "context" $) | nindent 12 }}
-          {{- end }}
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "diode.postgresql.secretname" . }}
+                  key: {{ include "diode.postgresql.secretkey" . }}
+            {{- if .Values.diodeReconciler.extraEnvs }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.diodeReconciler.extraEnvs "context" $) | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "diode.reconciler.configmap" . }}

--- a/charts/diode/templates/diode-secrets.yaml
+++ b/charts/diode/templates/diode-secrets.yaml
@@ -1,0 +1,16 @@
+{{- if and (not .Values.postgresql.enabled) (not .Values.externalPostgresql.existingSecretName) (not (empty .Values.externalPostgresql.password)) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "diode.postgresql.secretname" . }}
+  namespace: {{ include "diode.namespace" . }}
+  labels:
+    {{- include "diode.labels" . | nindent 4 }}
+  {{- if .Values.global.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{ include "diode.postgresql.secretkey" . }}: {{ .Values.externalPostgresql.password | b64enc | quote }}
+{{- end }}

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -24,7 +24,6 @@ global:
   # -- common labels for all resources
   commonLabels: {}
 
-
 diode:
   # -- environment name
   environment: development
@@ -35,6 +34,16 @@ externalPostgresql:
   hostname: localhost
   # -- port
   port: 5432
+  # -- database name
+  database: diode
+  # -- username
+  username: diode
+  # -- password
+  password: ""
+  # -- existing postgresql secret
+  existingSecretName: ""
+  # -- key of password in existing postgresql secret
+  existingSecretKey: postgresql-password
 
 # External Redis configuration (optional)
 externalRedis:


### PR DESCRIPTION
The intention behind this pull request is to get diode's chart more inline with how the netbox community chart handles postgresql secrets. While not exactly the same, the goal is to create some familiarity between the two. 

Additionally if a consumer of this chart were to leverage an external postgresql database, they would need to override environment variables to do so. This is less than ideal and these changes provide an easier mechanism to use external databases.

`values.yaml`:
- Expanded `externalPostgresql` values: Added support for database, username, password, existingSecretName, and existingSecretKey fields in values.yaml

`_helpers.tpl`:
- `diode.postgresql.database` - Returns database name (built-in or external)
- `diode.postgresql.username` - Returns username (built-in or external)
- `diode.postgresql.secretname` - Returns appropriate secret name based on configuration
- `diode.postgresql.secretkey` - Returns appropriate secret key based on configuration

`diode-secrets.yaml`: creates external postgresql secrets when needed

`diode-reconciler-deployment.yaml`: properly references postgresql passwords from secrets

`diode-reconciler-configmap.yaml`: uses helper templates for consistent database/username configuration