### PR TITLE
fix(gha): update JFrog build metadata to include image digest

### DIFF
--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -140,7 +140,9 @@ jobs:
 
       - name: Create and publish JFrog build
         run: |
-          echo '${{ steps.docker-build.outputs.metadata }}' > build-metadata
+          DIGEST="${{ steps.docker-build.outputs.digest }}"
+          IMAGE_TAG="netboxlabs.jfrog.io/${{ env.JF_REPOSITORY }}/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }}@${DIGEST}"
+          echo "${IMAGE_TAG}" > build-metadata
           jf rt build-docker-create ${{ env.JF_REPOSITORY }} --image-file build-metadata --build-name ${{ env.APP_NAME }} --build-number ${{ env.BUILD_VERSION }}
           jf rt build-publish ${{ env.APP_NAME }} ${{ env.BUILD_VERSION }}
 


### PR DESCRIPTION
This pull request updates the publishing workflow for JFrog builds to ensure the correct Docker image tag, including the digest, is used when creating the build metadata. This helps improve traceability and reproducibility of builds.

**Workflow improvements:**

* Updated the build metadata in `.github/workflows/server-release.yaml` to include the full Docker image tag with digest, rather than just the metadata output, ensuring accurate image identification in JFrog.