### PR TITLE
chore: update Go version to 1.25 and Alpine base image to 3.22

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -24,8 +24,8 @@ jobs:
           go-version: '1.25.x'
           check-latest: true
       - name: Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
+        uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 #v9.1.0
         with:
-          version: v2.1
+          version: v2.6
           working-directory: diode-server
           args: --config ../.github/golangci.yaml

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -16,7 +16,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   JF_REPOSITORY: obs-builds
 
 permissions:

--- a/diode-server/docker/Dockerfile-build
+++ b/diode-server/docker/Dockerfile-build
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
@@ -18,7 +18,7 @@ RUN --mount=target=. \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/authmanager ./cmd/authmanager
 
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache jq
 

--- a/diode-server/docker/Dockerfile-build.ingester
+++ b/diode-server/docker/Dockerfile-build.ingester
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 

--- a/diode-server/docker/Dockerfile-build.reconciler
+++ b/diode-server/docker/Dockerfile-build.reconciler
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 

--- a/diode-server/docker/Dockerfile.auth
+++ b/diode-server/docker/Dockerfile.auth
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache jq
 

--- a/diode-server/go.mod
+++ b/diode-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/diode/diode-server
 
-go 1.24.3
+go 1.25.4
 
 require (
 	github.com/MicahParks/keyfunc/v3 v3.3.11


### PR DESCRIPTION
This pull request updates the project to use Go version 1.25 across all workflows, Dockerfiles, and the module definition. Additionally, it upgrades the Alpine Linux base image for the authentication service from version 3.21 to 3.22. These changes ensure the project is using the latest supported Go and Alpine versions for improved stability and security.

**Go version upgrade:**

* Updated Go version to `1.25` in all GitHub workflow files, including `.github/workflows/go-test.yaml`, `.github/workflows/golangci-lint.yaml`, and `.github/workflows/server-release.yaml`. [[1]](diffhunk://#diff-459772e2288eadce428ea0649a84579e92ebb7ac501a4b06b99415d3bc892314L35-R35) [[2]](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0L24-R24) [[3]](diffhunk://#diff-99ac821f1014ee4b214339baa517b7b747d78a8ea51ddf2d734ca0d8d831dc1fL19-R19)
* Changed Go version argument to `1.25` in all Dockerfiles: `diode-server/docker/Dockerfile-build`, `diode-server/docker/Dockerfile-build.auth`, `diode-server/docker/Dockerfile-build.ingester`, and `diode-server/docker/Dockerfile-build.reconciler`. [[1]](diffhunk://#diff-8515511e0d541c06fb4d4f37e30d48249e5ded4e801b70e2b7e904b5f92a5113L1-R1) [[2]](diffhunk://#diff-e0d6ee70e9f6f939273a84c6edaf3b2a6a2b7c36d289a856149fae31832fa56cL1-R1) [[3]](diffhunk://#diff-8515511e0d541c06fb4d4f37e30d48249e5ded4e801b70e2b7e904b5f92a5113L1-R1) [[4]](diffhunk://#diff-b7ea1a2e2a50e01bd94630121d42f119077e46e63276e9f2d57acd15b392205aL1-R1)
* Updated Go version in `diode-server/go.mod` to `1.25.4`.

**Alpine Linux base image upgrade:**

* Changed Alpine base image from `3.21` to `3.22` in `diode-server/docker/Dockerfile-build.auth` and `diode-server/docker/Dockerfile.auth` for the authentication service. [[1]](diffhunk://#diff-e0d6ee70e9f6f939273a84c6edaf3b2a6a2b7c36d289a856149fae31832fa56cL21-R21) [[2]](diffhunk://#diff-e2c96e42912145147aab195db4e37ea8a5ffb68cbe1c4e189f53d33625af1c92L1-R1)