### PR TITLE
fix: make index creation idempotent in entity hash lookup migration

### DIFF
--- a/diode-server/dbstore/postgres/migrations/20251211000001_optimize_entity_hash_lookup.sql
+++ b/diode-server/dbstore/postgres/migrations/20251211000001_optimize_entity_hash_lookup.sql
@@ -1,15 +1,14 @@
 -- +goose Up
 
 -- Composite index for filtering by entity_hash and ordering by created_at
-CREATE INDEX idx_ingestion_logs_entity_hash_created_at 
+CREATE INDEX IF NOT EXISTS idx_ingestion_logs_entity_hash_created_at
 ON ingestion_logs(entity_hash, created_at DESC);
 
 -- Composite index to speed up latest change_set lookup per ingestion_log
-CREATE INDEX idx_change_sets_ingestion_log_id_id
+CREATE INDEX IF NOT EXISTS idx_change_sets_ingestion_log_id_id
 ON change_sets (ingestion_log_id, id DESC)
 INCLUDE (branch_id);
 -- +goose Down
 
 DROP INDEX IF EXISTS idx_change_sets_ingestion_log_id_id;
 DROP INDEX IF EXISTS idx_ingestion_logs_entity_hash_created_at;
-


### PR DESCRIPTION
This pull request updates a database migration script to make index creation idempotent, preventing errors if the indexes already exist. This improves the reliability of running migrations multiple times.

Database migration improvements:

* Modified the index creation statements in `20251211000001_optimize_entity_hash_lookup.sql` to use `CREATE INDEX IF NOT EXISTS` instead of `CREATE INDEX`, ensuring migrations can be safely re-run without causing errors.