### PR TITLE
fix: update node version in GHA workflow

### DIFF
--- a/.github/workflows/reusable_semantic_release.yaml
+++ b/.github/workflows/reusable_semantic_release.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "21.4.0"
+          node-version: "24.9.0"
       - name: Write package.json
         uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
         with:


### PR DESCRIPTION
This pull request updates the Node.js version used in the GitHub Actions workflow to ensure compatibility with newer dependencies and features.

* CI configuration update:
  * [`.github/workflows/reusable_semantic_release.yaml`](diffhunk://#diff-9e8960dc00dd3d6f18d42e50bf9a8e89b8273759d83eb38504efaae3ff091e49L33-R33): Changed the `node-version` in the workflow from `21.4.0` to `24.9.0` to use the latest stable Node.js release.