### PR TITLE
chore(chart): bump image tags

### DIFF
--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -240,7 +240,7 @@ helm show values diode/diode
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuth.image.tag | string | `"1.5.0"` | image tag |
+| diodeAuth.image.tag | string | `"1.6.1"` | image tag |
 | diodeAuth.replicaCount | int | `1` | replica count |
 | diodeAuth.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeAuth.serviceAccount.create | bool | `true` | create service account |
@@ -248,7 +248,7 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuthBootstrap.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuthBootstrap.image.tag | string | `"1.5.0"` | image tag |
+| diodeAuthBootstrap.image.tag | string | `"1.6.1"` | image tag |
 | diodeAuthBootstrap.job.annotations | object | `{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-weight":"2"}` | annotations to add to the auth bootstrap job |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
 | diodeAuthBootstrap.job.extraInitContainers | string or list | `""` | additional initContainers to run during bootstrap (may contain templating instructions) |
@@ -268,7 +268,7 @@ helm show values diode/diode
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeIngester.image.repository | string | `"docker.io/netboxlabs/diode-ingester"` | image repository |
-| diodeIngester.image.tag | string | `"1.5.0"` | image tag |
+| diodeIngester.image.tag | string | `"1.7.1"` | image tag |
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
@@ -300,7 +300,7 @@ helm show values diode/diode
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.image.repository | string | `"docker.io/netboxlabs/diode-reconciler"` | image repository |
-| diodeReconciler.image.tag | string | `"1.5.0"` | image tag |
+| diodeReconciler.image.tag | string | `"1.7.1"` | image tag |
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeReconciler.serviceAccount.create | bool | `true` | create service account |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -66,7 +66,7 @@ diodeAuth:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.5.0
+    tag: 1.6.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -112,7 +112,7 @@ diodeAuthBootstrap:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.5.0
+    tag: 1.6.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -135,7 +135,7 @@ diodeIngester:
     # -- image repository
     repository: docker.io/netboxlabs/diode-ingester
     # -- image tag
-    tag: 1.5.0
+    tag: 1.7.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -188,7 +188,7 @@ diodeReconciler:
     # -- image repository
     repository: docker.io/netboxlabs/diode-reconciler
     # -- image tag
-    tag: 1.5.0
+    tag: 1.7.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy


### PR DESCRIPTION
Provided new patch image tag predicted to be released in next run.

This pull request updates the default container image tags for several components in the Diode Helm chart to newer versions. Both the documentation (`README.md`) and the default values file (`values.yaml`) are updated to reflect these changes. This ensures that new deployments will use the latest recommended images for improved features, bug fixes, and security.

**Image tag updates:**

* Updated `diodeAuth` and `diodeAuthBootstrap` image tags from `1.5.0` to `1.6.1` in both `charts/diode/README.md` and `charts/diode/values.yaml`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L243-R251) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L69-R69) [[3]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L115-R115)
* Updated `diodeIngester` image tag from `1.5.0` to `1.7.1` in both `charts/diode/README.md` and `charts/diode/values.yaml`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L271-R271) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L138-R138)
* Updated `diodeReconciler` image tag from `1.5.0` to `1.7.1` in both `charts/diode/README.md` and `charts/diode/values.yaml`. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L303-R303) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L191-R191)