### PR TITLE
fix: enhance server release workflow

### DIFF
--- a/.github/workflows/reusable_semantic_release_get_next_version.yaml
+++ b/.github/workflows/reusable_semantic_release_get_next_version.yaml
@@ -30,6 +30,9 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.app_dir }}
+    env:
+      APP_NAME: ${{ inputs.app_name }}
+      APP_DIR: ${{ inputs.app_dir }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -38,11 +41,11 @@ jobs:
       - name: Write package.json
         uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
         with:
-          path: ${{ inputs.app_dir }}/package.json
+          path: ${{ env.APP_DIR }}/package.json
           write-mode: overwrite
           contents: |
             {
-              "name": "${{ inputs.app_name }}",
+              "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
@@ -56,14 +59,14 @@ jobs:
       - name: Write .releaserc.json
         uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
         with:
-          path: ${{ inputs.app_dir }}/.releaserc.json
+          path: ${{ env.APP_DIR }}/.releaserc.json
           write-mode: overwrite
           contents: |
             {
               "branches": "release",
               "repositoryUrl": "https://github.com/netboxlabs/diode",
               "debug": "true",
-              "tagFormat": "${{ inputs.app_name }}/v${version}",
+              "tagFormat": "${{ env.APP_NAME }}/v${version}",
               "plugins": [
                 ["semantic-release-export-data"],
                 ["@semantic-release/commit-analyzer", {
@@ -105,12 +108,28 @@ jobs:
         id: short-sha
         run: echo "short-sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
       - name: Set release version
+        if: steps.get-next-version.outputs.new-release-published != ''
         id: release-version
         env:
+          SHORT_SHA: ${{ steps.short-sha.outputs.short-sha }}
           NEXT_RELEASE_VERSION: ${{ steps.get-next-version.outputs.new-release-version }}
-          APP_NAME: ${{ inputs.app_name }}
         run: |
           echo "release-version=`echo $NEXT_RELEASE_VERSION | sed 's/${APP_NAME}-v//g'`" >> $GITHUB_OUTPUT
+          
+          # store version in file for this app
+          mkdir -p versions
+          echo "$NEXT_RELEASE_VERSION" > "versions/${{ env.APP_NAME}}_${{ env.SHORT_SHA }}.txt"
+
+      - name: Upload version artifact
+        if: steps.get-next-version.outputs.new-release-published != ''
+        uses: actions/upload-artifact@v4
+        env:
+          SHORT_SHA: ${{ steps.short-sha.outputs.short-sha }}
+        with:
+          name: version-${{ env.APP_NAME }}_${{ env.SHORT_SHA }}
+          path: ${{ env.APP_DIR }}/versions/${{ env.APP_NAME }}_${{ env.SHORT_SHA }}.txt
+          retention-days: 1
+
     outputs:
       new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
       new-release-version: ${{ steps.release-version.outputs.release-version }}

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -59,11 +59,31 @@ jobs:
         app: ${{ fromJSON(needs.setup.outputs.apps) }}
     if: needs.get-next-version.outputs.new-release-published == 'true'
     env:
-      BUILD_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
-      BUILD_COMMIT: ${{ needs.get-next-version.outputs.short-sha }}
+      APP_NAME: diode-${{ matrix.app }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Get short sha
+        id: short-sha
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Download version artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: version-${{ env.APP_NAME }}_${{ env.SHORT_SHA }}
+          path: ./versions
+
+      - name: Set build version
+        run: |
+          BUILD_VERSION=$(cat ./versions/${{ env.APP_NAME }}_${{ env.SHORT_SHA }}.txt)
+          # error if BUILD_VERSION is empty
+          if [ -z "$BUILD_VERSION" ]; then
+            echo "BUILD_VERSION is empty, exiting"
+            exit 1
+          fi
+          echo "BUILD_VERSION=${BUILD_VERSION}" >> $GITHUB_ENV
+          echo "BUILD_COMMIT=${{ env.SHORT_SHA }}" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve how app versioning is handled and shared between jobs. The main changes introduce the use of environment variables for consistency, automate writing and uploading version files as artifacts, and update the downstream release workflow to consume these artifacts for more reliable version management.

**Workflow improvements for versioning and artifact management:**

* Added environment variables (`APP_NAME` and `APP_DIR`) to jobs in `.github/workflows/reusable_semantic_release_get_next_version.yaml` to ensure consistent usage throughout the workflow.
* Updated steps that write `package.json` and `.releaserc.json` to use the new environment variables instead of direct inputs, making the workflow more robust and easier to maintain. [[1]](diffhunk://#diff-1910d3a5a12c77bb4295e64ce34833f3cda1a473edeb78ac7b610710712c32a7L41-R48) [[2]](diffhunk://#diff-1910d3a5a12c77bb4295e64ce34833f3cda1a473edeb78ac7b610710712c32a7L59-R69)

**Automated version file creation and artifact upload:**

* After determining the next release version, the workflow now writes the version to a file named with the app name and short SHA, and uploads this file as an artifact for downstream jobs to consume.

**Consumption of version artifact in the release workflow:**

* The `server-release.yaml` workflow now downloads the version artifact, reads the version from the file, and sets it as an environment variable for the build. This ensures the release uses the correct version and commit information, and adds error handling if the version is missing.