### PR TITLE
chore(chart): bump diode image tags

### DIFF
--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -79,7 +79,7 @@ diodeAuth:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.11.0
+    tag: 1.11.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -129,7 +129,7 @@ diodeAuthBootstrap:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.11.0
+    tag: 1.11.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -156,7 +156,7 @@ diodeIngester:
     # -- image repository
     repository: docker.io/netboxlabs/diode-ingester
     # -- image tag
-    tag: 1.12.0
+    tag: 1.12.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -213,7 +213,7 @@ diodeReconciler:
     # -- image repository
     repository: docker.io/netboxlabs/diode-reconciler
     # -- image tag
-    tag: 1.12.0
+    tag: 1.12.1
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy


### PR DESCRIPTION
This pull request updates the container image versions for several components in the `charts/diode/values.yaml` file to ensure the deployment uses the latest patch releases.

Image version updates:

* Updated `diodeAuth` image tag from `1.11.0` to `1.11.1` to use the latest patch version.
* Updated `diodeAuthBootstrap` image tag from `1.11.0` to `1.11.1` for consistency with `diodeAuth`.
* Updated `diodeIngester` image tag from `1.12.0` to `1.12.1` to include the latest fixes.
* Updated `diodeReconciler` image tag from `1.12.0` to `1.12.1` to ensure up-to-date deployment.