### PR TITLE
Update documentation to mark `rir` as required for ASN ingestion

### DIFF
--- a/docs/diode-proto.md
+++ b/docs/diode-proto.md
@@ -229,7 +229,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | asn | [int64](#int64) |  |  |
-| rir | [RIR](#diode-v1-RIR) | optional |  |
+| rir | [RIR](#diode-v1-RIR) |  |  |
 | tenant | [Tenant](#diode-v1-Tenant) | optional |  |
 | description | [string](#string) | optional |  |
 | comments | [string](#string) | optional |  |


### PR DESCRIPTION
`rir`is required for ASN
<img width="1627" height="452" alt="image" src="https://github.com/user-attachments/assets/bedfd12d-2252-4a8b-ba63-0dce09ebcc34" />
