### PR TITLE
chore(chart): bump diode version to 1.13.0 and update image tags

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: "1.12.0"
+version: "1.13.0"
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Diode
 
-![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -207,7 +207,7 @@ helm show values diode/diode
 | https://charts.bitnami.com/bitnami | postgresql | 16.6.3 |
 | https://charts.bitnami.com/bitnami | redis | 20.11.5 |
 | https://charts.jetstack.io | cert-manager | v1.12.0 |
-| https://k8s.ory.sh/helm/charts | hydra | 0.53.0 |
+| https://k8s.ory.sh/helm/charts | hydra | 0.60.0 |
 | https://kubernetes.github.io/ingress-nginx | ingress-nginx | 4.12.1 |
 
 ## Values
@@ -242,7 +242,7 @@ helm show values diode/diode
 | diodeAuth.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuth.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuth.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuth.image.tag | string | `"1.11.0"` | image tag |
+| diodeAuth.image.tag | string | `"1.12.0"` | image tag |
 | diodeAuth.replicaCount | int | `1` | replica count |
 | diodeAuth.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeAuth.serviceAccount.create | bool | `true` | create service account |
@@ -250,7 +250,7 @@ helm show values diode/diode
 | diodeAuthBootstrap.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeAuthBootstrap.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeAuthBootstrap.image.repository | string | `"docker.io/netboxlabs/diode-auth"` | image repository |
-| diodeAuthBootstrap.image.tag | string | `"1.11.0"` | image tag |
+| diodeAuthBootstrap.image.tag | string | `"1.12.0"` | image tag |
 | diodeAuthBootstrap.job.annotations | object | `{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-weight":"2"}` | annotations to add to the auth bootstrap job |
 | diodeAuthBootstrap.job.backoffLimit | int | `20` | backoff limit |
 | diodeAuthBootstrap.job.extraInitContainers | string or list | `""` | additional initContainers to run during bootstrap (may contain templating instructions) |
@@ -274,7 +274,7 @@ helm show values diode/diode
 | diodeIngester.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeIngester.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeIngester.image.repository | string | `"docker.io/netboxlabs/diode-ingester"` | image repository |
-| diodeIngester.image.tag | string | `"1.12.0"` | image tag |
+| diodeIngester.image.tag | string | `"1.13.0"` | image tag |
 | diodeIngester.replicaCount | int | `1` | replica count |
 | diodeIngester.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeIngester.serviceAccount.create | bool | `true` | create service account |
@@ -308,7 +308,7 @@ helm show values diode/diode
 | diodeReconciler.image.imagePullSecrets | list | `[]` | secrets with credentials to pull images from a private registry |
 | diodeReconciler.image.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | diodeReconciler.image.repository | string | `"docker.io/netboxlabs/diode-reconciler"` | image repository |
-| diodeReconciler.image.tag | string | `"1.12.0"` | image tag |
+| diodeReconciler.image.tag | string | `"1.13.0"` | image tag |
 | diodeReconciler.replicaCount | int | `1` | replica count |
 | diodeReconciler.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | diodeReconciler.serviceAccount.create | bool | `true` | create service account |

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -79,7 +79,7 @@ diodeAuth:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.11.1
+    tag: 1.12.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -129,7 +129,7 @@ diodeAuthBootstrap:
     # -- image repository
     repository: docker.io/netboxlabs/diode-auth
     # -- image tag
-    tag: 1.11.1
+    tag: 1.12.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -156,7 +156,7 @@ diodeIngester:
     # -- image repository
     repository: docker.io/netboxlabs/diode-ingester
     # -- image tag
-    tag: 1.12.1
+    tag: 1.13.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy
@@ -213,7 +213,7 @@ diodeReconciler:
     # -- image repository
     repository: docker.io/netboxlabs/diode-reconciler
     # -- image tag
-    tag: 1.12.1
+    tag: 1.13.0
     # -- secrets with credentials to pull images from a private registry
     imagePullSecrets: []
     # -- pull policy


### PR DESCRIPTION
This pull request updates the Diode Helm chart and related documentation to use newer component versions and images. The main changes are version bumps for the chart itself, its dependencies, and the Docker images for several Diode components.

**Version and image updates:**

- Chart and documentation versioning:
  * Bumped the chart version in `Chart.yaml` from `1.12.0` to `1.13.0`.
  * Updated version badges and image tags in `README.md` to reflect the new chart and component versions [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L5-R5) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L245-R253) [[3]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L277-R277) [[4]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L311-R311).

- Dependency updates:
  * Upgraded the `hydra` chart dependency from version `0.53.0` to `0.60.0` in the documentation.

- Docker image updates:
  * Updated `diodeAuth` and `diodeAuthBootstrap` image tags from `1.11.0`/`1.11.1` to `1.12.0` in both `README.md` and `values.yaml` [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L245-R253) [[2]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L82-R82) [[3]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L132-R132).
  * Updated `diodeIngester` and `diodeReconciler` image tags from `1.12.0`/`1.12.1` to `1.13.0` in both `README.md` and `values.yaml` [[1]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L277-R277) [[2]](diffhunk://#diff-3e2bb6714248fbff7661428c3bdf1fa2bf38c239fbad4af77305f34439386961L311-R311) [[3]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L159-R159) [[4]](diffhunk://#diff-e20229573f80e0fb2015a23c7a3c8419e21c7df15f7255f61871f1fde14da5e2L216-R216).