### PR TITLE
fix: reconciler - remove hardcoded sslmode config

### DIFF
--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -311,6 +311,7 @@ helm show values diode/diode
 | externalPostgresql.password | string | `""` | password |
 | externalPostgresql.port | int | `5432` | port |
 | externalPostgresql.username | string | `"diode"` | username |
+| externalPostgresql.sslMode | string | `"disable"` | postgres ssl connection mode |
 | externalRedis.hostname | string | `"localhost"` | hostname |
 | externalRedis.port | int | `6379` | port |
 | global.commonAnnotations | object | `{}` | common annotations for all resources |

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -344,6 +344,19 @@ Create the secret key for PostgreSQL password
 {{- end }}
 
 {{/*
+Create the SSL option for PostgreSQL
+*/}}
+{{- define "diode.postgresql.sslMode" -}}
+{{- if .Values.postgresql.sslMode -}}
+{{- printf "postgres-password" }}
+{{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "sslMode") (not (empty .Values.externalPostgresql.sslMode)) -}}
+{{- .Values.externalPostgresql.sslMode }}
+{{- else -}}
+{{- printf "disable" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the hostname of the public Hydra service
 */}}
 {{- define "diode.hydra.public.hostname" -}}

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -348,7 +348,7 @@ Create the SSL option for PostgreSQL
 */}}
 {{- define "diode.postgresql.sslMode" -}}
 {{- if .Values.postgresql.sslMode -}}
-{{- printf "postgres-password" }}
+{{- printf "disable" }}
 {{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "sslMode") (not (empty .Values.externalPostgresql.sslMode)) -}}
 {{- .Values.externalPostgresql.sslMode }}
 {{- else -}}

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -347,7 +347,7 @@ Create the secret key for PostgreSQL password
 Create the SSL option for PostgreSQL
 */}}
 {{- define "diode.postgresql.sslMode" -}}
-{{- if .Values.postgresql.sslMode -}}
+{{- if .Values.postgresql.enabled -}}
 {{- printf "disable" }}
 {{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "sslMode") (not (empty .Values.externalPostgresql.sslMode)) -}}
 {{- .Values.externalPostgresql.sslMode }}

--- a/charts/diode/templates/diode-reconciler-configmap.yaml
+++ b/charts/diode/templates/diode-reconciler-configmap.yaml
@@ -29,6 +29,7 @@ data:
   POSTGRES_PORT: {{ include "diode.postgresql.port" . | quote }}
   POSTGRES_DB_NAME: {{ include "diode.postgresql.database" . | quote }}
   POSTGRES_USER: {{ include "diode.postgresql.username" . | quote }}
+  POSTGRES_SSL_MODE: {{ include "diode.postgresql.sslMode" . | quote }}
   NETBOX_DIODE_PLUGIN_API_BASE_URL: {{ $config.netboxDiodePluginApiBaseUrl | quote }}
   NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY: {{ $config.netboxDiodePluginSkipTlsVerify | quote }}
   DIODE_AUTH_TOKEN_URL: {{ printf "%s/token" (include "diode.auth.url" .) | quote }}

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -40,6 +40,8 @@ externalPostgresql:
   username: diode
   # -- password
   password: ""
+  # -- ssl mode
+  sslMode: ""
   # -- existing postgresql secret
   existingSecretName: ""
   # -- key of password in existing postgresql secret

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	metricRecorder.SetServiceInfo(ctx, fmt.Sprintf("%s.%s", version.GetBuildVersion(), version.GetBuildCommit()))
 
-	dbURL := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", cfg.PostgresHost, cfg.PostgresPort, cfg.PostgresUser, cfg.PostgresPassword, cfg.PostgresDBName)
+	dbURL := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", cfg.PostgresHost, cfg.PostgresPort, cfg.PostgresUser, cfg.PostgresPassword, cfg.PostgresDBName, cfg.PostgresSSLMode)
 
 	if cfg.MigrationEnabled {
 		if err := runDBMigrations(ctx, s.Logger(), dbURL); err != nil {

--- a/diode-server/reconciler/config.go
+++ b/diode-server/reconciler/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	PostgresDBName                string `envconfig:"POSTGRES_DB_NAME"`
 	PostgresUser                  string `envconfig:"POSTGRES_USER"`
 	PostgresPassword              string `envconfig:"POSTGRES_PASSWORD"`
+	PostgresSSLMode               string `envconfig:"POSTGRES_SSL_MODE" default:"disable"`
 
 	NetBoxDiodePluginAPIBaseURL    string `envconfig:"NETBOX_DIODE_PLUGIN_API_BASE_URL" required:"true"`
 	NetBoxDiodePluginSkipTLSVerify bool   `envconfig:"NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY" default:"false"`


### PR DESCRIPTION
previously, ssl mode was not configurable when creating a connection to the postgres database. while the lack of SSL is acceptable for local deployments (i.e., containerized postgres in-cluster), we hit security restrictions when trying to connect to external databases (like RDS). this commit allows the operator to configure the ssl mode to their choosing.