### PR TITLE
feat: add support for extra volumes and volume mounts in pods

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: "1.10.0"
+version: "1.11.0"
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -237,6 +237,8 @@ helm show values diode/diode
 | diodeAuth.enabled | bool | `true` | enabled |
 | diodeAuth.extraEnvs | string or list | `[]` | extra environment variables to be set on containers' `env` section |
 | diodeAuth.extraInitContainers | string or list | `""` | additional containers to run before auth finishes initializing (may contain templating instructions) |
+| diodeAuth.extraVolumeMounts | string or list | `[]` | additional volumes to mount in the container (may contain templating instructions) |
+| diodeAuth.extraVolumes | string or list | `[]` | additional volumes to define for the container (may contain templating instructions) |
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
@@ -252,6 +254,8 @@ helm show values diode/diode
 | diodeAuthBootstrap.job.annotations | object | `{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-weight":"2"}` | annotations to add to the auth bootstrap job |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
 | diodeAuthBootstrap.job.extraInitContainers | string or list | `""` | additional initContainers to run during bootstrap (may contain templating instructions) |
+| diodeAuthBootstrap.job.extraVolumeMounts | string or list | `[]` | additional volumes to mount in the container (may contain templating instructions) |
+| diodeAuthBootstrap.job.extraVolumes | string or list | `[]` | additional volumes to define for the container (may contain templating instructions) |
 | diodeIngester.annotations | object | `{}` | annotations to add to the ingester deployment |
 | diodeIngester.config.loggingLevel | string | `"INFO"` | logging level |
 | diodeIngester.config.redisStreamDb | int | `1` | redis stream db |
@@ -264,6 +268,8 @@ helm show values diode/diode
 | diodeIngester.existingSecret | string | `"diode-ingester-secret"` | existing secret name |
 | diodeIngester.extraEnvs | string or list | `[]` | extra environment variables to be set on containers' `env` section |
 | diodeIngester.extraInitContainers | string or list | `""` | additional containers to run before the ingester finishes initializing (may contain templating instructions) |
+| diodeIngester.extraVolumeMounts | string or list | `[]` | additional volumes to mount in the container (may contain templating instructions) |
+| diodeIngester.extraVolumes | string or list | `[]` | additional volumes to define for the container (may contain templating instructions) |
 | diodeIngester.grpc.serviceName | string | `"diode.v1.IngesterService"` | grpc service name |
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
@@ -296,6 +302,8 @@ helm show values diode/diode
 | diodeReconciler.existingSecret | string | `"diode-reconciler-secret"` | existing secret name |
 | diodeReconciler.extraEnvs | string or list | `[]` | extra environment variables to be set on containers' `env` section |
 | diodeReconciler.extraInitContainers | string or list | `""` | additional containers to run before the reconciler finishes initializing (may contain templating instructions) |
+| diodeReconciler.extraVolumeMounts | string or list | `[]` | additional volumes to mount in the container (may contain templating instructions) |
+| diodeReconciler.extraVolumes | string or list | `[]` | additional volumes to define for the container (may contain templating instructions) |
 | diodeReconciler.grpc.serviceName | string | `"diode.v1.ReconcilerService"` | grpc service name |
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |

--- a/charts/diode/templates/diode-auth-bootstrap-job.yaml
+++ b/charts/diode/templates/diode-auth-bootstrap-job.yaml
@@ -58,10 +58,16 @@ spec:
             - name: HYDRA_ADMIN_URL
               value: {{ include "diode.hydra.admin.url" . }}
           volumeMounts:
+            {{- if .Values.diodeAuthBootstrap.job.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.diodeAuthBootstrap.job.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
             - name: oauth2-secret
               mountPath: /etc/config/oauth2/client
               readOnly: true
       volumes:
+        {{- if .Values.diodeAuthBootstrap.job.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.diodeAuthBootstrap.job.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
         - name: oauth2-secret
           secret:
             secretName: {{ include "diode.auth.oauth2.secret" . }}

--- a/charts/diode/templates/diode-auth-deployment.yaml
+++ b/charts/diode/templates/diode-auth-deployment.yaml
@@ -78,4 +78,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "diode.auth.configmap" . }}
+          {{- if .Values.diodeAuth.extraVolumeMounts }}
+          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.diodeAuth.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+      {{- if .Values.diodeAuth.extraVolumes }}
+      volumes: {{- include "common.tplvalues.render" (dict "value" .Values.diodeAuth.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
 {{- end }} 

--- a/charts/diode/templates/diode-ingester-deployment.yaml
+++ b/charts/diode/templates/diode-ingester-deployment.yaml
@@ -78,5 +78,10 @@ spec:
                 name: {{ include "diode.ingester.configmap" . }}
             - secretRef:
                 name: {{ include "diode.ingester.secret" . }}
-
+          {{- if .Values.diodeIngester.extraVolumeMounts }}
+          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.diodeIngester.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+      {{- if .Values.diodeIngester.extraVolumes }}
+      volumes: {{- include "common.tplvalues.render" (dict "value" .Values.diodeIngester.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
 {{- end }} 

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -103,10 +103,16 @@ spec:
             - secretRef:
                 name: {{ include "diode.auth.oauth2.secret" . }}
           volumeMounts:
+            {{- if .Values.diodeReconciler.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.diodeReconciler.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
             - name: oauth2-secret
               mountPath: /etc/config/oauth2/client
               readOnly: true
       volumes:
+        {{- if .Values.diodeReconciler.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.diodeReconciler.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
         - name: oauth2-secret
           secret:
             secretName: {{ include "diode.auth.oauth2.secret" . }}

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -103,6 +103,10 @@ diodeAuth:
   extraEnvs: []
   # -- (string or list) additional containers to run before auth finishes initializing (may contain templating instructions)
   extraInitContainers: ""
+  # -- (string or list) additional volumes to define for the container (may contain templating instructions)
+  extraVolumes: []
+  # -- (string or list) additional volumes to mount in the container (may contain templating instructions)
+  extraVolumeMounts: []
   # -- annotations to add to the auth deployment
   annotations: {}
   config:
@@ -139,6 +143,10 @@ diodeAuthBootstrap:
       "helm.sh/hook-weight": "2"
     # -- (string or list) additional initContainers to run during bootstrap (may contain templating instructions)
     extraInitContainers: ""
+    # -- (string or list) additional volumes to define for the container (may contain templating instructions)
+    extraVolumes: []
+    # -- (string or list) additional volumes to mount in the container (may contain templating instructions)
+    extraVolumeMounts: []
 
 # Diode Ingester configuration
 diodeIngester:
@@ -177,6 +185,10 @@ diodeIngester:
   extraEnvs: []
   # -- (string or list) additional containers to run before the ingester finishes initializing (may contain templating instructions)
   extraInitContainers: ""
+  # -- (string or list) additional volumes to define for the container (may contain templating instructions)
+  extraVolumes: []
+  # -- (string or list) additional volumes to mount in the container (may contain templating instructions)
+  extraVolumeMounts: []
   # -- annotations to add to the ingester deployment
   annotations: {}
   config:
@@ -230,6 +242,11 @@ diodeReconciler:
   extraEnvs: []
   # -- (string or list) additional containers to run before the reconciler finishes initializing (may contain templating instructions)
   extraInitContainers: ""
+  # -- (string or list) additional volumes to define for the container (may contain templating instructions)
+  extraVolumes: []
+  # -- (string or list) additional volumes to mount in the container (may contain templating instructions)
+  extraVolumeMounts: []
+  # -- annotations to add to the auth deployment
   # -- annotations to add to the reconciler deployment
   annotations: {}
   config:


### PR DESCRIPTION
TL;DR: add support for configuring volumes and volume mounts added to the various diode pods. This is to support mounting secrets or other data, for example to provide a cert and key to be used for mTLS with external Redis.

---

This pull request updates the Diode Helm chart to version 1.11.0 and introduces new configuration options to support custom volume mounts and volumes for the Auth, Ingester, Reconciler, and Auth Bootstrap components. These enhancements provide greater flexibility for mounting additional files or secrets into the relevant containers and jobs.

Key changes:

**Feature: Additional Volume and VolumeMount Support**
* Added `extraVolumes` and `extraVolumeMounts` options to `diodeAuth`, `diodeIngester`, `diodeReconciler`, and `diodeAuthBootstrap.job` in `values.yaml` to allow users to specify custom volumes and mounts via Helm values. [[1]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R106-R109) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R146-R149) [[3]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R188-R191) [[4]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2R245-R249)
* Updated the corresponding deployment and job templates (`diode-auth-deployment.yaml`, `diode-ingester-deployment.yaml`, `diode-reconciler-deployment.yaml`, `diode-auth-bootstrap-job.yaml`) to render these new volume and mount definitions when provided. [[1]](diffhunk://#diff-f7aefdf5ce4585299408ce0cacfffda7b0f5d2494b11c306f174c4eb249e5bbdR81-R86) [[2]](diffhunk://#diff-8bed87c066be5a33d2a20ef23520641413633a704e236fb966cfff3050c62885L81-R86) [[3]](diffhunk://#diff-e57ae474813dbc1e247e171afee57e2d70985f197b049eda411d61b417a6ba78R106-R115) [[4]](diffhunk://#diff-9837c846428ee54aba4b1d0fec6264a4f6396e9860f58bb28528a908f4e779a1R61-R70)

**Documentation and Chart Metadata**
* Updated `README.md` to document the new `extraVolumes` and `extraVolumeMounts` options for each component, ensuring users are aware of the new configuration capabilities. [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R240-R241) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R257-R258) [[3]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R271-R272) [[4]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961R305-R306)
* Bumped the chart version from 1.10.0 to 1.11.0 in both `Chart.yaml` and the version badge in `README.md` to reflect these changes. [[1]](diffhunk://#diff-b886313e1c0741f2c72a92382362d33b52e225680751f83cd06d7f1e542d8bc5L5-R5) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5)