### PR TITLE
feat(matching): add fuzzy string matching package

### DIFF
--- a/diode-server/go.mod
+++ b/diode-server/go.mod
@@ -36,9 +36,11 @@ require (
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
 	golang.org/x/oauth2 v0.33.0
+	golang.org/x/text v0.31.0
 	golang.org/x/time v0.11.0
 	google.golang.org/grpc v1.72.1
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.37.1
 )
 
@@ -117,10 +119,8 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250519155744-55703ea1f237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.65.8 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/diode-server/matching/config.go
+++ b/diode-server/matching/config.go
@@ -68,6 +68,8 @@ func (c *Config) GetFinalRules() map[string]*EntityMatchingRule {
 
 	// Step 2: Apply global settings (only when not explicitly set)
 	for _, rule := range result {
+		// MinConfidence == 0 is treated as "use global default".
+		// To accept very low confidence matches, use a small positive value (e.g., 0.1).
 		if rule.MinConfidence == 0 {
 			rule.MinConfidence = MatchConfidence(c.GlobalSettings.DefaultMinConfidence)
 		}
@@ -107,7 +109,8 @@ func (c *Config) ApplyOverrides(_ map[string]*EntityMatchingRule) map[string]*En
 
 // mergeEntityRule merges override settings into an existing entity rule
 func (c *Config) mergeEntityRule(existing *EntityMatchingRule, override *EntityMatchingRule) {
-	// Override top-level settings
+	// Override MinConfidence only if explicitly set (> 0).
+	// MinConfidence == 0 is treated as "not set" / use existing value.
 	if override.MinConfidence > 0 {
 		existing.MinConfidence = override.MinConfidence
 	}

--- a/diode-server/matching/config.go
+++ b/diode-server/matching/config.go
@@ -1,0 +1,126 @@
+package matching
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the configuration for entity matching
+type Config struct {
+	// Global settings
+	GlobalSettings GlobalMatchingSettings `yaml:"global_settings"`
+
+	// Default entity rules (YAML-first approach - these are the primary source of truth)
+	DefaultEntityRules map[string]EntityMatchingRule `yaml:"default_entity_rules"`
+
+	// Entity-specific overrides (for environment-specific adjustments)
+	EntityOverrides map[string]EntityMatchingRule `yaml:"entity_overrides"`
+}
+
+// GlobalMatchingSettings defines global matching behavior
+type GlobalMatchingSettings struct {
+	DefaultMinConfidence     float64 `yaml:"default_min_confidence"`
+	DefaultRequireAllPrimary bool    `yaml:"default_require_all_primary"`
+	EnableFuzzyMatching      bool    `yaml:"enable_fuzzy_matching"`
+	DefaultFuzzyThreshold    float64 `yaml:"default_fuzzy_threshold"`
+}
+
+// LoadMatchingConfig loads matching configuration from file
+func LoadMatchingConfig(configPath string) (*Config, error) {
+	if configPath == "" {
+		return nil, fmt.Errorf("configuration file path is required")
+	}
+
+	// Check if config file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("configuration file not found: %s", configPath)
+	}
+
+	// Read config file
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
+	}
+
+	// Parse YAML
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file %s: %w", configPath, err)
+	}
+
+	return &config, nil
+}
+
+// GetFinalRules processes YAML configuration and returns final matching rules
+func (c *Config) GetFinalRules() map[string]*EntityMatchingRule {
+	result := make(map[string]*EntityMatchingRule)
+
+	// Step 1: Start with YAML default rules (primary source of truth)
+	for entityType, rule := range c.DefaultEntityRules {
+		if entityType == "*" {
+			continue // Skip universal rule for now
+		}
+		newRule := rule // Copy the rule
+		result[entityType] = &newRule
+	}
+
+	// Step 2: Apply global settings
+	for _, rule := range result {
+		if rule.MinConfidence == 0 {
+			rule.MinConfidence = MatchConfidence(c.GlobalSettings.DefaultMinConfidence)
+		}
+
+		if !rule.RequireAllPrimary {
+			rule.RequireAllPrimary = c.GlobalSettings.DefaultRequireAllPrimary
+		}
+	}
+
+	// Step 3: Apply entity-specific overrides (environment-specific adjustments)
+	for entityType, override := range c.EntityOverrides {
+		if existing, exists := result[entityType]; exists {
+			// Merge the override with existing rule
+			c.mergeEntityRule(existing, &override)
+		} else {
+			// Create new rule from override
+			newRule := override
+			result[entityType] = &newRule
+		}
+	}
+
+	return result
+}
+
+// ApplyWithDefaults is deprecated - use GetFinalRules() for pure YAML configuration
+func (c *Config) ApplyWithDefaults(_ map[string]*EntityMatchingRule) map[string]*EntityMatchingRule {
+	// Ignore auto-generated rules - YAML is now the only source of truth
+	return c.GetFinalRules()
+}
+
+// ApplyOverrides is kept for backward compatibility but delegates to GetFinalRules
+func (c *Config) ApplyOverrides(_ map[string]*EntityMatchingRule) map[string]*EntityMatchingRule {
+	// Ignore passed rules - YAML is now the only source of truth
+	return c.GetFinalRules()
+}
+
+// mergeEntityRule merges override settings into an existing entity rule
+func (c *Config) mergeEntityRule(existing *EntityMatchingRule, override *EntityMatchingRule) {
+	// Override top-level settings
+	if override.MinConfidence > 0 {
+		existing.MinConfidence = override.MinConfidence
+	}
+
+	existing.RequireAllPrimary = override.RequireAllPrimary
+
+	// Override field rules if provided
+	if len(override.PrimaryRules) > 0 {
+		existing.PrimaryRules = override.PrimaryRules
+	}
+	if len(override.SecondaryRules) > 0 {
+		existing.SecondaryRules = override.SecondaryRules
+	}
+	if len(override.FallbackRules) > 0 {
+		existing.FallbackRules = override.FallbackRules
+	}
+}

--- a/diode-server/matching/config.go
+++ b/diode-server/matching/config.go
@@ -111,7 +111,14 @@ func (c *Config) mergeEntityRule(existing *EntityMatchingRule, override *EntityM
 		existing.MinConfidence = override.MinConfidence
 	}
 
-	existing.RequireAllPrimary = override.RequireAllPrimary
+	// Only override RequireAllPrimary if explicitly set to true in override.
+	// Since YAML unmarshalling defaults omitted booleans to false, we cannot
+	// distinguish between "not set" and "explicitly set to false". To avoid
+	// accidentally clearing RequireAllPrimary when the override only intends
+	// to change other fields, we only apply it when true.
+	if override.RequireAllPrimary {
+		existing.RequireAllPrimary = true
+	}
 
 	// Override field rules if provided
 	if len(override.PrimaryRules) > 0 {

--- a/diode-server/matching/config.go
+++ b/diode-server/matching/config.go
@@ -66,14 +66,15 @@ func (c *Config) GetFinalRules() map[string]*EntityMatchingRule {
 		result[entityType] = &newRule
 	}
 
-	// Step 2: Apply global settings
+	// Step 2: Apply global settings (only when not explicitly set)
 	for _, rule := range result {
 		if rule.MinConfidence == 0 {
 			rule.MinConfidence = MatchConfidence(c.GlobalSettings.DefaultMinConfidence)
 		}
 
-		if !rule.RequireAllPrimary {
-			rule.RequireAllPrimary = c.GlobalSettings.DefaultRequireAllPrimary
+		// Only apply global default if RequireAllPrimary was not explicitly set (nil)
+		if rule.RequireAllPrimary == nil {
+			rule.SetRequireAllPrimary(c.GlobalSettings.DefaultRequireAllPrimary)
 		}
 	}
 
@@ -111,13 +112,9 @@ func (c *Config) mergeEntityRule(existing *EntityMatchingRule, override *EntityM
 		existing.MinConfidence = override.MinConfidence
 	}
 
-	// Only override RequireAllPrimary if explicitly set to true in override.
-	// Since YAML unmarshalling defaults omitted booleans to false, we cannot
-	// distinguish between "not set" and "explicitly set to false". To avoid
-	// accidentally clearing RequireAllPrimary when the override only intends
-	// to change other fields, we only apply it when true.
-	if override.RequireAllPrimary {
-		existing.RequireAllPrimary = true
+	// Override RequireAllPrimary only if explicitly set in override (not nil)
+	if override.RequireAllPrimary != nil {
+		existing.RequireAllPrimary = override.RequireAllPrimary
 	}
 
 	// Override field rules if provided

--- a/diode-server/matching/fuzzy.go
+++ b/diode-server/matching/fuzzy.go
@@ -1,0 +1,241 @@
+package matching
+
+import (
+	"math"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// FuzzyMatcher provides database-agnostic fuzzy string matching algorithms
+type FuzzyMatcher struct{}
+
+// NewFuzzyMatcher creates a new fuzzy matcher instance
+func NewFuzzyMatcher() *FuzzyMatcher {
+	return &FuzzyMatcher{}
+}
+
+// CalculateSimilarity calculates similarity between two strings using multiple algorithms
+// Returns a score between 0.0 and 1.0 where 1.0 is an exact match
+func (fm *FuzzyMatcher) CalculateSimilarity(s1, s2 string, options *FuzzyOptions) float64 {
+	if s1 == s2 {
+		return 1.0
+	}
+
+	if len(s1) == 0 || len(s2) == 0 {
+		return 0.0
+	}
+
+	// Apply normalization options
+	if options != nil {
+		if options.CaseIgnore {
+			s1 = strings.ToLower(s1)
+			s2 = strings.ToLower(s2)
+		}
+
+		if options.Normalize {
+			s1 = fm.normalizeString(s1)
+			s2 = fm.normalizeString(s2)
+		}
+	}
+
+	// Use Jaro-Winkler similarity which works well for names and identifiers
+	jaroWinkler := fm.jaroWinklerSimilarity(s1, s2)
+
+	// For very short strings or when Jaro-Winkler gives low scores,
+	// also consider Levenshtein distance
+	if len(s1) < 4 || len(s2) < 4 || jaroWinkler < 0.7 {
+		levenshtein := fm.levenshteinSimilarity(s1, s2)
+		// Take the maximum of both algorithms
+		return math.Max(jaroWinkler, levenshtein)
+	}
+
+	return jaroWinkler
+}
+
+// levenshteinDistance calculates the Levenshtein distance between two strings
+func (fm *FuzzyMatcher) levenshteinDistance(s1, s2 string) int {
+	if len(s1) == 0 {
+		return len(s2)
+	}
+	if len(s2) == 0 {
+		return len(s1)
+	}
+
+	// Create a matrix to store distances
+	matrix := make([][]int, len(s1)+1)
+	for i := range matrix {
+		matrix[i] = make([]int, len(s2)+1)
+	}
+
+	// Initialize first row and column
+	for i := 0; i <= len(s1); i++ {
+		matrix[i][0] = i
+	}
+	for j := 0; j <= len(s2); j++ {
+		matrix[0][j] = j
+	}
+
+	// Fill the matrix
+	for i := 1; i <= len(s1); i++ {
+		for j := 1; j <= len(s2); j++ {
+			cost := 0
+			if s1[i-1] != s2[j-1] {
+				cost = 1
+			}
+
+			matrix[i][j] = minInt(
+				minInt(matrix[i-1][j]+1, matrix[i][j-1]+1), // deletion, insertion
+				matrix[i-1][j-1]+cost,                      // substitution
+			)
+		}
+	}
+
+	return matrix[len(s1)][len(s2)]
+}
+
+// levenshteinSimilarity converts Levenshtein distance to similarity score (0.0-1.0)
+func (fm *FuzzyMatcher) levenshteinSimilarity(s1, s2 string) float64 {
+	distance := fm.levenshteinDistance(s1, s2)
+	maxLen := maxInt(len(s1), len(s2))
+	if maxLen == 0 {
+		return 1.0
+	}
+	return 1.0 - float64(distance)/float64(maxLen)
+}
+
+// jaroSimilarity calculates the Jaro similarity between two strings
+func (fm *FuzzyMatcher) jaroSimilarity(s1, s2 string) float64 {
+	if s1 == s2 {
+		return 1.0
+	}
+
+	len1, len2 := len(s1), len(s2)
+	if len1 == 0 || len2 == 0 {
+		return 0.0
+	}
+
+	// Calculate the match window
+	matchWindow := maxInt(len1, len2)/2 - 1
+	if matchWindow < 0 {
+		matchWindow = 0
+	}
+
+	s1Matches := make([]bool, len1)
+	s2Matches := make([]bool, len2)
+
+	matches := 0
+	transpositions := 0
+
+	// Find matches
+	for i := 0; i < len1; i++ {
+		start := maxInt(0, i-matchWindow)
+		end := minInt(i+matchWindow+1, len2)
+
+		for j := start; j < end; j++ {
+			if s2Matches[j] || s1[i] != s2[j] {
+				continue
+			}
+			s1Matches[i] = true
+			s2Matches[j] = true
+			matches++
+			break
+		}
+	}
+
+	if matches == 0 {
+		return 0.0
+	}
+
+	// Find transpositions
+	k := 0
+	for i := 0; i < len1; i++ {
+		if !s1Matches[i] {
+			continue
+		}
+		for !s2Matches[k] {
+			k++
+		}
+		if s1[i] != s2[k] {
+			transpositions++
+		}
+		k++
+	}
+
+	// Calculate Jaro similarity
+	jaro := (float64(matches)/float64(len1) +
+		float64(matches)/float64(len2) +
+		float64(matches-transpositions/2)/float64(matches)) / 3.0
+
+	return jaro
+}
+
+// jaroWinklerSimilarity calculates the Jaro-Winkler similarity between two strings
+// This gives more weight to strings that have a common prefix
+func (fm *FuzzyMatcher) jaroWinklerSimilarity(s1, s2 string) float64 {
+	jaro := fm.jaroSimilarity(s1, s2)
+
+	if jaro < 0.7 {
+		return jaro
+	}
+
+	// Calculate common prefix length (up to 4 characters)
+	prefixLen := 0
+	for i := 0; i < minInt(minInt(len(s1), len(s2)), 4); i++ {
+		if s1[i] == s2[i] {
+			prefixLen++
+		} else {
+			break
+		}
+	}
+
+	// Jaro-Winkler formula
+	return jaro + (0.1 * float64(prefixLen) * (1.0 - jaro))
+}
+
+// normalizeString performs Unicode normalization and removes extra whitespace/punctuation
+func (fm *FuzzyMatcher) normalizeString(s string) string {
+	// Perform Unicode normalization (NFC - canonical composition)
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	normalized, _, _ := transform.String(t, s)
+
+	// Remove extra whitespace and normalize punctuation
+	normalized = strings.TrimSpace(normalized)
+
+	// Replace multiple whitespace with single space
+	var result strings.Builder
+	var prevSpace bool
+
+	for _, r := range normalized {
+		if unicode.IsSpace(r) {
+			if !prevSpace {
+				result.WriteRune(' ')
+				prevSpace = true
+			}
+		} else {
+			result.WriteRune(r)
+			prevSpace = false
+		}
+	}
+
+	return strings.TrimSpace(result.String())
+}
+
+// minInt returns the minimum of two integers
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// maxInt returns the maximum of two integers
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/diode-server/matching/fuzzy_test.go
+++ b/diode-server/matching/fuzzy_test.go
@@ -1,0 +1,204 @@
+package matching
+
+import (
+	"testing"
+)
+
+func TestFuzzyMatcher(t *testing.T) {
+	fm := NewFuzzyMatcher()
+
+	tests := []struct {
+		name      string
+		s1        string
+		s2        string
+		options   *FuzzyOptions
+		expected  float64
+		threshold float64
+	}{
+		{
+			name:      "exact match",
+			s1:        "device-01",
+			s2:        "device-01",
+			options:   &FuzzyOptions{MinSimilarity: 0.8},
+			expected:  1.0,
+			threshold: 1.0,
+		},
+		{
+			name:      "case insensitive match",
+			s1:        "Device-01",
+			s2:        "device-01",
+			options:   &FuzzyOptions{MinSimilarity: 0.8, CaseIgnore: true},
+			expected:  1.0,
+			threshold: 1.0,
+		},
+		{
+			name:      "similar names (typo)",
+			s1:        "device-01",
+			s2:        "devise-01",
+			options:   &FuzzyOptions{MinSimilarity: 0.7},
+			expected:  0.85,
+			threshold: 0.8,
+		},
+		{
+			name:      "serial numbers with minor differences",
+			s1:        "ABC123DEF456",
+			s2:        "ABC123DF456",
+			options:   &FuzzyOptions{MinSimilarity: 0.8},
+			expected:  0.9,
+			threshold: 0.85,
+		},
+		{
+			name:      "completely different strings",
+			s1:        "device-north",
+			s2:        "switch-south",
+			options:   &FuzzyOptions{MinSimilarity: 0.7},
+			expected:  0.0,
+			threshold: 0.3,
+		},
+		{
+			name:      "normalized strings with punctuation",
+			s1:        "device.01.prod",
+			s2:        "device 01 prod",
+			options:   &FuzzyOptions{MinSimilarity: 0.8, Normalize: true},
+			expected:  0.95,
+			threshold: 0.9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			similarity := fm.CalculateSimilarity(tt.s1, tt.s2, tt.options)
+
+			if similarity < tt.threshold {
+				t.Errorf("CalculateSimilarity(%q, %q) = %f, want >= %f",
+					tt.s1, tt.s2, similarity, tt.threshold)
+			}
+
+			t.Logf("CalculateSimilarity(%q, %q) = %f", tt.s1, tt.s2, similarity)
+		})
+	}
+}
+
+func TestJaroWinklerSimilarity(t *testing.T) {
+	fm := NewFuzzyMatcher()
+
+	tests := []struct {
+		name     string
+		s1       string
+		s2       string
+		expected float64
+		delta    float64
+	}{
+		{
+			name:     "identical strings",
+			s1:       "test",
+			s2:       "test",
+			expected: 1.0,
+			delta:    0.001,
+		},
+		{
+			name:     "similar with common prefix",
+			s1:       "device-01",
+			s2:       "device-02",
+			expected: 0.9,
+			delta:    0.1,
+		},
+		{
+			name:     "completely different",
+			s1:       "abc",
+			s2:       "xyz",
+			expected: 0.0,
+			delta:    0.1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			similarity := fm.jaroWinklerSimilarity(tt.s1, tt.s2)
+
+			if similarity < tt.expected-tt.delta || similarity > tt.expected+tt.delta {
+				t.Errorf("jaroWinklerSimilarity(%q, %q) = %f, want %f ± %f",
+					tt.s1, tt.s2, similarity, tt.expected, tt.delta)
+			}
+		})
+	}
+}
+
+func TestLevenshteinDistance(t *testing.T) {
+	fm := NewFuzzyMatcher()
+
+	tests := []struct {
+		name     string
+		s1       string
+		s2       string
+		expected int
+	}{
+		{
+			name:     "identical strings",
+			s1:       "test",
+			s2:       "test",
+			expected: 0,
+		},
+		{
+			name:     "one character difference",
+			s1:       "test",
+			s2:       "best",
+			expected: 1,
+		},
+		{
+			name:     "insertion",
+			s1:       "test",
+			s2:       "tests",
+			expected: 1,
+		},
+		{
+			name:     "deletion",
+			s1:       "tests",
+			s2:       "test",
+			expected: 1,
+		},
+		{
+			name:     "empty strings",
+			s1:       "",
+			s2:       "abc",
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			distance := fm.levenshteinDistance(tt.s1, tt.s2)
+
+			if distance != tt.expected {
+				t.Errorf("levenshteinDistance(%q, %q) = %d, want %d",
+					tt.s1, tt.s2, distance, tt.expected)
+			}
+		})
+	}
+}
+
+// Benchmark tests
+func BenchmarkCalculateSimilarity(b *testing.B) {
+	fm := NewFuzzyMatcher()
+	options := &FuzzyOptions{MinSimilarity: 0.8, CaseIgnore: true, Normalize: true}
+
+	for i := 0; i < b.N; i++ {
+		fm.CalculateSimilarity("device-01-production", "devise-01-prod", options)
+	}
+}
+
+func BenchmarkJaroWinklerSimilarity(b *testing.B) {
+	fm := NewFuzzyMatcher()
+
+	for i := 0; i < b.N; i++ {
+		fm.jaroWinklerSimilarity("device-01-production", "devise-01-prod")
+	}
+}
+
+func BenchmarkLevenshteinDistance(b *testing.B) {
+	fm := NewFuzzyMatcher()
+
+	for i := 0; i < b.N; i++ {
+		fm.levenshteinDistance("device-01-production", "devise-01-prod")
+	}
+}

--- a/diode-server/matching/types.go
+++ b/diode-server/matching/types.go
@@ -73,8 +73,21 @@ type EntityMatchingRule struct {
 	SecondaryRules     []FieldMatchRule `json:"secondary_rules" yaml:"secondary_rules"`                               // Secondary matching criteria (lower confidence)
 	FallbackRules      []FieldMatchRule `json:"fallback_rules" yaml:"fallback_rules"`                                 // Fallback matching criteria (lowest confidence)
 	MinConfidence      MatchConfidence  `json:"min_confidence" yaml:"min_confidence"`                                 // Minimum confidence threshold for this entity type
-	RequireAllPrimary  bool             `json:"require_all_primary" yaml:"require_all_primary"`                       // If true, all primary rules must match
+	RequireAllPrimary  *bool            `json:"require_all_primary,omitempty" yaml:"require_all_primary,omitempty"`   // If true, all primary rules must match; nil means use global default
 	EdgePropertyFields []string         `json:"edge_property_fields,omitempty" yaml:"edge_property_fields,omitempty"` // Fields to store as edge properties instead of node properties
+}
+
+// GetRequireAllPrimary returns the RequireAllPrimary value, with a fallback default
+func (r *EntityMatchingRule) GetRequireAllPrimary(defaultValue bool) bool {
+	if r.RequireAllPrimary == nil {
+		return defaultValue
+	}
+	return *r.RequireAllPrimary
+}
+
+// SetRequireAllPrimary sets the RequireAllPrimary value
+func (r *EntityMatchingRule) SetRequireAllPrimary(value bool) {
+	r.RequireAllPrimary = &value
 }
 
 // EntityMatchingConfig contains all matching rules and global configuration

--- a/diode-server/matching/types.go
+++ b/diode-server/matching/types.go
@@ -1,0 +1,131 @@
+package matching
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
+)
+
+// MatchConfidence represents the confidence level of an entity match
+type MatchConfidence float64
+
+const (
+	// ConfidenceHigh is the threshold for high confidence matches (>= 0.9)
+	ConfidenceHigh MatchConfidence = 0.9
+	// ConfidenceMedium is the threshold for medium confidence matches (0.7-0.89)
+	ConfidenceMedium MatchConfidence = 0.7
+	// ConfidenceLow is the threshold for low confidence matches (0.5-0.69)
+	ConfidenceLow MatchConfidence = 0.5
+	// ConfidenceNone indicates no match (< 0.5)
+	ConfidenceNone MatchConfidence = 0.0
+)
+
+// MatchResult represents the result of an entity matching operation
+type MatchResult struct {
+	NodeID         *int64          `json:"node_id,omitempty"`
+	ExternalID     *string         `json:"external_id,omitempty"`
+	Confidence     MatchConfidence `json:"confidence"`
+	MatchingFields []string        `json:"matching_fields"`
+	MatchReason    string          `json:"match_reason"`
+	ExistingData   json.RawMessage `json:"existing_data,omitempty"`
+}
+
+// FieldMatchRule defines how a specific field should be matched
+type FieldMatchRule struct {
+	FieldPath    string          `json:"field_path" yaml:"field_path"`                 // JSON path to the field (e.g., "name", "device_type.name")
+	MatchType    FieldMatchType  `json:"match_type" yaml:"match_type"`                 // How to match this field
+	Weight       float64         `json:"weight" yaml:"weight"`                         // Importance weight (0.0-1.0)
+	Required     bool            `json:"required" yaml:"required"`                     // If true, match fails if this field doesn't match
+	Confidence   MatchConfidence `json:"confidence" yaml:"confidence"`                 // Confidence contribution when this field matches
+	FuzzyOptions *FuzzyOptions   `json:"fuzzy_options,omitempty" yaml:"fuzzy_options"` // Options for fuzzy matching
+}
+
+// FieldMatchType defines different ways to match field values
+type FieldMatchType string
+
+const (
+	// MatchExact performs exact string/value matching
+	MatchExact FieldMatchType = "exact"
+	// MatchFuzzy performs fuzzy string matching
+	MatchFuzzy FieldMatchType = "fuzzy"
+	// MatchContains checks if one string contains another
+	MatchContains FieldMatchType = "contains"
+	// MatchNumeric performs numeric comparison with tolerance
+	MatchNumeric FieldMatchType = "numeric"
+	// MatchExists checks if field exists (not null/empty)
+	MatchExists FieldMatchType = "exists"
+	// MatchRegex performs regular expression matching
+	MatchRegex FieldMatchType = "regex"
+)
+
+// FuzzyOptions contains options for fuzzy matching
+type FuzzyOptions struct {
+	MinSimilarity float64 `json:"min_similarity" yaml:"min_similarity"` // Minimum similarity ratio (0.0-1.0)
+	CaseIgnore    bool    `json:"case_ignore" yaml:"case_ignore"`       // Ignore case differences
+	Normalize     bool    `json:"normalize" yaml:"normalize"`           // Normalize whitespace and punctuation
+}
+
+// EntityMatchingRule defines how to match entities of a specific type
+type EntityMatchingRule struct {
+	EntityType         string           `json:"entity_type" yaml:"entity_type"`                                       // Type of entity (e.g., "Device", "Interface")
+	PrimaryRules       []FieldMatchRule `json:"primary_rules" yaml:"primary_rules"`                                   // Primary matching criteria
+	SecondaryRules     []FieldMatchRule `json:"secondary_rules" yaml:"secondary_rules"`                               // Secondary matching criteria (lower confidence)
+	FallbackRules      []FieldMatchRule `json:"fallback_rules" yaml:"fallback_rules"`                                 // Fallback matching criteria (lowest confidence)
+	MinConfidence      MatchConfidence  `json:"min_confidence" yaml:"min_confidence"`                                 // Minimum confidence threshold for this entity type
+	RequireAllPrimary  bool             `json:"require_all_primary" yaml:"require_all_primary"`                       // If true, all primary rules must match
+	EdgePropertyFields []string         `json:"edge_property_fields,omitempty" yaml:"edge_property_fields,omitempty"` // Fields to store as edge properties instead of node properties
+}
+
+// EntityMatchingConfig contains all matching rules and global configuration
+type EntityMatchingConfig struct {
+	Rules          map[string]*EntityMatchingRule `json:"rules"`           // Rules by entity type
+	GlobalMinConf  MatchConfidence                `json:"global_min_conf"` // Global minimum confidence
+	EnableFallback bool                           `json:"enable_fallback"` // Enable fallback matching
+	CacheResults   bool                           `json:"cache_results"`   // Cache matching results
+	MaxCacheSize   int                            `json:"max_cache_size"`  // Maximum cache entries
+}
+
+// EntityMatcher interface defines methods for entity matching with confidence scoring
+type EntityMatcher interface {
+	// FindMatches finds potential matches for an entity with confidence scores
+	FindMatches(ctx context.Context, entity *diodepb.Entity) ([]MatchResult, error)
+
+	// FindBestMatch finds the best match for an entity above the confidence threshold
+	FindBestMatch(ctx context.Context, entity *diodepb.Entity) (*MatchResult, error)
+
+	// GetMatchingRule returns the matching rule for a specific entity type
+	GetMatchingRule(entityType string) (*EntityMatchingRule, error)
+
+	// UpdateMatchingRule updates or adds a matching rule for an entity type
+	UpdateMatchingRule(entityType string, rule *EntityMatchingRule) error
+}
+
+// IsHighConfidence returns true if the confidence is high enough to treat as same entity
+func (c MatchConfidence) IsHighConfidence() bool {
+	return c >= ConfidenceHigh
+}
+
+// IsMediumConfidence returns true if the confidence requires manual review
+func (c MatchConfidence) IsMediumConfidence() bool {
+	return c >= ConfidenceMedium && c < ConfidenceHigh
+}
+
+// IsLowConfidence returns true if the confidence indicates a potential match
+func (c MatchConfidence) IsLowConfidence() bool {
+	return c >= ConfidenceLow && c < ConfidenceMedium
+}
+
+// String returns a human-readable description of the confidence level
+func (c MatchConfidence) String() string {
+	switch {
+	case c >= ConfidenceHigh:
+		return "High"
+	case c >= ConfidenceMedium:
+		return "Medium"
+	case c >= ConfidenceLow:
+		return "Low"
+	default:
+		return "None"
+	}
+}


### PR DESCRIPTION
Add standalone matching package for entity similarity comparison:

## New Files
- `matching/types.go`: Core types for entity matching
  - MatchConfidence (High/Medium/Low thresholds)
  - MatchResult for match operations
  - FieldMatchRule for configurable matching rules
  - EntityMatchingRule per entity type
  - EntityMatcher interface

- `matching/fuzzy.go`: Fuzzy string matching algorithms
  - Jaro-Winkler similarity (good for names/identifiers)
  - Levenshtein distance (edit-based similarity)
  - Unicode normalization support
  - Case-insensitive matching option

- `matching/config.go`: YAML configuration support
  - Load matching rules from config file
  - Global settings with per-entity overrides
  - Rule merging and defaults

- `matching/fuzzy_test.go`: Comprehensive tests
  - Unit tests for all algorithms
  - Benchmark tests for performance

## Dependencies
- golang.org/x/text (for Unicode normalization)
- gopkg.in/yaml.v3 (for config parsing)

This package is standalone with no dependencies on other diode packages, making it suitable for use in graph-based entity matching.