### PR TITLE
feat(reconciler): add GraphBuilder for recursive entity extraction

### DIFF
--- a/diode-server/cmd/protograph/generator.go
+++ b/diode-server/cmd/protograph/generator.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
+	"sort"
+	"strings"
 	"text/template"
+
+	"github.com/netboxlabs/diode/diode-server/strcase"
 )
 
 // EntityType represents a parsed entity type from the protobuf
@@ -18,7 +22,8 @@ type EntityType struct {
 
 // EntityField represents a field within an entity type
 type EntityField struct {
-	Name       string  // Field name (e.g., "name", "serial")
+	Name       string  // Field name (e.g., "name", "serial") - snake_case from proto
+	GoName     string  // Go field name (e.g., "Name", "Serial") - PascalCase
 	Type       string  // Field type (e.g., "string", "int32", "Device")
 	IsOptional bool    // Whether field is optional
 	IsRepeated bool    // Whether field is repeated (array/slice)
@@ -26,6 +31,12 @@ type EntityField struct {
 	JSONPath   string  // JSON path for accessing field (e.g., "name", "site.name")
 	Confidence float64 // Generated confidence score based on field characteristics
 	MatchType  string  // Suggested match type based on field type
+}
+
+// FieldTypeMapping represents a mapping from field name to entity type
+type FieldTypeMapping struct {
+	FieldName  string // Field name (snake_case or PascalCase)
+	EntityType string // Target entity type
 }
 
 // Generator handles the code generation process
@@ -36,7 +47,12 @@ type Generator struct {
 
 // NewGenerator creates a new code generator instance
 func NewGenerator(packageName string) (*Generator, error) {
-	tmpl, err := template.New("entity_mappings").Parse(entityMappingTemplate)
+	funcMap := template.FuncMap{
+		"snakeCase": strcase.ToSnakeCase,
+		"lowerCase": strings.ToLower,
+	}
+
+	tmpl, err := template.New("entity_mappings").Funcs(funcMap).Parse(entityMappingTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}
@@ -49,12 +65,17 @@ func NewGenerator(packageName string) (*Generator, error) {
 
 // GenerateCode generates Go code for entity mappings
 func (g *Generator) GenerateCode(entities []EntityType) (string, error) {
+	// Build field-to-type mappings from all entity fields
+	fieldMappings := g.buildFieldTypeMappings(entities)
+
 	data := struct {
-		Package  string
-		Entities []EntityType
+		Package       string
+		Entities      []EntityType
+		FieldMappings []FieldTypeMapping
 	}{
-		Package:  g.packageName,
-		Entities: entities,
+		Package:       g.packageName,
+		Entities:      entities,
+		FieldMappings: fieldMappings,
 	}
 
 	var buf bytes.Buffer
@@ -70,4 +91,50 @@ func (g *Generator) GenerateCode(entities []EntityType) (string, error) {
 	}
 
 	return string(formatted), nil
+}
+
+// buildFieldTypeMappings extracts field-to-entity-type mappings from all entities
+func (g *Generator) buildFieldTypeMappings(entities []EntityType) []FieldTypeMapping {
+	// Use a map to deduplicate mappings
+	seen := make(map[string]string)
+
+	// Build set of known entity types for validation
+	knownTypes := make(map[string]bool)
+	for _, e := range entities {
+		knownTypes[e.Name] = true
+	}
+
+	for _, entity := range entities {
+		for _, field := range entity.Fields {
+			// Only include nested fields that reference known entity types
+			if field.IsNested && knownTypes[field.Type] {
+				// Add snake_case mapping (proto field name)
+				if _, exists := seen[field.Name]; !exists {
+					seen[field.Name] = field.Type
+				}
+				// Add PascalCase mapping (Go field name)
+				if field.GoName != "" {
+					if _, exists := seen[field.GoName]; !exists {
+						seen[field.GoName] = field.Type
+					}
+				}
+			}
+		}
+	}
+
+	// Convert map to sorted slice for deterministic output
+	mappings := make([]FieldTypeMapping, 0, len(seen))
+	for fieldName, entityType := range seen {
+		mappings = append(mappings, FieldTypeMapping{
+			FieldName:  fieldName,
+			EntityType: entityType,
+		})
+	}
+
+	// Sort for deterministic output
+	sort.Slice(mappings, func(i, j int) bool {
+		return mappings[i].FieldName < mappings[j].FieldName
+	})
+
+	return mappings
 }

--- a/diode-server/cmd/protograph/parser.go
+++ b/diode-server/cmd/protograph/parser.go
@@ -151,7 +151,7 @@ func (g *Generator) parseOneofField(line string) EntityType {
 	}
 }
 
-// convertFieldNameToOneofName converts proto field names to Go oneof field names
+// convertFieldNameToOneofName converts proto field names to Go oneof field names.
 // e.g., "asn" -> "Asn", "asn_range" -> "AsnRange", "device_type" -> "DeviceType"
 func convertFieldNameToOneofName(fieldName string) string {
 	// Handle special cases for acronyms first
@@ -184,13 +184,14 @@ func convertFieldNameToOneofName(fieldName string) string {
 
 	// Convert snake_case to CamelCase for regular cases
 	parts := strings.Split(fieldName, "_")
-	result := ""
+	var result strings.Builder
 	for _, part := range parts {
 		if len(part) > 0 {
-			result += strings.ToUpper(part[:1]) + part[1:]
+			result.WriteString(strings.ToUpper(part[:1]))
+			result.WriteString(part[1:])
 		}
 	}
-	return result
+	return result.String()
 }
 
 // parseEntityFields extracts field information from a specific message type
@@ -200,29 +201,34 @@ func (g *Generator) parseEntityFields(content, entityName string) ([]EntityField
 	// Find the message definition for this entity
 	lines := strings.Split(content, "\n")
 	inMessage := false
+	braceDepth := 0
 	messagePattern := fmt.Sprintf("message %s", entityName)
 
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
+		trimmedLine := strings.TrimSpace(line)
 
 		// Find the message start
-		if strings.HasPrefix(line, messagePattern+" ") || line == messagePattern+" {" {
+		if strings.HasPrefix(trimmedLine, messagePattern+" ") || trimmedLine == messagePattern+" {" {
 			inMessage = true
+			braceDepth = 1 // Start at depth 1 for the message opening brace
 			continue
 		}
 
-		// Exit message when we find closing brace or another message
-		if inMessage && (strings.HasPrefix(line, "}") || strings.HasPrefix(line, "message ")) {
-			if strings.HasPrefix(line, "}") {
-				break
-			}
-			inMessage = false
+		if !inMessage {
 			continue
 		}
 
-		// Parse field definitions
-		if inMessage && strings.Contains(line, "=") && !strings.HasPrefix(line, "//") && !strings.Contains(line, "oneof") {
-			field, err := g.parseFieldLine(line)
+		// Track brace depth for nested blocks (enums, validation rules, etc.)
+		braceDepth += strings.Count(trimmedLine, "{") - strings.Count(trimmedLine, "}")
+
+		// Exit message when we return to depth 0
+		if braceDepth <= 0 {
+			break
+		}
+
+		// Only parse fields at depth 1 (direct message fields, not nested blocks)
+		if braceDepth == 1 && strings.Contains(trimmedLine, "=") && !strings.HasPrefix(trimmedLine, "//") && !strings.Contains(trimmedLine, "oneof") {
+			field, err := g.parseFieldLine(trimmedLine)
 			if err != nil {
 				continue // Skip malformed lines
 			}
@@ -258,6 +264,7 @@ func (g *Generator) parseFieldLine(line string) (EntityField, error) {
 
 	field := EntityField{
 		Name:       matches[3],
+		GoName:     snakeToPascal(matches[3]),
 		Type:       matches[2],
 		IsOptional: matches[1] == "optional" || strings.Contains(line, "oneof"),
 		IsRepeated: matches[1] == "repeated",
@@ -265,6 +272,20 @@ func (g *Generator) parseFieldLine(line string) (EntityField, error) {
 	}
 
 	return field, nil
+}
+
+// snakeToPascal converts snake_case to PascalCase
+// e.g., "tagged_vlans" -> "TaggedVlans", "site" -> "Site"
+func snakeToPascal(s string) string {
+	parts := strings.Split(s, "_")
+	var result strings.Builder
+	for _, part := range parts {
+		if len(part) > 0 {
+			result.WriteString(strings.ToUpper(part[:1]))
+			result.WriteString(part[1:])
+		}
+	}
+	return result.String()
 }
 
 // isNestedType determines if a field type is a nested message type

--- a/diode-server/cmd/protograph/parser.go
+++ b/diode-server/cmd/protograph/parser.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/netboxlabs/diode/diode-server/strcase"
 )
 
 // ParseProtobuf parses the protobuf file and extracts all entity types from the Entity oneof
@@ -264,7 +266,7 @@ func (g *Generator) parseFieldLine(line string) (EntityField, error) {
 
 	field := EntityField{
 		Name:       matches[3],
-		GoName:     snakeToPascal(matches[3]),
+		GoName:     strcase.ToPascalCase(matches[3]),
 		Type:       matches[2],
 		IsOptional: matches[1] == "optional" || strings.Contains(line, "oneof"),
 		IsRepeated: matches[1] == "repeated",
@@ -272,20 +274,6 @@ func (g *Generator) parseFieldLine(line string) (EntityField, error) {
 	}
 
 	return field, nil
-}
-
-// snakeToPascal converts snake_case to PascalCase
-// e.g., "tagged_vlans" -> "TaggedVlans", "site" -> "Site"
-func snakeToPascal(s string) string {
-	parts := strings.Split(s, "_")
-	var result strings.Builder
-	for _, part := range parts {
-		if len(part) > 0 {
-			result.WriteString(strings.ToUpper(part[:1]))
-			result.WriteString(part[1:])
-		}
-	}
-	return result.String()
 }
 
 // isNestedType determines if a field type is a nested message type

--- a/diode-server/cmd/protograph/templates.go
+++ b/diode-server/cmd/protograph/templates.go
@@ -6,11 +6,12 @@ package {{.Package}}
 
 import (
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
+	"github.com/netboxlabs/diode/diode-server/strcase"
 )
 
 // CreateEntityFromInterface creates a diodepb.Entity from a typed interface value.
 // This replaces the large manual switch statements in the GraphBuilder.
-func CreateEntityFromInterface(fieldValue interface{}) *diodepb.Entity {
+func CreateEntityFromInterface(fieldValue any) *diodepb.Entity {
 	if fieldValue == nil {
 		return nil
 	}
@@ -27,7 +28,7 @@ func CreateEntityFromInterface(fieldValue interface{}) *diodepb.Entity {
 
 // GetEntityTypeName returns the entity type name for a given interface value.
 // This is useful for debugging and logging.
-func GetEntityTypeName(fieldValue interface{}) string {
+func GetEntityTypeName(fieldValue any) string {
 	if fieldValue == nil {
 		return ""
 	}
@@ -43,7 +44,7 @@ func GetEntityTypeName(fieldValue interface{}) string {
 }
 
 // IsKnownEntityType checks if the given interface value is a known entity type.
-func IsKnownEntityType(fieldValue interface{}) bool {
+func IsKnownEntityType(fieldValue any) bool {
 	if fieldValue == nil {
 		return false
 	}
@@ -67,4 +68,54 @@ func GetAllEntityTypes() []string {
 {{- end}}
 	}
 }
+
+// EdgeTypePair represents both directions of a relationship.
+type EdgeTypePair struct {
+	Forward string // e.g., BELONGS_TO_SITE (source references target)
+	Reverse string // e.g., HAS_DEVICE (target contains source)
+}
+
+// GetEdgeTypesForField returns both edge types for a bidirectional relationship.
+// Forward: BELONGS_TO_X (source entity references target entity)
+// Reverse: HAS_X (target entity contains source entity)
+// e.g., Device.Site -> Forward: "BELONGS_TO_SITE", Reverse: "HAS_DEVICE"
+func GetEdgeTypesForField(fieldName, sourceEntityType string) EdgeTypePair {
+	return EdgeTypePair{
+		Forward: "BELONGS_TO_" + strcase.ToUpperSnakeCase(fieldName),
+		Reverse: "HAS_" + strcase.ToUpperSnakeCase(sourceEntityType),
+	}
+}
+
+// GetEdgeTypeForField returns the forward edge type for a given field name.
+// Convention: BELONGS_TO_UPPER_SNAKE_CASE(fieldName)
+// e.g., "Site" -> "BELONGS_TO_SITE", "DeviceType" -> "BELONGS_TO_DEVICE_TYPE"
+func GetEdgeTypeForField(fieldName string) string {
+	return "BELONGS_TO_" + strcase.ToUpperSnakeCase(fieldName)
+}
+
+// GetReverseEdgeTypeForField returns the reverse edge type for a given source entity type.
+// Convention: HAS_UPPER_SNAKE_CASE(sourceEntityType)
+// e.g., "Device" -> "HAS_DEVICE", "Interface" -> "HAS_INTERFACE"
+func GetReverseEdgeTypeForField(sourceEntityType string) string {
+	return "HAS_" + strcase.ToUpperSnakeCase(sourceEntityType)
+}
+
+// GetNodeTypeForField returns the node type (entity type name) for a given field name.
+// Supports both PascalCase (Go reflection) and snake_case (proto/JSON) field names.
+// e.g., "TaggedVlans" -> "VLAN", "tagged_vlans" -> "VLAN", "Site" -> "Site"
+func GetNodeTypeForField(fieldName string) string {
+	// Map field names to their target entity types
+	// Extracted from proto message field definitions
+	fieldToType := map[string]string{
+{{- range .FieldMappings}}
+		"{{.FieldName}}": "{{.EntityType}}",
+{{- end}}
+	}
+
+	if entityType, ok := fieldToType[fieldName]; ok {
+		return entityType
+	}
+	return fieldName // Return as-is if not found (may be the entity type itself)
+}
+
 `

--- a/diode-server/entitymatcher/matcher.go
+++ b/diode-server/entitymatcher/matcher.go
@@ -19,12 +19,22 @@ import (
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
 	"github.com/netboxlabs/diode/diode-server/gen/protograph"
 	"github.com/netboxlabs/diode/diode-server/matching"
-	"github.com/netboxlabs/diode/diode-server/reconciler"
 )
+
+// GraphNode is an alias to the SQLC-generated GraphNode type
+type GraphNode = postgres.GraphNode
+
+// Repository defines the repository interface needed by Matcher.
+// This is kept minimal to allow simpler mocking in tests.
+// reconciler.GraphRepository satisfies this interface.
+type Repository interface {
+	FindNodesByFieldMatch(ctx context.Context, arg postgres.FindNodesByFieldMatchParams) ([]postgres.GraphNode, error)
+	GetGraphNodesByType(ctx context.Context, arg postgres.GetGraphNodesByTypeParams) ([]postgres.GraphNode, error)
+}
 
 // Matcher implements confidence-based entity matching
 type Matcher struct {
-	repo         reconciler.GraphRepository
+	repo         Repository
 	config       *matching.EntityMatchingConfig
 	logger       *slog.Logger
 	fuzzyMatcher *matching.FuzzyMatcher
@@ -35,7 +45,7 @@ type Matcher struct {
 }
 
 // NewMatcher creates a new EntityMatcher with the given configuration
-func NewMatcher(repo reconciler.GraphRepository, config *matching.EntityMatchingConfig, logger *slog.Logger) *Matcher {
+func NewMatcher(repo Repository, config *matching.EntityMatchingConfig, logger *slog.Logger) *Matcher {
 	if config == nil {
 		config = DefaultEntityMatchingConfig()
 	}
@@ -85,7 +95,7 @@ func getEntityTypeName(entity *diodepb.Entity) string {
 }
 
 // extractFieldValue extracts a field value from entity data using a JSON path
-func extractFieldValue(data interface{}, fieldPath string) (interface{}, error) {
+func extractFieldValue(data any, fieldPath string) (any, error) {
 	if data == nil {
 		return nil, fmt.Errorf("data is nil")
 	}
@@ -95,7 +105,7 @@ func extractFieldValue(data interface{}, fieldPath string) (interface{}, error) 
 
 	for _, part := range parts {
 		switch v := current.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			// Try exact match first, then case-insensitive
 			if val, exists := v[part]; exists {
 				current = val
@@ -113,7 +123,7 @@ func extractFieldValue(data interface{}, fieldPath string) (interface{}, error) 
 					current = nil
 				}
 			}
-		case *map[string]interface{}:
+		case *map[string]any:
 			if v != nil {
 				// Try exact match first, then case-insensitive
 				if val, exists := (*v)[part]; exists {
@@ -276,7 +286,7 @@ func (m *Matcher) UpdateMatchingRule(entityType string, rule *matching.EntityMat
 }
 
 // findCandidateNodes searches the database for potential matching nodes
-func (m *Matcher) findCandidateNodes(ctx context.Context, entity *diodepb.Entity, entityType string, rule *matching.EntityMatchingRule) ([]*reconciler.GraphNode, error) {
+func (m *Matcher) findCandidateNodes(ctx context.Context, entity *diodepb.Entity, entityType string, rule *matching.EntityMatchingRule) ([]*GraphNode, error) {
 	// Extract entity data for comparison
 	entityData, err := m.entityToMap(entity)
 	if err != nil {
@@ -289,7 +299,7 @@ func (m *Matcher) findCandidateNodes(ctx context.Context, entity *diodepb.Entity
 		"secondary_rules", len(rule.SecondaryRules),
 		"fallback_rules", len(rule.FallbackRules))
 
-	var allCandidates []*reconciler.GraphNode
+	var allCandidates []*GraphNode
 
 	// Strategy 1: Try exact matches on primary fields first
 	primaryCandidates, err := m.findCandidatesByPrimaryFields(ctx, entityType, entityData, rule.PrimaryRules)
@@ -334,8 +344,8 @@ func (m *Matcher) findCandidateNodes(ctx context.Context, entity *diodepb.Entity
 }
 
 // findCandidatesByPrimaryFields searches using primary matching fields (supports both exact and fuzzy matches)
-func (m *Matcher) findCandidatesByPrimaryFields(ctx context.Context, entityType string, entityData map[string]interface{}, primaryRules []matching.FieldMatchRule) ([]*reconciler.GraphNode, error) {
-	var candidates []*reconciler.GraphNode
+func (m *Matcher) findCandidatesByPrimaryFields(ctx context.Context, entityType string, entityData map[string]any, primaryRules []matching.FieldMatchRule) ([]*GraphNode, error) {
+	var candidates []*GraphNode
 
 	for _, rule := range primaryRules {
 		// Extract field value from entity data
@@ -390,7 +400,7 @@ func (m *Matcher) findCandidatesByPrimaryFields(ctx context.Context, entityType 
 
 		// Convert to GraphNode format
 		for _, dbNode := range dbNodes {
-			candidates = append(candidates, &reconciler.GraphNode{
+			candidates = append(candidates, &GraphNode{
 				ID:             dbNode.ID,
 				ExternalID:     dbNode.ExternalID,
 				NodeType:       dbNode.NodeType,
@@ -431,7 +441,7 @@ func (m *Matcher) findFuzzyCandidatesForField(ctx context.Context, entityType, f
 	// Check each node for fuzzy match
 	for _, node := range allNodes {
 		// Parse node data to extract field value
-		var nodeData map[string]interface{}
+		var nodeData map[string]any
 		if err := json.Unmarshal(node.Data, &nodeData); err != nil {
 			m.logger.Warn("failed to parse node data for fuzzy matching", "node_id", node.ID, "error", err)
 			continue
@@ -483,8 +493,8 @@ func (m *Matcher) findFuzzyCandidatesForField(ctx context.Context, entityType, f
 }
 
 // findCandidatesBySecondaryFields searches using secondary matching fields (supports both exact and fuzzy matches)
-func (m *Matcher) findCandidatesBySecondaryFields(ctx context.Context, entityType string, entityData map[string]interface{}, secondaryRules []matching.FieldMatchRule) ([]*reconciler.GraphNode, error) {
-	var candidates []*reconciler.GraphNode
+func (m *Matcher) findCandidatesBySecondaryFields(ctx context.Context, entityType string, entityData map[string]any, secondaryRules []matching.FieldMatchRule) ([]*GraphNode, error) {
+	var candidates []*GraphNode
 
 	// For secondary rules, try both exact and fuzzy matching approaches
 	for _, rule := range secondaryRules {
@@ -535,7 +545,7 @@ func (m *Matcher) findCandidatesBySecondaryFields(ctx context.Context, entityTyp
 
 		// Convert to GraphNode format and add to candidates
 		for _, dbNode := range dbNodes {
-			candidates = append(candidates, &reconciler.GraphNode{
+			candidates = append(candidates, &GraphNode{
 				ID:             dbNode.ID,
 				ExternalID:     dbNode.ExternalID,
 				NodeType:       dbNode.NodeType,
@@ -554,7 +564,7 @@ func (m *Matcher) findCandidatesBySecondaryFields(ctx context.Context, entityTyp
 }
 
 // findCandidatesByFallbackStrategy searches using broader criteria
-func (m *Matcher) findCandidatesByFallbackStrategy(ctx context.Context, entityType string, _ map[string]interface{}, _ []matching.FieldMatchRule) ([]*reconciler.GraphNode, error) {
+func (m *Matcher) findCandidatesByFallbackStrategy(ctx context.Context, entityType string, _ map[string]any, _ []matching.FieldMatchRule) ([]*GraphNode, error) {
 	// For fallback, get all nodes of this type and let the scoring algorithm handle fuzzy matching
 	params := postgres.GetGraphNodesByTypeParams{
 		NodeType: entityType,
@@ -567,9 +577,9 @@ func (m *Matcher) findCandidatesByFallbackStrategy(ctx context.Context, entityTy
 		return nil, fmt.Errorf("fallback node retrieval failed: %w", err)
 	}
 
-	var candidates []*reconciler.GraphNode
+	var candidates []*GraphNode
 	for _, dbNode := range dbNodes {
-		candidates = append(candidates, &reconciler.GraphNode{
+		candidates = append(candidates, &GraphNode{
 			ID:             dbNode.ID,
 			ExternalID:     dbNode.ExternalID,
 			NodeType:       dbNode.NodeType,
@@ -583,9 +593,9 @@ func (m *Matcher) findCandidatesByFallbackStrategy(ctx context.Context, entityTy
 }
 
 // deduplicateCandidates removes duplicate nodes from the candidate list
-func (m *Matcher) deduplicateCandidates(candidates []*reconciler.GraphNode) []*reconciler.GraphNode {
+func (m *Matcher) deduplicateCandidates(candidates []*GraphNode) []*GraphNode {
 	seen := make(map[int64]struct{})
-	var unique []*reconciler.GraphNode
+	var unique []*GraphNode
 
 	for _, candidate := range candidates {
 		if _, exists := seen[candidate.ID]; !exists {
@@ -598,13 +608,13 @@ func (m *Matcher) deduplicateCandidates(candidates []*reconciler.GraphNode) []*r
 }
 
 // extractFieldFromMap extracts a field value from a map using dot notation
-func (m *Matcher) extractFieldFromMap(data map[string]interface{}, fieldPath string) (interface{}, bool) {
+func (m *Matcher) extractFieldFromMap(data map[string]any, fieldPath string) (any, bool) {
 	value, err := extractFieldValue(data, fieldPath)
 	return value, err == nil && value != nil
 }
 
 // scoreMatch calculates the confidence score for a potential match
-func (m *Matcher) scoreMatch(entity *diodepb.Entity, candidate *reconciler.GraphNode, rule *matching.EntityMatchingRule) (*matching.MatchResult, error) {
+func (m *Matcher) scoreMatch(entity *diodepb.Entity, candidate *GraphNode, rule *matching.EntityMatchingRule) (*matching.MatchResult, error) {
 	// Convert entity to comparable format
 	entityData, err := m.entityToMap(entity)
 	if err != nil {
@@ -612,7 +622,7 @@ func (m *Matcher) scoreMatch(entity *diodepb.Entity, candidate *reconciler.Graph
 	}
 
 	// Parse candidate data
-	var candidateData map[string]interface{}
+	var candidateData map[string]any
 	if err := json.Unmarshal(candidate.Data, &candidateData); err != nil {
 		return nil, fmt.Errorf("failed to parse candidate data: %w", err)
 	}
@@ -665,7 +675,7 @@ func (m *Matcher) scoreMatch(entity *diodepb.Entity, candidate *reconciler.Graph
 }
 
 // scoreFieldRules scores a set of field rules and returns confidence, matching fields, and reason
-func (m *Matcher) scoreFieldRules(entityData, candidateData map[string]interface{}, rules []matching.FieldMatchRule) (matching.MatchConfidence, []string, string) {
+func (m *Matcher) scoreFieldRules(entityData, candidateData map[string]any, rules []matching.FieldMatchRule) (matching.MatchConfidence, []string, string) {
 	if len(rules) == 0 {
 		return matching.ConfidenceNone, nil, "no rules defined"
 	}
@@ -704,7 +714,7 @@ func (m *Matcher) scoreFieldRules(entityData, candidateData map[string]interface
 }
 
 // compareFieldValues compares two field values based on the match rule
-func (m *Matcher) compareFieldValues(entityValue, candidateValue interface{}, rule matching.FieldMatchRule) (bool, matching.MatchConfidence) {
+func (m *Matcher) compareFieldValues(entityValue, candidateValue any, rule matching.FieldMatchRule) (bool, matching.MatchConfidence) {
 	if entityValue == nil || candidateValue == nil {
 		// MatchExists requires both values to be present; if either is nil, no match
 		return false, matching.ConfidenceNone
@@ -739,7 +749,7 @@ func (m *Matcher) compareFieldValues(entityValue, candidateValue interface{}, ru
 }
 
 // compareExact performs exact value comparison
-func (m *Matcher) compareExact(entityValue, candidateValue interface{}) bool {
+func (m *Matcher) compareExact(entityValue, candidateValue any) bool {
 	// Convert both to strings for comparison
 	entityStr := fmt.Sprintf("%v", entityValue)
 	candidateStr := fmt.Sprintf("%v", candidateValue)
@@ -747,7 +757,7 @@ func (m *Matcher) compareExact(entityValue, candidateValue interface{}) bool {
 }
 
 // compareFuzzy performs fuzzy string matching using advanced algorithms
-func (m *Matcher) compareFuzzy(entityValue, candidateValue interface{}, options *matching.FuzzyOptions, baseConfidence matching.MatchConfidence) (bool, matching.MatchConfidence) {
+func (m *Matcher) compareFuzzy(entityValue, candidateValue any, options *matching.FuzzyOptions, baseConfidence matching.MatchConfidence) (bool, matching.MatchConfidence) {
 	entityStr := fmt.Sprintf("%v", entityValue)
 	candidateStr := fmt.Sprintf("%v", candidateValue)
 
@@ -764,7 +774,7 @@ func (m *Matcher) compareFuzzy(entityValue, candidateValue interface{}, options 
 }
 
 // compareContains checks if one string contains the other
-func (m *Matcher) compareContains(entityValue, candidateValue interface{}) bool {
+func (m *Matcher) compareContains(entityValue, candidateValue any) bool {
 	entityStr := strings.ToLower(fmt.Sprintf("%v", entityValue))
 	candidateStr := strings.ToLower(fmt.Sprintf("%v", candidateValue))
 
@@ -772,7 +782,7 @@ func (m *Matcher) compareContains(entityValue, candidateValue interface{}) bool 
 }
 
 // compareNumeric performs numeric comparison with tolerance
-func (m *Matcher) compareNumeric(entityValue, candidateValue interface{}) bool {
+func (m *Matcher) compareNumeric(entityValue, candidateValue any) bool {
 	entityFloat, err1 := parseFloat(entityValue)
 	candidateFloat, err2 := parseFloat(candidateValue)
 
@@ -786,7 +796,7 @@ func (m *Matcher) compareNumeric(entityValue, candidateValue interface{}) bool {
 }
 
 // compareRegex performs regular expression matching
-func (m *Matcher) compareRegex(entityValue, candidateValue interface{}) bool {
+func (m *Matcher) compareRegex(entityValue, candidateValue any) bool {
 	pattern := fmt.Sprintf("%v", entityValue)
 	text := fmt.Sprintf("%v", candidateValue)
 
@@ -799,7 +809,7 @@ func (m *Matcher) compareRegex(entityValue, candidateValue interface{}) bool {
 }
 
 // entityToMap converts a protobuf entity to a map for field extraction
-func (m *Matcher) entityToMap(entity *diodepb.Entity) (map[string]interface{}, error) {
+func (m *Matcher) entityToMap(entity *diodepb.Entity) (map[string]any, error) {
 	// Get the actual entity from the wrapper
 	actualEntity := entity.GetEntity()
 	if actualEntity == nil {
@@ -812,7 +822,7 @@ func (m *Matcher) entityToMap(entity *diodepb.Entity) (map[string]interface{}, e
 		return nil, fmt.Errorf("failed to marshal entity: %w", err)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal entity to map: %w", err)
 	}
@@ -876,7 +886,7 @@ func (m *Matcher) getCacheKey(entity *diodepb.Entity, entityType string) string 
 
 // Utility functions
 
-func parseFloat(value interface{}) (float64, error) {
+func parseFloat(value any) (float64, error) {
 	switch v := value.(type) {
 	case float64:
 		return v, nil
@@ -901,7 +911,7 @@ func abs(x float64) float64 {
 }
 
 // getMapKeys returns the keys of a map as a slice for debugging
-func getMapKeys(m map[string]interface{}) []string {
+func getMapKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/diode-server/entitymatcher/matcher_test.go
+++ b/diode-server/entitymatcher/matcher_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/diode/diode-server/gen/dbstore/postgres"
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
 	"github.com/netboxlabs/diode/diode-server/matching"
-	"github.com/netboxlabs/diode/diode-server/reconciler"
 	"github.com/netboxlabs/diode/diode-server/reconciler/mocks"
 )
 
@@ -230,9 +230,7 @@ func TestEntityMatcherFuzzyMatching(t *testing.T) {
 func TestDefaultEntityMatchingConfig(t *testing.T) {
 	config := DefaultEntityMatchingConfig()
 
-	if config == nil {
-		t.Fatal("DefaultEntityMatchingConfig returned nil")
-	}
+	require.NotNil(t, config, "DefaultEntityMatchingConfig returned nil")
 	if config.Rules == nil {
 		t.Error("Rules map should not be nil")
 	}
@@ -256,9 +254,7 @@ func TestNewMatcherWithNilConfig(t *testing.T) {
 
 	matcher := NewMatcher(mockRepo, nil, logger)
 
-	if matcher == nil {
-		t.Fatal("NewMatcher returned nil")
-	}
+	require.NotNil(t, matcher, "NewMatcher returned nil")
 	// Should use default config when nil is passed
 	if matcher.config == nil {
 		t.Error("Matcher config should not be nil")
@@ -415,7 +411,7 @@ func TestDeduplicateCandidates(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	matcher := &Matcher{logger: logger}
 
-	candidates := []*reconciler.GraphNode{
+	candidates := []*GraphNode{
 		{ID: 1, ExternalID: "node-1"},
 		{ID: 2, ExternalID: "node-2"},
 		{ID: 1, ExternalID: "node-1"}, // duplicate
@@ -1154,7 +1150,7 @@ func TestScoreMatchWithInvalidCandidateData(t *testing.T) {
 	}
 
 	// Create candidate with invalid JSON
-	candidate := &reconciler.GraphNode{
+	candidate := &GraphNode{
 		ID:         1,
 		ExternalID: "device-01",
 		NodeType:   "Device",
@@ -1190,9 +1186,7 @@ func TestFindBestMatchWithHighConfidence(t *testing.T) {
 		t.Fatalf("FindBestMatch failed: %v", err)
 	}
 
-	if best == nil {
-		t.Fatal("Expected a best match, got nil")
-	}
+	require.NotNil(t, best, "Expected a best match, got nil")
 
 	// Should have high confidence due to exact match on both fields
 	if best.Confidence < matching.ConfidenceMedium {

--- a/diode-server/gen/protograph/entity_mappings.go
+++ b/diode-server/gen/protograph/entity_mappings.go
@@ -4,11 +4,12 @@ package protograph
 
 import (
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
+	"github.com/netboxlabs/diode/diode-server/strcase"
 )
 
 // CreateEntityFromInterface creates a diodepb.Entity from a typed interface value.
 // This replaces the large manual switch statements in the GraphBuilder.
-func CreateEntityFromInterface(fieldValue interface{}) *diodepb.Entity {
+func CreateEntityFromInterface(fieldValue any) *diodepb.Entity {
 	if fieldValue == nil {
 		return nil
 	}
@@ -211,7 +212,7 @@ func CreateEntityFromInterface(fieldValue interface{}) *diodepb.Entity {
 
 // GetEntityTypeName returns the entity type name for a given interface value.
 // This is useful for debugging and logging.
-func GetEntityTypeName(fieldValue interface{}) string {
+func GetEntityTypeName(fieldValue any) string {
 	if fieldValue == nil {
 		return ""
 	}
@@ -413,7 +414,7 @@ func GetEntityTypeName(fieldValue interface{}) string {
 }
 
 // IsKnownEntityType checks if the given interface value is a known entity type.
-func IsKnownEntityType(fieldValue interface{}) bool {
+func IsKnownEntityType(fieldValue any) bool {
 	if fieldValue == nil {
 		return false
 	}
@@ -714,4 +715,196 @@ func GetAllEntityTypes() []string {
 		"Owner",
 		"OwnerGroup",
 	}
+}
+
+// EdgeTypePair represents both directions of a relationship.
+type EdgeTypePair struct {
+	Forward string // e.g., BELONGS_TO_SITE (source references target)
+	Reverse string // e.g., HAS_DEVICE (target contains source)
+}
+
+// GetEdgeTypesForField returns both edge types for a bidirectional relationship.
+// Forward: BELONGS_TO_X (source entity references target entity)
+// Reverse: HAS_X (target entity contains source entity)
+// e.g., Device.Site -> Forward: "BELONGS_TO_SITE", Reverse: "HAS_DEVICE"
+func GetEdgeTypesForField(fieldName, sourceEntityType string) EdgeTypePair {
+	return EdgeTypePair{
+		Forward: "BELONGS_TO_" + strcase.ToUpperSnakeCase(fieldName),
+		Reverse: "HAS_" + strcase.ToUpperSnakeCase(sourceEntityType),
+	}
+}
+
+// GetEdgeTypeForField returns the forward edge type for a given field name.
+// Convention: BELONGS_TO_UPPER_SNAKE_CASE(fieldName)
+// e.g., "Site" -> "BELONGS_TO_SITE", "DeviceType" -> "BELONGS_TO_DEVICE_TYPE"
+func GetEdgeTypeForField(fieldName string) string {
+	return "BELONGS_TO_" + strcase.ToUpperSnakeCase(fieldName)
+}
+
+// GetReverseEdgeTypeForField returns the reverse edge type for a given source entity type.
+// Convention: HAS_UPPER_SNAKE_CASE(sourceEntityType)
+// e.g., "Device" -> "HAS_DEVICE", "Interface" -> "HAS_INTERFACE"
+func GetReverseEdgeTypeForField(sourceEntityType string) string {
+	return "HAS_" + strcase.ToUpperSnakeCase(sourceEntityType)
+}
+
+// GetNodeTypeForField returns the node type (entity type name) for a given field name.
+// Supports both PascalCase (Go reflection) and snake_case (proto/JSON) field names.
+// e.g., "TaggedVlans" -> "VLAN", "tagged_vlans" -> "VLAN", "Site" -> "Site"
+func GetNodeTypeForField(fieldName string) string {
+	// Map field names to their target entity types
+	// Extracted from proto message field definitions
+	fieldToType := map[string]string{
+		"Accounts":                "ProviderAccount",
+		"Asns":                    "ASN",
+		"Assignments":             "CircuitGroupAssignment",
+		"Bridge":                  "Interface",
+		"Cable":                   "Cable",
+		"ChoiceSet":               "CustomFieldChoiceSet",
+		"Circuit":                 "Circuit",
+		"Cluster":                 "Cluster",
+		"Contact":                 "Contact",
+		"DefaultPlatform":         "Platform",
+		"Device":                  "Device",
+		"DeviceType":              "DeviceType",
+		"ExportTargets":           "RouteTarget",
+		"Group":                   "CircuitGroup",
+		"Groups":                  "ContactGroup",
+		"IkePolicy":               "IKEPolicy",
+		"ImportTargets":           "RouteTarget",
+		"InstalledDevice":         "Device",
+		"InstalledModule":         "Module",
+		"Interface":               "Interface",
+		"InterfaceA":              "Interface",
+		"InterfaceB":              "Interface",
+		"Ipaddresses":             "IPAddress",
+		"IpsecPolicy":             "IPSecPolicy",
+		"IpsecProfile":            "IPSecProfile",
+		"L2vpn":                   "L2VPN",
+		"Lag":                     "Interface",
+		"Location":                "Location",
+		"Manufacturer":            "Manufacturer",
+		"Master":                  "Device",
+		"Module":                  "Module",
+		"ModuleBay":               "ModuleBay",
+		"ModuleType":              "ModuleType",
+		"NatInside":               "IPAddress",
+		"OobIp":                   "IPAddress",
+		"OutsideIp":               "IPAddress",
+		"Owner":                   "Owner",
+		"Parent":                  "ContactGroup",
+		"Platform":                "Platform",
+		"Policy":                  "VLANTranslationPolicy",
+		"PowerPanel":              "PowerPanel",
+		"PowerPort":               "PowerPort",
+		"PrimaryIp4":              "IPAddress",
+		"PrimaryIp6":              "IPAddress",
+		"PrimaryMacAddress":       "MACAddress",
+		"Profile":                 "ModuleTypeProfile",
+		"Proposals":               "IKEProposal",
+		"Provider":                "Provider",
+		"ProviderAccount":         "ProviderAccount",
+		"ProviderNetwork":         "ProviderNetwork",
+		"QinqSvlan":               "VLAN",
+		"Rack":                    "Rack",
+		"RackType":                "RackType",
+		"RearPort":                "RearPort",
+		"Region":                  "Region",
+		"Rir":                     "RIR",
+		"Role":                    "ContactRole",
+		"Site":                    "Site",
+		"Sites":                   "Site",
+		"TaggedVlans":             "VLAN",
+		"Tags":                    "Tag",
+		"Tenant":                  "Tenant",
+		"Tunnel":                  "Tunnel",
+		"Type":                    "CircuitType",
+		"UntaggedVlan":            "VLAN",
+		"Vdcs":                    "VirtualDeviceContext",
+		"VirtualChassis":          "VirtualChassis",
+		"VirtualCircuit":          "VirtualCircuit",
+		"VirtualMachine":          "VirtualMachine",
+		"Vlan":                    "VLAN",
+		"VlanTranslationPolicy":   "VLANTranslationPolicy",
+		"Vrf":                     "VRF",
+		"WirelessLans":            "WirelessLAN",
+		"accounts":                "ProviderAccount",
+		"asns":                    "ASN",
+		"assignments":             "CircuitGroupAssignment",
+		"bridge":                  "Interface",
+		"cable":                   "Cable",
+		"choice_set":              "CustomFieldChoiceSet",
+		"circuit":                 "Circuit",
+		"cluster":                 "Cluster",
+		"contact":                 "Contact",
+		"default_platform":        "Platform",
+		"device":                  "Device",
+		"device_type":             "DeviceType",
+		"export_targets":          "RouteTarget",
+		"group":                   "CircuitGroup",
+		"groups":                  "ContactGroup",
+		"ike_policy":              "IKEPolicy",
+		"import_targets":          "RouteTarget",
+		"installed_device":        "Device",
+		"installed_module":        "Module",
+		"interface":               "Interface",
+		"interface_a":             "Interface",
+		"interface_b":             "Interface",
+		"ipaddresses":             "IPAddress",
+		"ipsec_policy":            "IPSecPolicy",
+		"ipsec_profile":           "IPSecProfile",
+		"l2vpn":                   "L2VPN",
+		"lag":                     "Interface",
+		"location":                "Location",
+		"manufacturer":            "Manufacturer",
+		"master":                  "Device",
+		"module":                  "Module",
+		"module_bay":              "ModuleBay",
+		"module_type":             "ModuleType",
+		"nat_inside":              "IPAddress",
+		"oob_ip":                  "IPAddress",
+		"outside_ip":              "IPAddress",
+		"owner":                   "Owner",
+		"parent":                  "ContactGroup",
+		"platform":                "Platform",
+		"policy":                  "VLANTranslationPolicy",
+		"power_panel":             "PowerPanel",
+		"power_port":              "PowerPort",
+		"primary_ip4":             "IPAddress",
+		"primary_ip6":             "IPAddress",
+		"primary_mac_address":     "MACAddress",
+		"profile":                 "ModuleTypeProfile",
+		"proposals":               "IKEProposal",
+		"provider":                "Provider",
+		"provider_account":        "ProviderAccount",
+		"provider_network":        "ProviderNetwork",
+		"qinq_svlan":              "VLAN",
+		"rack":                    "Rack",
+		"rack_type":               "RackType",
+		"rear_port":               "RearPort",
+		"region":                  "Region",
+		"rir":                     "RIR",
+		"role":                    "ContactRole",
+		"site":                    "Site",
+		"sites":                   "Site",
+		"tagged_vlans":            "VLAN",
+		"tags":                    "Tag",
+		"tenant":                  "Tenant",
+		"tunnel":                  "Tunnel",
+		"type":                    "CircuitType",
+		"untagged_vlan":           "VLAN",
+		"vdcs":                    "VirtualDeviceContext",
+		"virtual_chassis":         "VirtualChassis",
+		"virtual_circuit":         "VirtualCircuit",
+		"virtual_machine":         "VirtualMachine",
+		"vlan":                    "VLAN",
+		"vlan_translation_policy": "VLANTranslationPolicy",
+		"vrf":                     "VRF",
+		"wireless_lans":           "WirelessLAN",
+	}
+
+	if entityType, ok := fieldToType[fieldName]; ok {
+		return entityType
+	}
+	return fieldName // Return as-is if not found (may be the entity type itself)
 }

--- a/diode-server/gen/protograph/entity_mappings_test.go
+++ b/diode-server/gen/protograph/entity_mappings_test.go
@@ -15,34 +15,11 @@ func TestCreateEntityFromInterface(t *testing.T) {
 		wantNil  bool
 		wantType string
 	}{
-		{
-			name:    "nil input",
-			input:   nil,
-			wantNil: true,
-		},
-		{
-			name:     "device pointer",
-			input:    &diodepb.Device{},
-			wantNil:  false,
-			wantType: "Device",
-		},
-		{
-			name:     "site pointer",
-			input:    &diodepb.Site{},
-			wantNil:  false,
-			wantType: "Site",
-		},
-		{
-			name:     "interface pointer",
-			input:    &diodepb.Interface{},
-			wantNil:  false,
-			wantType: "Interface",
-		},
-		{
-			name:    "unknown type",
-			input:   "string",
-			wantNil: true,
-		},
+		{"nil input", nil, true, ""},
+		{"device pointer", &diodepb.Device{}, false, "Device"},
+		{"site pointer", &diodepb.Site{}, false, "Site"},
+		{"interface pointer", &diodepb.Interface{}, false, "Interface"},
+		{"unknown type", "string", true, ""},
 	}
 
 	for _, tt := range tests {
@@ -52,6 +29,7 @@ func TestCreateEntityFromInterface(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				assert.NotNil(t, result)
+				assert.Equal(t, tt.wantType, GetEntityTypeName(tt.input))
 			}
 		})
 	}

--- a/diode-server/gen/protograph/entity_mappings_test.go
+++ b/diode-server/gen/protograph/entity_mappings_test.go
@@ -1,0 +1,198 @@
+package protograph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
+)
+
+func TestCreateEntityFromInterface(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		wantNil  bool
+		wantType string
+	}{
+		{
+			name:    "nil input",
+			input:   nil,
+			wantNil: true,
+		},
+		{
+			name:     "device pointer",
+			input:    &diodepb.Device{},
+			wantNil:  false,
+			wantType: "Device",
+		},
+		{
+			name:     "site pointer",
+			input:    &diodepb.Site{},
+			wantNil:  false,
+			wantType: "Site",
+		},
+		{
+			name:     "interface pointer",
+			input:    &diodepb.Interface{},
+			wantNil:  false,
+			wantType: "Interface",
+		},
+		{
+			name:    "unknown type",
+			input:   "string",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CreateEntityFromInterface(tt.input)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestGetEntityTypeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{"nil", nil, ""},
+		{"device", &diodepb.Device{}, "Device"},
+		{"site", &diodepb.Site{}, "Site"},
+		{"interface", &diodepb.Interface{}, "Interface"},
+		{"manufacturer", &diodepb.Manufacturer{}, "Manufacturer"},
+		{"unknown", "string", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetEntityTypeName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsKnownEntityType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"device", &diodepb.Device{}, true},
+		{"site", &diodepb.Site{}, true},
+		{"string", "string", false},
+		{"int", 42, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsKnownEntityType(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetAllEntityTypes(t *testing.T) {
+	types := GetAllEntityTypes()
+	assert.NotEmpty(t, types)
+	assert.Contains(t, types, "Device")
+	assert.Contains(t, types, "Site")
+	assert.Contains(t, types, "Interface")
+}
+
+func TestGetEdgeTypesForField(t *testing.T) {
+	tests := []struct {
+		name       string
+		fieldName  string
+		sourceType string
+		wantFwd    string
+		wantRev    string
+	}{
+		{
+			name:       "site field from device",
+			fieldName:  "Site",
+			sourceType: "Device",
+			wantFwd:    "BELONGS_TO_SITE",
+			wantRev:    "HAS_DEVICE",
+		},
+		{
+			name:       "device_type field",
+			fieldName:  "DeviceType",
+			sourceType: "Device",
+			wantFwd:    "BELONGS_TO_DEVICE_TYPE",
+			wantRev:    "HAS_DEVICE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetEdgeTypesForField(tt.fieldName, tt.sourceType)
+			assert.Equal(t, tt.wantFwd, result.Forward)
+			assert.Equal(t, tt.wantRev, result.Reverse)
+		})
+	}
+}
+
+func TestGetEdgeTypeForField(t *testing.T) {
+	tests := []struct {
+		fieldName string
+		expected  string
+	}{
+		{"Site", "BELONGS_TO_SITE"},
+		{"DeviceType", "BELONGS_TO_DEVICE_TYPE"},
+		{"Manufacturer", "BELONGS_TO_MANUFACTURER"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			result := GetEdgeTypeForField(tt.fieldName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetReverseEdgeTypeForField(t *testing.T) {
+	tests := []struct {
+		sourceType string
+		expected   string
+	}{
+		{"Device", "HAS_DEVICE"},
+		{"Site", "HAS_SITE"},
+		{"Interface", "HAS_INTERFACE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sourceType, func(t *testing.T) {
+			result := GetReverseEdgeTypeForField(tt.sourceType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetNodeTypeForField(t *testing.T) {
+	tests := []struct {
+		fieldName string
+		expected  string
+	}{
+		{"site", "Site"},
+		{"Site", "Site"},
+		{"device_type", "DeviceType"},
+		{"DeviceType", "DeviceType"},
+		{"UnknownField", "UnknownField"}, // Returns as-is if not found
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			result := GetNodeTypeForField(tt.fieldName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/diode-server/reconciler/graph_builder.go
+++ b/diode-server/reconciler/graph_builder.go
@@ -1,0 +1,1455 @@
+package reconciler
+
+//go:generate go run ../cmd/protograph -proto=../../diode-proto/diode/v1/ingester.proto -output=../gen/protograph/entity_mappings.go
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/netboxlabs/diode/diode-server/entityhash"
+	"github.com/netboxlabs/diode/diode-server/gen/dbstore/postgres"
+	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
+	"github.com/netboxlabs/diode/diode-server/gen/netbox"
+	"github.com/netboxlabs/diode/diode-server/gen/protograph"
+	"github.com/netboxlabs/diode/diode-server/matching"
+)
+
+const (
+	// CurrentSchemaVersion represents the current matching schema version
+	CurrentSchemaVersion = 1
+	// DefaultSnapshotRetention is the default number of snapshots to keep
+	DefaultSnapshotRetention = 5
+)
+
+// GraphBuilder handles extraction and persistence of entity relationships
+type GraphBuilder struct {
+	repo              GraphRepository
+	logger            *slog.Logger
+	nodeCache         map[string]*GraphNode  // Cache for deduplication: "nodeType:externalID" -> *GraphNode
+	entityMatcher     matching.EntityMatcher // Confidence-based entity matcher
+	updatedNodes      map[string]*GraphNode  // Track nodes that were updated during processing
+	seenInThisRequest map[string]bool        // Track which nodes have been seen in this ingestion request
+	matchingConfig    *matching.Config       // Entity matching configuration for extracting attributes
+	snapshotRetention int                    // Number of snapshots to retain per node
+}
+
+// NewGraphBuilder creates a new GraphBuilder instance.
+// Note: EntityMatcher is nil by default. Use NewGraphBuilderWithMatcher or SetEntityMatcher
+// to enable confidence-based entity matching.
+func NewGraphBuilder(repo GraphRepository, logger *slog.Logger) *GraphBuilder {
+	return &GraphBuilder{
+		repo:              repo,
+		logger:            logger,
+		nodeCache:         make(map[string]*GraphNode),
+		entityMatcher:     nil, // Set via NewGraphBuilderWithMatcher or SetEntityMatcher
+		updatedNodes:      make(map[string]*GraphNode),
+		seenInThisRequest: make(map[string]bool),
+		snapshotRetention: DefaultSnapshotRetention,
+	}
+}
+
+// NewGraphBuilderWithMatcher creates a new GraphBuilder instance with custom entity matcher
+func NewGraphBuilderWithMatcher(repo GraphRepository, logger *slog.Logger, matcher matching.EntityMatcher) *GraphBuilder {
+	return &GraphBuilder{
+		repo:              repo,
+		logger:            logger,
+		nodeCache:         make(map[string]*GraphNode),
+		entityMatcher:     matcher,
+		updatedNodes:      make(map[string]*GraphNode),
+		seenInThisRequest: make(map[string]bool),
+		snapshotRetention: DefaultSnapshotRetention,
+	}
+}
+
+// SetEntityMatcher sets the entity matcher for confidence-based matching
+func (gb *GraphBuilder) SetEntityMatcher(matcher matching.EntityMatcher) {
+	gb.entityMatcher = matcher
+}
+
+// SetMatchingConfig sets the entity matching configuration
+func (gb *GraphBuilder) SetMatchingConfig(config *matching.Config) {
+	gb.matchingConfig = config
+}
+
+// SetSnapshotRetention sets the number of snapshots to retain per node
+func (gb *GraphBuilder) SetSnapshotRetention(count int) {
+	if count > 0 {
+		gb.snapshotRetention = count
+	}
+}
+
+// extractMatchingAttributes extracts only the attributes needed for matching from the full entity data
+func (gb *GraphBuilder) extractMatchingAttributes(entityType string, fullEntityData json.RawMessage) (json.RawMessage, error) {
+	// If no matching config is set, return the full entity data as fallback
+	if gb.matchingConfig == nil {
+		return fullEntityData, nil
+	}
+
+	// Get matching rules for this entity type
+	var entityRule matching.EntityMatchingRule
+	var found bool
+
+	// Try to get entity-specific rule first
+	if entityRule, found = gb.matchingConfig.DefaultEntityRules[entityType]; !found {
+		// Fall back to wildcard rule
+		if entityRule, found = gb.matchingConfig.DefaultEntityRules["*"]; !found {
+			// No matching rules found, return full data
+			return fullEntityData, nil
+		}
+	}
+
+	// Parse the full entity data
+	var fullData map[string]any
+	if err := json.Unmarshal(fullEntityData, &fullData); err != nil {
+		return nil, fmt.Errorf("failed to parse entity data: %w", err)
+	}
+
+	// Extract only the fields used in matching rules
+	matchingData := make(map[string]any)
+
+	// Process primary rules
+	for _, rule := range entityRule.PrimaryRules {
+		if value := gb.extractFieldByPath(fullData, rule.FieldPath); value != nil {
+			gb.setFieldByPath(matchingData, rule.FieldPath, value)
+		}
+	}
+
+	// Process secondary rules
+	for _, rule := range entityRule.SecondaryRules {
+		if value := gb.extractFieldByPath(fullData, rule.FieldPath); value != nil {
+			gb.setFieldByPath(matchingData, rule.FieldPath, value)
+		}
+	}
+
+	// If no matching data was extracted (empty object), fall back to full entity data
+	if len(matchingData) == 0 {
+		return fullEntityData, nil
+	}
+
+	// Marshal the extracted matching data back to JSON
+	matchingJSON, err := json.Marshal(matchingData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal matching data: %w", err)
+	}
+
+	return matchingJSON, nil
+}
+
+// extractFieldByPath extracts a value from nested data using a field path like "Device.name" or "Device.site.name"
+func (gb *GraphBuilder) extractFieldByPath(data map[string]any, fieldPath string) any {
+	parts := strings.Split(fieldPath, ".")
+	current := data
+
+	for _, part := range parts {
+		if current == nil {
+			return nil
+		}
+
+		if nextValue, exists := current[part]; exists {
+			if nextMap, ok := nextValue.(map[string]any); ok {
+				current = nextMap
+			} else {
+				// This is the final value
+				return nextValue
+			}
+		} else {
+			return nil
+		}
+	}
+
+	return current
+}
+
+// setFieldByPath sets a value in nested data using a field path like "Device.name" or "Device.site.name"
+func (gb *GraphBuilder) setFieldByPath(data map[string]any, fieldPath string, value any) {
+	parts := strings.Split(fieldPath, ".")
+	current := data
+
+	// Navigate to the parent of the target field
+	for _, part := range parts[:len(parts)-1] {
+		if _, exists := current[part]; !exists {
+			current[part] = make(map[string]any)
+		}
+		if nextMap, ok := current[part].(map[string]any); ok {
+			current = nextMap
+		} else {
+			// Path conflicts with existing non-map value, create a new path
+			current[part] = make(map[string]any)
+			current = current[part].(map[string]any)
+		}
+	}
+
+	// Set the final value
+	finalKey := parts[len(parts)-1]
+	current[finalKey] = value
+}
+
+// createSnapshot creates a new snapshot for the given node with the full entity data
+func (gb *GraphBuilder) createSnapshot(ctx context.Context, nodeID int64, fullEntityData json.RawMessage) error {
+	// Insert the new snapshot (sequence number is auto-computed by the SQL query)
+	_, err := gb.repo.InsertSnapshot(ctx, postgres.InsertSnapshotParams{
+		NodeID:       nodeID,
+		SnapshotData: fullEntityData,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to insert snapshot: %w", err)
+	}
+
+	// Clean up old snapshots to maintain retention limit
+	err = gb.repo.CleanupOldSnapshots(ctx, postgres.CleanupOldSnapshotsParams{
+		NodeID: nodeID,
+		Limit:  int32(gb.snapshotRetention),
+	})
+	if err != nil {
+		gb.logger.Warn("failed to cleanup old snapshots", "error", err, "node_id", nodeID)
+		// Don't fail the entire operation for cleanup issues
+	}
+
+	return nil
+}
+
+// needsSchemaUpdate checks if a node needs its matching data updated due to schema version mismatch
+func (gb *GraphBuilder) needsSchemaUpdate(node *postgres.GraphNode) bool {
+	return node.MatchingSchemaVersion < CurrentSchemaVersion
+}
+
+// updateNodeMatchingData updates a node's matching data to the current schema version
+func (gb *GraphBuilder) updateNodeMatchingData(ctx context.Context, node *postgres.GraphNode, fullEntityData json.RawMessage) error {
+	// Extract matching attributes based on current schema
+	matchingData, err := gb.extractMatchingAttributes(node.NodeType, fullEntityData)
+	if err != nil {
+		return fmt.Errorf("failed to extract matching attributes: %w", err)
+	}
+
+	// Update the node with new matching data and schema version
+	_, err = gb.repo.UpdateGraphNodeData(ctx, postgres.UpdateGraphNodeDataParams{
+		NodeType:              node.NodeType,
+		ExternalID:            node.ExternalID,
+		Data:                  matchingData,
+		MatchingSchemaVersion: CurrentSchemaVersion,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update node matching data: %w", err)
+	}
+
+	return nil
+}
+
+// GetCompleteNodeData retrieves a node with its complete entity data by combining matching data and latest snapshot
+func (gb *GraphBuilder) GetCompleteNodeData(ctx context.Context, nodeType, externalID string) (*CompleteNodeData, error) {
+	// Get the node with its latest snapshot in a single query
+	nodeWithSnapshot, err := gb.repo.GetNodeWithLatestSnapshot(ctx, postgres.GetNodeWithLatestSnapshotParams{
+		NodeType:   nodeType,
+		ExternalID: externalID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node with latest snapshot: %w", err)
+	}
+
+	result := &CompleteNodeData{
+		ID:                    nodeWithSnapshot.ID,
+		ExternalID:            nodeWithSnapshot.ExternalID,
+		NodeType:              nodeWithSnapshot.NodeType,
+		MatchingData:          nodeWithSnapshot.MatchingData,
+		DuplicateCount:        nodeWithSnapshot.DuplicateCount,
+		MatchingSchemaVersion: nodeWithSnapshot.MatchingSchemaVersion,
+		CreatedAt:             nodeWithSnapshot.CreatedAt,
+		UpdatedAt:             nodeWithSnapshot.UpdatedAt,
+	}
+
+	// Check if we have snapshot data
+	if len(nodeWithSnapshot.SnapshotData) > 0 {
+		result.CompleteData = nodeWithSnapshot.SnapshotData
+		result.SnapshotSequenceNumber = &nodeWithSnapshot.SequenceNumber
+		if nodeWithSnapshot.SnapshotCreatedAt.Valid {
+			result.SnapshotCreatedAt = &nodeWithSnapshot.SnapshotCreatedAt
+		}
+	} else {
+		// No snapshot available, use matching data as fallback
+		result.CompleteData = nodeWithSnapshot.MatchingData
+		gb.logger.Warn("no snapshot available for node, using matching data as complete data",
+			"node_type", nodeType,
+			"external_id", externalID)
+	}
+
+	return result, nil
+}
+
+// GetNodeSnapshots retrieves all snapshots for a given node
+func (gb *GraphBuilder) GetNodeSnapshots(ctx context.Context, nodeID int64, limit, offset int) ([]postgres.GraphNodeSnapshot, error) {
+	return gb.repo.GetSnapshotsByNode(ctx, postgres.GetSnapshotsByNodeParams{
+		NodeID: nodeID,
+		Limit:  int32(limit),
+		Offset: int32(offset),
+	})
+}
+
+// CompleteNodeData represents a node with its complete entity data
+type CompleteNodeData struct {
+	ID                     int64               `json:"id"`
+	ExternalID             string              `json:"external_id"`
+	NodeType               string              `json:"node_type"`
+	MatchingData           json.RawMessage     `json:"matching_data"` // Data used for matching
+	CompleteData           json.RawMessage     `json:"complete_data"` // Complete entity data from latest snapshot
+	DuplicateCount         int32               `json:"duplicate_count"`
+	MatchingSchemaVersion  int32               `json:"matching_schema_version"`
+	SnapshotSequenceNumber *int32              `json:"snapshot_sequence_number,omitempty"`
+	CreatedAt              pgtype.Timestamptz  `json:"created_at"`
+	UpdatedAt              pgtype.Timestamptz  `json:"updated_at"`
+	SnapshotCreatedAt      *pgtype.Timestamptz `json:"snapshot_created_at,omitempty"`
+}
+
+// MigrateNodesToCurrentSchema performs bulk migration of nodes to the current schema version
+func (gb *GraphBuilder) MigrateNodesToCurrentSchema(ctx context.Context, batchSize int) (int, error) {
+	if gb.matchingConfig == nil {
+		return 0, fmt.Errorf("matching configuration not set, cannot perform schema migration")
+	}
+
+	migratedCount := 0
+	offset := 0
+
+	for {
+		// Find nodes needing schema update
+		nodes, err := gb.repo.FindNodesNeedingSchemaUpdate(ctx, postgres.FindNodesNeedingSchemaUpdateParams{
+			MatchingSchemaVersion: int32(CurrentSchemaVersion),
+			Limit:                 int32(batchSize),
+			Offset:                int32(offset),
+		})
+		if err != nil {
+			return migratedCount, fmt.Errorf("failed to find nodes needing schema update: %w", err)
+		}
+
+		if len(nodes) == 0 {
+			break // No more nodes to migrate
+		}
+
+		// Process each node
+		for _, node := range nodes {
+			// Get the latest snapshot for this node to reconstruct full entity data
+			latestSnapshot, err := gb.repo.GetLatestSnapshot(ctx, node.ID)
+			if err != nil {
+				gb.logger.Warn("failed to get latest snapshot for schema migration, skipping node",
+					"error", err,
+					"node_id", node.ID,
+					"node_type", node.NodeType,
+					"external_id", node.ExternalID)
+				continue
+			}
+
+			// Update the node's matching data based on current schema
+			err = gb.updateNodeMatchingData(ctx, &node, latestSnapshot.SnapshotData)
+			if err != nil {
+				gb.logger.Warn("failed to update node matching data during schema migration",
+					"error", err,
+					"node_id", node.ID,
+					"node_type", node.NodeType,
+					"external_id", node.ExternalID)
+				continue
+			}
+
+			migratedCount++
+			gb.logger.Debug("migrated node to current schema",
+				"node_id", node.ID,
+				"node_type", node.NodeType,
+				"external_id", node.ExternalID,
+				"old_version", node.MatchingSchemaVersion,
+				"new_version", CurrentSchemaVersion)
+		}
+
+		offset += len(nodes)
+	}
+
+	gb.logger.Info("completed schema migration",
+		"migrated_count", migratedCount,
+		"target_schema_version", CurrentSchemaVersion)
+
+	return migratedCount, nil
+}
+
+// ExtractGraph processes an entity and creates/updates its graph representation recursively
+func (gb *GraphBuilder) ExtractGraph(ctx context.Context, entity *diodepb.Entity) error {
+	if entity == nil || entity.GetEntity() == nil {
+		return fmt.Errorf("entity or entity content is nil")
+	}
+
+	// Clear caches for each top-level extraction
+	gb.nodeCache = make(map[string]*GraphNode)
+	gb.updatedNodes = make(map[string]*GraphNode)
+	gb.seenInThisRequest = make(map[string]bool)
+
+	// Recursively process the entire entity tree
+	rootNode, err := gb.processEntityRecursively(ctx, entity)
+	if err != nil {
+		return fmt.Errorf("failed to process entity tree: %w", err)
+	}
+
+	// Propagate updates to dependent nodes
+	if len(gb.updatedNodes) > 0 {
+		err = gb.propagateNodeUpdates(ctx)
+		if err != nil {
+			gb.logger.Warn("failed to propagate node updates", "error", err)
+		}
+	}
+
+	gb.logger.Debug("completed recursive graph extraction",
+		"root_node_type", rootNode.NodeType,
+		"root_external_id", rootNode.ExternalID,
+		"total_nodes_processed", len(gb.nodeCache),
+		"nodes_updated", len(gb.updatedNodes))
+
+	return nil
+}
+
+// processEntityRecursively processes an entity and all its nested entities recursively
+func (gb *GraphBuilder) processEntityRecursively(ctx context.Context, entity *diodepb.Entity) (*GraphNode, error) {
+	if entity == nil || entity.GetEntity() == nil {
+		return nil, nil
+	}
+
+	// Extract node type using proto names for consistency
+	nodeType := getEntityTypeName(entity)
+	if nodeType == "" {
+		return nil, fmt.Errorf("failed to get object type from entity")
+	}
+
+	fingerprinter := entityhash.NewEntityFingerprinter()
+	externalID, err := fingerprinter.GenerateEntityHash(entity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate entity hash: %w", err)
+	}
+
+	// Check if we've already processed this node (deduplication)
+	cacheKey := fmt.Sprintf("%s:%s", nodeType, externalID)
+	if cachedNode, exists := gb.nodeCache[cacheKey]; exists {
+		return cachedNode, nil
+	}
+
+	// Try confidence-based matching first before creating new node
+	var matchedNode *GraphNode
+	var matchConfidence matching.MatchConfidence
+	var matchReason string
+	var bestMatch *matching.MatchResult
+
+	if gb.entityMatcher != nil {
+		var matchErr error
+		bestMatch, matchErr = gb.entityMatcher.FindBestMatch(ctx, entity)
+		if matchErr != nil {
+			gb.logger.Warn("failed to find entity matches", "error", matchErr, "entity_type", nodeType)
+		} else if bestMatch != nil && bestMatch.NodeID != nil {
+			// Found a confident match, use existing node
+			matchedNode = &GraphNode{
+				ID:         *bestMatch.NodeID,
+				ExternalID: externalID, // Keep new external ID for this observation
+				NodeType:   nodeType,
+				Data:       bestMatch.ExistingData,
+			}
+			matchConfidence = bestMatch.Confidence
+			matchReason = bestMatch.MatchReason
+
+			gb.logger.Info("found confident match for entity",
+				"entity_type", nodeType,
+				"matched_node_id", *bestMatch.NodeID,
+				"confidence", float64(bestMatch.Confidence),
+				"reason", bestMatch.MatchReason,
+				"matching_fields", bestMatch.MatchingFields)
+		}
+	}
+
+	// Marshal entity data
+	entityData, err := protojson.Marshal(entity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal entity: %w", err)
+	}
+
+	var node *GraphNode
+
+	if matchedNode != nil {
+		// Found a confident match - use the existing node's external ID to find and update it
+		if bestMatch.ExternalID == nil {
+			return nil, fmt.Errorf("matched node missing external ID")
+		}
+
+		existingNode, err := gb.repo.FindGraphNode(ctx, postgres.FindGraphNodeParams{
+			NodeType:   nodeType,
+			ExternalID: *bestMatch.ExternalID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to find existing matched node: %w", err)
+		}
+
+		// Extract matching attributes from the new entity data
+		matchingData, err := gb.extractMatchingAttributes(nodeType, entityData)
+		if err != nil {
+			gb.logger.Warn("failed to extract matching attributes, using full data", "error", err, "node_type", nodeType)
+			matchingData = entityData
+		}
+
+		// Convert FindGraphNodeRow to GraphNode for schema checks
+		existingGraphNode := &postgres.GraphNode{
+			ID:                    existingNode.ID,
+			ExternalID:            existingNode.ExternalID,
+			NodeType:              existingNode.NodeType,
+			Data:                  existingNode.Data,
+			DuplicateCount:        existingNode.DuplicateCount,
+			MatchingSchemaVersion: existingNode.MatchingSchemaVersion,
+		}
+
+		// Check if existing node needs schema update (lazy migration)
+		if gb.needsSchemaUpdate(existingGraphNode) {
+			gb.logger.Info("updating node matching data due to schema change",
+				"node_type", nodeType,
+				"external_id", existingNode.ExternalID,
+				"old_version", existingNode.MatchingSchemaVersion,
+				"new_version", CurrentSchemaVersion)
+
+			err = gb.updateNodeMatchingData(ctx, existingGraphNode, entityData)
+			if err != nil {
+				gb.logger.Warn("failed to update node schema, continuing", "error", err)
+			}
+		}
+
+		// Create a unique key for this node in this request
+		requestKey := fmt.Sprintf("%s:%s", nodeType, existingNode.ExternalID)
+
+		var result postgres.UpsertGraphNodeRow
+		if gb.seenInThisRequest[requestKey] {
+			// Already seen in this request - update data but don't increment duplicate count
+			updateResult, err := gb.repo.UpdateGraphNodeData(ctx, postgres.UpdateGraphNodeDataParams{
+				NodeType:              nodeType,
+				ExternalID:            existingNode.ExternalID,
+				Data:                  matchingData,
+				MatchingSchemaVersion: CurrentSchemaVersion,
+			})
+			if err == nil {
+				// Convert UpdateGraphNodeDataRow to UpsertGraphNodeRow format
+				result = postgres.UpsertGraphNodeRow(updateResult)
+			}
+			gb.logger.Debug("updated matched node data without incrementing duplicate count",
+				"node_type", nodeType,
+				"external_id", existingNode.ExternalID)
+		} else {
+			// First time seeing this node in this request - normal upsert with duplicate count increment
+			params := postgres.UpsertGraphNodeParams{
+				ExternalID:            existingNode.ExternalID, // Keep existing external ID
+				NodeType:              nodeType,
+				Data:                  matchingData, // Use extracted matching data
+				MatchingSchemaVersion: CurrentSchemaVersion,
+			}
+			result, err = gb.repo.UpsertGraphNode(ctx, params)
+			// Mark this node as seen in this request
+			gb.seenInThisRequest[requestKey] = true
+			gb.logger.Debug("updated matched node with duplicate count increment",
+				"node_type", nodeType,
+				"external_id", existingNode.ExternalID,
+				"duplicate_count", result.DuplicateCount)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to update matched node: %w", err)
+		}
+
+		// Create snapshot with full entity data
+		err = gb.createSnapshot(ctx, result.ID, entityData)
+		if err != nil {
+			gb.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
+			// Don't fail the entire operation for snapshot issues
+		}
+
+		node = &GraphNode{
+			ID:                    result.ID,
+			ExternalID:            result.ExternalID,
+			NodeType:              result.NodeType,
+			Data:                  result.Data,
+			DuplicateCount:        result.DuplicateCount,
+			MatchingSchemaVersion: result.MatchingSchemaVersion,
+		}
+
+		// Track this node as updated for propagation
+		nodeKey := fmt.Sprintf("%s:%s", nodeType, result.ExternalID)
+		gb.updatedNodes[nodeKey] = node
+
+		gb.logger.Info("reused existing matched node",
+			"matched_node_id", matchedNode.ID,
+			"confidence", float64(matchConfidence),
+			"reason", matchReason,
+			"duplicate_count", node.DuplicateCount,
+			"external_id", result.ExternalID)
+	} else {
+		// Create or update node in database (no match found)
+		node, err = gb.upsertNode(ctx, externalID, nodeType, entityData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upsert node: %w", err)
+		}
+	}
+
+	// Cache the node for deduplication
+	gb.nodeCache[cacheKey] = node
+
+	gb.logger.Debug("processed graph node",
+		"node_type", nodeType,
+		"external_id", externalID,
+		"duplicate_count", node.DuplicateCount,
+		"node_id", node.ID)
+
+	// Recursively process all nested entities and create edges
+	edges, err := gb.extractEdgesRecursively(ctx, entity, node)
+	if err != nil {
+		gb.logger.Warn("failed to extract edges recursively",
+			"node_type", nodeType,
+			"external_id", externalID,
+			"error", err)
+	} else {
+		// Create all edges
+		for _, edge := range edges {
+			if err := gb.upsertEdge(ctx, edge); err != nil {
+				gb.logger.Warn("failed to create edge",
+					"source_id", edge.SourceNodeID,
+					"target_id", edge.TargetNodeID,
+					"edge_type", edge.EdgeType,
+					"error", err)
+			}
+		}
+		gb.logger.Debug("processed edges for node", "count", len(edges), "node_id", node.ID)
+	}
+
+	return node, nil
+}
+
+// extractEdgesRecursively finds all relationships within the entity and creates edges recursively
+func (gb *GraphBuilder) extractEdgesRecursively(ctx context.Context, entity *diodepb.Entity, sourceNode *GraphNode) ([]*GraphEdge, error) {
+	var edges []*GraphEdge
+
+	// Get the actual entity from the wrapper (e.g., Device from Entity_Device)
+	wrapperValue := reflect.ValueOf(entity.GetEntity())
+	if wrapperValue.Kind() == reflect.Ptr {
+		wrapperValue = wrapperValue.Elem()
+	}
+
+	// The wrapper has one field containing the actual entity
+	if wrapperValue.NumField() != 1 {
+		return edges, fmt.Errorf("expected wrapper to have exactly 1 field, got %d", wrapperValue.NumField())
+	}
+
+	// Get the actual entity (e.g., the Device struct inside Entity_Device)
+	actualEntityField := wrapperValue.Field(0)
+	if !actualEntityField.IsValid() || actualEntityField.IsNil() {
+		return edges, nil
+	}
+
+	entityValue := actualEntityField
+	if entityValue.Kind() == reflect.Ptr {
+		entityValue = entityValue.Elem()
+	}
+
+	entityType := entityValue.Type()
+	gb.logger.Debug("processing actual entity fields", "entity_type", entityType.Name(), "num_fields", entityValue.NumField())
+
+	for i := 0; i < entityValue.NumField(); i++ {
+		field := entityValue.Field(i)
+		fieldType := entityType.Field(i)
+		fieldName := fieldType.Name
+
+		// Skip non-exported fields
+		if !field.CanInterface() {
+			continue
+		}
+
+		gb.logger.Debug("found field", "field", fieldName, "kind", field.Kind().String(), "type", fmt.Sprintf("%T", field.Interface()))
+
+		// Process single entity field
+		if field.Kind() == reflect.Ptr && !field.IsNil() {
+			gb.logger.Debug("processing pointer field", "field", fieldName, "type", fmt.Sprintf("%T", field.Interface()))
+			edge, err := gb.processFieldRecursively(ctx, sourceNode, field, fieldName)
+			if err != nil {
+				gb.logger.Warn("failed to process field recursively", "field", fieldName, "error", err)
+				continue
+			}
+			if edge != nil {
+				edges = append(edges, edge)
+			}
+		}
+
+		// Process slice fields (repeated references)
+		if field.Kind() == reflect.Slice {
+			gb.logger.Debug("processing slice field", "field", fieldName, "length", field.Len())
+			sliceEdges, err := gb.processSliceFieldRecursively(ctx, sourceNode, field, fieldName)
+			if err != nil {
+				gb.logger.Warn("failed to process slice field recursively", "field", fieldName, "error", err)
+				continue
+			}
+			edges = append(edges, sliceEdges...)
+		}
+	}
+
+	return edges, nil
+}
+
+// extractEdgeProperties extracts properties to be stored on an edge based on reflection
+// It automatically identifies fields that should be edge properties (not node properties)
+// based on the edge_property_fields configuration in the matching config.
+func (gb *GraphBuilder) extractEdgeProperties(fieldValue any, _ string) json.RawMessage {
+	if fieldValue == nil {
+		return json.RawMessage("{}")
+	}
+
+	// If no matching config, return empty properties
+	if gb.matchingConfig == nil {
+		return json.RawMessage("{}")
+	}
+
+	// Get the entity type name from the field value
+	entityTypeName := gb.getEntityTypeNameFromValue(fieldValue)
+	if entityTypeName == "" {
+		return json.RawMessage("{}")
+	}
+
+	// Look up the matching rule for this entity type to get edge property fields
+	entityRule, found := gb.matchingConfig.DefaultEntityRules[entityTypeName]
+	if !found || len(entityRule.EdgePropertyFields) == 0 {
+		return json.RawMessage("{}")
+	}
+
+	propertyFieldNames := entityRule.EdgePropertyFields
+
+	// Use reflection to extract the configured fields
+	properties := make(map[string]any)
+	val := reflect.ValueOf(fieldValue)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	// Extract each configured edge property field
+	for _, fieldName := range propertyFieldNames {
+		if field := val.FieldByName(fieldName); field.IsValid() && field.CanInterface() {
+			fieldValue := field.Interface()
+
+			// Only include non-zero values
+			if !reflect.DeepEqual(fieldValue, reflect.Zero(field.Type()).Interface()) {
+				// Convert field name to snake_case for JSON
+				jsonFieldName := gb.toSnakeCase(fieldName)
+				properties[jsonFieldName] = fieldValue
+			}
+		}
+	}
+
+	// If we extracted any properties, return them as JSON
+	if len(properties) > 0 {
+		if propsJSON, err := json.Marshal(properties); err == nil {
+			gb.logger.Debug("extracted edge properties",
+				"entity_type", entityTypeName,
+				"properties", properties)
+			return propsJSON
+		}
+	}
+
+	// Default: return empty JSON object for edges without special properties
+	return json.RawMessage("{}")
+}
+
+// getEntityTypeNameFromValue extracts the entity type name from a reflect.Value
+func (gb *GraphBuilder) getEntityTypeNameFromValue(fieldValue any) string {
+	typ := reflect.TypeOf(fieldValue)
+	if typ == nil {
+		return ""
+	}
+
+	// Handle pointer types
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	// Get the type name (e.g., "ServicePort")
+	return typ.Name()
+}
+
+// toSnakeCase converts a PascalCase or camelCase string to snake_case
+func (gb *GraphBuilder) toSnakeCase(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	var result strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			result.WriteRune('_')
+		}
+		result.WriteRune(r)
+	}
+
+	return strings.ToLower(result.String())
+}
+
+// processFieldRecursively processes a single field and creates an edge if it references another entity, recursively processing nested entities
+func (gb *GraphBuilder) processFieldRecursively(ctx context.Context, sourceNode *GraphNode, field reflect.Value, fieldName string) (*GraphEdge, error) {
+	if !field.IsValid() || field.IsNil() {
+		return nil, nil
+	}
+
+	fieldInterface := field.Interface()
+
+	// Try to recursively process this field as a nested entity first
+	targetNode, err := gb.processNestedEntityRecursively(ctx, fieldInterface, fieldName)
+	if err != nil {
+		return nil, err
+	}
+
+	// If recursive processing didn't work, try the fallback approach
+	if targetNode == nil {
+		targetNode, err = gb.findTargetNodeFromField(ctx, fieldInterface, fieldName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if targetNode == nil {
+		return nil, nil
+	}
+
+	// Create edge based on field name
+	edgeType := gb.getEdgeTypeFromFieldName(fieldName)
+
+	return &GraphEdge{
+		SourceNodeID: sourceNode.ID,
+		TargetNodeID: targetNode.ID,
+		EdgeType:     edgeType,
+		Properties:   json.RawMessage("{}"),
+	}, nil
+}
+
+// processSliceFieldRecursively processes slice fields that may contain multiple references, recursively processing each nested entity
+func (gb *GraphBuilder) processSliceFieldRecursively(ctx context.Context, sourceNode *GraphNode, field reflect.Value, fieldName string) ([]*GraphEdge, error) {
+	var edges []*GraphEdge
+
+	for i := 0; i < field.Len(); i++ {
+		item := field.Index(i)
+		if !item.IsValid() || item.IsNil() {
+			continue
+		}
+
+		// Extract edge properties before processing (for ServicePort, extract port_state)
+		edgeProperties := gb.extractEdgeProperties(item.Interface(), fieldName)
+
+		targetNode, err := gb.processNestedEntityRecursively(ctx, item.Interface(), fieldName)
+		if err != nil {
+			gb.logger.Warn("failed to process slice item", "field", fieldName, "index", i, "error", err)
+			continue
+		}
+
+		if targetNode == nil {
+			continue
+		}
+
+		edgeType := gb.getEdgeTypeFromFieldName(fieldName)
+		edges = append(edges, &GraphEdge{
+			SourceNodeID: sourceNode.ID,
+			TargetNodeID: targetNode.ID,
+			EdgeType:     edgeType,
+			Properties:   edgeProperties,
+		})
+	}
+
+	return edges, nil
+}
+
+// processNestedEntityRecursively attempts to process a nested entity recursively
+func (gb *GraphBuilder) processNestedEntityRecursively(ctx context.Context, fieldValue any, _ string) (*GraphNode, error) {
+	// Use generated function to create entity from field value
+	entity := protograph.CreateEntityFromInterface(fieldValue)
+	if entity == nil {
+		return nil, nil
+	}
+
+	// If we successfully created an entity, recursively process it
+	return gb.processEntityRecursively(ctx, entity)
+}
+
+// upsertNode creates or updates a node, incrementing duplicate count only once per ingestion request
+func (gb *GraphBuilder) upsertNode(ctx context.Context, externalID, nodeType string, fullEntityData json.RawMessage) (*GraphNode, error) {
+	// Extract matching attributes from full entity data
+	matchingData, err := gb.extractMatchingAttributes(nodeType, fullEntityData)
+	if err != nil {
+		gb.logger.Warn("failed to extract matching attributes, using full data", "error", err, "node_type", nodeType)
+		matchingData = fullEntityData
+	}
+
+	// Create a unique key for this node in this request
+	requestKey := fmt.Sprintf("%s:%s", nodeType, externalID)
+
+	// Check if we've already processed this node in this ingestion request
+	alreadySeenInRequest := gb.seenInThisRequest[requestKey]
+
+	var result postgres.UpsertGraphNodeRow
+
+	if alreadySeenInRequest {
+		// This node was already seen in this request - update data but don't increment duplicate count
+		updateResult, err := gb.repo.UpdateGraphNodeData(ctx, postgres.UpdateGraphNodeDataParams{
+			NodeType:              nodeType,
+			ExternalID:            externalID,
+			Data:                  matchingData,
+			MatchingSchemaVersion: CurrentSchemaVersion,
+		})
+		if err == nil {
+			// Convert UpdateGraphNodeDataRow to UpsertGraphNodeRow format
+			result = postgres.UpsertGraphNodeRow(updateResult)
+		}
+		gb.logger.Debug("updated node data without incrementing duplicate count",
+			"node_type", nodeType,
+			"external_id", externalID)
+	} else {
+		// First time seeing this node in this request - normal upsert with duplicate count increment
+		result, err = gb.repo.UpsertGraphNode(ctx, postgres.UpsertGraphNodeParams{
+			ExternalID:            externalID,
+			NodeType:              nodeType,
+			Data:                  matchingData,
+			MatchingSchemaVersion: CurrentSchemaVersion,
+		})
+		// Mark this node as seen in this request
+		gb.seenInThisRequest[requestKey] = true
+		gb.logger.Debug("upserted node with duplicate count increment",
+			"node_type", nodeType,
+			"external_id", externalID,
+			"duplicate_count", result.DuplicateCount)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Create snapshot with full entity data
+	err = gb.createSnapshot(ctx, result.ID, fullEntityData)
+	if err != nil {
+		gb.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
+		// Don't fail the entire operation for snapshot issues
+	}
+
+	return &GraphNode{
+		ID:                    result.ID,
+		ExternalID:            result.ExternalID,
+		NodeType:              result.NodeType,
+		Data:                  result.Data,
+		DuplicateCount:        result.DuplicateCount,
+		MatchingSchemaVersion: result.MatchingSchemaVersion,
+	}, nil
+}
+
+// findTargetNodeFromField attempts to find or create a target node from a field value
+func (gb *GraphBuilder) findTargetNodeFromField(ctx context.Context, fieldValue any, fieldName string) (*GraphNode, error) {
+	// Use generated function to create entity from field value
+	entity := protograph.CreateEntityFromInterface(fieldValue)
+
+	if entity != nil {
+		// Use comprehensive functions if we successfully created an entity
+		nodeType := getEntityTypeName(entity)
+		if nodeType == "" {
+			return nil, fmt.Errorf("failed to get object type for nested entity")
+		}
+
+		fingerprinter := entityhash.NewEntityFingerprinter()
+		externalID, err := fingerprinter.GenerateEntityHash(entity)
+		if err != nil {
+			return nil, err
+		}
+
+		if externalID == "" {
+			return nil, nil
+		}
+
+		// Try to find existing node
+		return gb.findNodeByTypeAndID(ctx, nodeType, externalID)
+	}
+
+	// Fallback to the old approach if entity type not recognized
+	if hasName, ok := fieldValue.(interface{ GetName() string }); ok {
+		name := hasName.GetName()
+		if name == "" {
+			return nil, nil
+		}
+
+		// Determine node type from field name
+		nodeType := gb.getNodeTypeFromFieldName(fieldName)
+
+		// Try to find existing node
+		return gb.findNodeByTypeAndID(ctx, nodeType, name)
+	}
+
+	return nil, nil
+}
+
+// findNodeByTypeAndID looks up an existing node by type and external ID
+func (gb *GraphBuilder) findNodeByTypeAndID(ctx context.Context, nodeType, externalID string) (*GraphNode, error) {
+	result, err := gb.repo.FindGraphNode(ctx, postgres.FindGraphNodeParams{
+		NodeType:   nodeType,
+		ExternalID: externalID,
+	})
+	if err != nil {
+		// Check if this is a "no rows" error - return nil, nil if so
+		if err.Error() == "no rows in result set" {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &GraphNode{
+		ID:             result.ID,
+		ExternalID:     result.ExternalID,
+		NodeType:       result.NodeType,
+		Data:           result.Data,
+		DuplicateCount: result.DuplicateCount,
+	}, nil
+}
+
+// upsertEdge creates or updates an edge
+func (gb *GraphBuilder) upsertEdge(ctx context.Context, edge *GraphEdge) error {
+	return gb.repo.UpsertGraphEdge(ctx, postgres.UpsertGraphEdgeParams{
+		SourceNodeID: edge.SourceNodeID,
+		TargetNodeID: edge.TargetNodeID,
+		EdgeType:     edge.EdgeType,
+		Properties:   edge.Properties,
+	})
+}
+
+// getEntityTypeName extracts the entity type name from an entity using proto names
+func getEntityTypeName(entity *diodepb.Entity) string {
+	if entity == nil || entity.GetEntity() == nil {
+		return ""
+	}
+
+	// Simple approach using reflection to get the type name
+	entityWrapper := entity.GetEntity()
+	entityType := reflect.TypeOf(entityWrapper)
+	if entityType == nil {
+		return ""
+	}
+
+	// Extract the type name from the wrapper (e.g., "Entity_Device" -> "Device")
+	typeName := entityType.Elem().Name()
+	if name, found := strings.CutPrefix(typeName, "Entity_"); found {
+		return name
+	}
+
+	return typeName
+}
+
+// getEdgeTypeFromFieldName maps field names to semantic edge types
+func (gb *GraphBuilder) getEdgeTypeFromFieldName(fieldName string) string {
+	switch fieldName {
+	// Hierarchical relationships
+	case "Device", "device":
+		return "BELONGS_TO_DEVICE"
+	case "Site", "site":
+		return "BELONGS_TO_SITE"
+	case "Location", "location":
+		return "LOCATED_IN"
+	case "Rack", "rack":
+		return "POSITIONED_IN_RACK"
+	case "Region", "region":
+		return "BELONGS_TO_REGION"
+	case "SiteGroup", "site_group":
+		return "BELONGS_TO_SITE_GROUP"
+	case "Cluster", "cluster":
+		return "BELONGS_TO_CLUSTER"
+	case "ClusterGroup", "cluster_group":
+		return "BELONGS_TO_CLUSTER_GROUP"
+	case "VirtualMachine", "virtual_machine":
+		return "BELONGS_TO_VM"
+
+	// Network relationships
+	case "Vrf", "vrf":
+		return "MEMBER_OF_VRF"
+	case "TaggedVlans", "tagged_vlans", "Vlan", "vlan":
+		return "TAGGED_WITH_VLAN"
+	case "UntaggedVlan", "untagged_vlan":
+		return "UNTAGGED_VLAN"
+	case "Interface", "interface":
+		return "CONNECTS_TO_INTERFACE"
+	case "VMInterface", "vm_interface":
+		return "CONNECTS_TO_VM_INTERFACE"
+
+	// Organizational relationships
+	case "Tags", "tags", "Tag", "tag":
+		return "TAGGED_WITH"
+	case "Tenant", "tenant":
+		return "BELONGS_TO_TENANT"
+	case "TenantGroup", "tenant_group":
+		return "BELONGS_TO_TENANT_GROUP"
+	case "Contact", "contact":
+		return "ASSIGNED_CONTACT"
+	case "ContactGroup", "contact_group":
+		return "BELONGS_TO_CONTACT_GROUP"
+	case "ContactRole", "contact_role":
+		return "HAS_CONTACT_ROLE"
+
+	// Type relationships
+	case "DeviceType", "device_type":
+		return "INSTANCE_OF_DEVICE_TYPE"
+	case "DeviceRole", "device_role":
+		return "HAS_DEVICE_ROLE"
+	case "Platform", "platform":
+		return "RUNS_ON_PLATFORM"
+	case "Manufacturer", "manufacturer":
+		return "MANUFACTURED_BY"
+	case "ClusterType", "cluster_type":
+		return "INSTANCE_OF_CLUSTER_TYPE"
+	case "RackType", "rack_type":
+		return "INSTANCE_OF_RACK_TYPE"
+	case "RackRole", "rack_role":
+		return "HAS_RACK_ROLE"
+
+	// Circuit relationships
+	case "Provider", "provider":
+		return "PROVIDED_BY"
+	case "Circuit", "circuit":
+		return "BELONGS_TO_CIRCUIT"
+	case "CircuitType", "circuit_type":
+		return "INSTANCE_OF_CIRCUIT_TYPE"
+
+	// Cable relationships
+	case "Cable", "cable":
+		return "CONNECTED_BY_CABLE"
+	case "ATerminations", "a_terminations":
+		return "CABLE_A_SIDE"
+	case "BTerminations", "b_terminations":
+		return "CABLE_B_SIDE"
+
+	// Power relationships
+	case "PowerFeed", "power_feed":
+		return "POWERED_BY"
+	case "PowerPanel", "power_panel":
+		return "POWERED_FROM_PANEL"
+	case "PowerOutlet", "power_outlet":
+		return "CONNECTS_TO_POWER_OUTLET"
+	case "PowerPort", "power_port":
+		return "CONNECTS_TO_POWER_PORT"
+
+	// Parent/child relationships
+	case "Parent", "parent":
+		return "CHILD_OF"
+	case "ParentInterface", "parent_interface":
+		return "CHILD_OF_INTERFACE"
+
+	// Service port relationships
+	case "ServicePorts", "service_ports", "ServicePort", "service_port":
+		return "HAS_SERVICE_PORT"
+
+	default:
+		return "REFERENCES"
+	}
+}
+
+// getNodeTypeFromFieldName maps field names to netbox object types using existing constants
+func (gb *GraphBuilder) getNodeTypeFromFieldName(fieldName string) string {
+	switch fieldName {
+	case "Device", "device":
+		return netbox.DeviceObjectType
+	case "Site", "site":
+		return netbox.SiteObjectType
+	case "Location", "location":
+		return netbox.LocationObjectType
+	case "Rack", "rack":
+		return netbox.RackObjectType
+	case "Vrf", "vrf":
+		return netbox.VRFObjectType
+	case "TaggedVlans", "tagged_vlans", "Vlan", "vlan":
+		return netbox.VLANObjectType
+	case "Tags", "tags", "Tag", "tag":
+		return netbox.TagObjectType
+	case "Tenant", "tenant":
+		return netbox.TenantObjectType
+	case "DeviceType", "device_type":
+		return netbox.DeviceTypeObjectType
+	case "DeviceRole", "device_role":
+		return netbox.DeviceRoleObjectType
+	case "Platform", "platform":
+		return netbox.PlatformObjectType
+	case "Manufacturer", "manufacturer":
+		return netbox.ManufacturerObjectType
+	case "Interface", "interface":
+		return netbox.InterfaceObjectType
+	case "Region", "region":
+		return netbox.RegionObjectType
+	case "SiteGroup", "site_group":
+		return netbox.SiteGroupObjectType
+	case "TenantGroup", "tenant_group":
+		return netbox.TenantGroupObjectType
+	case "RackRole", "rack_role":
+		return netbox.RackRoleObjectType
+	case "RackType", "rack_type":
+		return netbox.RackTypeObjectType
+	case "Cluster", "cluster":
+		return netbox.ClusterObjectType
+	case "ClusterType", "cluster_type":
+		return netbox.ClusterTypeObjectType
+	case "ClusterGroup", "cluster_group":
+		return netbox.ClusterGroupObjectType
+	case "VirtualMachine", "virtual_machine":
+		return netbox.VirtualMachineObjectType
+	case "VMInterface", "vm_interface":
+		return netbox.VMInterfaceObjectType
+	case "Contact", "contact":
+		return netbox.ContactObjectType
+	case "ContactGroup", "contact_group":
+		return netbox.ContactGroupObjectType
+	case "ContactRole", "contact_role":
+		return netbox.ContactRoleObjectType
+	case "Provider", "provider":
+		return netbox.ProviderObjectType
+	case "Circuit", "circuit":
+		return netbox.CircuitObjectType
+	case "CircuitType", "circuit_type":
+		return netbox.CircuitTypeObjectType
+	case "Cable", "cable":
+		return netbox.CableObjectType
+	default:
+		return "unknown"
+	}
+}
+
+// propagateNodeUpdates finds nodes that reference updated nodes and refreshes them with the latest data
+func (gb *GraphBuilder) propagateNodeUpdates(ctx context.Context) error {
+	if len(gb.updatedNodes) == 0 {
+		return nil
+	}
+
+	gb.logger.Debug("propagating node updates", "updated_nodes_count", len(gb.updatedNodes))
+
+	// Debug: Log all updated nodes
+	for key, updatedNode := range gb.updatedNodes {
+		gb.logger.Debug("updated node",
+			"key", key,
+			"node_type", updatedNode.NodeType,
+			"external_id", updatedNode.ExternalID,
+			"node_id", updatedNode.ID)
+	}
+
+	// For each node in the cache, check if it contains references to updated nodes
+	for cacheKey, cachedNode := range gb.nodeCache {
+		// Check if this node references any updated nodes by examining its data
+		// (Note: we check ALL nodes, even if they were updated themselves, because they
+		// might contain references to OTHER updated nodes that need refreshing)
+		needsUpdate, err := gb.nodeReferencesUpdatedNodes(cachedNode, cacheKey)
+		if err != nil {
+			gb.logger.Warn("failed to check node references", "error", err, "node_type", cachedNode.NodeType)
+			continue
+		}
+
+		if needsUpdate {
+			gb.logger.Debug("node needs update due to references",
+				"node_type", cachedNode.NodeType,
+				"external_id", cachedNode.ExternalID)
+
+			// Regenerate the node data with updated references
+			err = gb.refreshNodeWithUpdatedReferences(ctx, cachedNode)
+			if err != nil {
+				gb.logger.Warn("failed to refresh node with updated references",
+					"error", err,
+					"node_type", cachedNode.NodeType,
+					"external_id", cachedNode.ExternalID)
+			} else {
+				gb.logger.Debug("refreshed node with updated references",
+					"node_type", cachedNode.NodeType,
+					"external_id", cachedNode.ExternalID)
+			}
+		} else {
+			gb.logger.Debug("node does not need update",
+				"node_type", cachedNode.NodeType,
+				"external_id", cachedNode.ExternalID)
+		}
+	}
+
+	return nil
+}
+
+// nodeReferencesUpdatedNodes checks if a node contains references to any updated nodes
+func (gb *GraphBuilder) nodeReferencesUpdatedNodes(node *GraphNode, nodeKey string) (bool, error) {
+	// Parse the node's JSON data to look for references
+	var nodeData map[string]any
+	if err := json.Unmarshal(node.Data, &nodeData); err != nil {
+		return false, fmt.Errorf("failed to parse node data: %w", err)
+	}
+
+	// Recursively check for references to updated node types (excluding this node itself)
+	return gb.checkDataForUpdatedReferences(nodeData, nodeKey), nil
+}
+
+// checkDataForUpdatedReferences recursively checks if data contains references to updated nodes
+func (gb *GraphBuilder) checkDataForUpdatedReferences(data any, excludeNodeKey string) bool {
+	switch v := data.(type) {
+	case map[string]any:
+		// Check if this map represents an entity that might be updated
+		if name, hasName := v["name"]; hasName {
+			if nameStr, ok := name.(string); ok {
+				// Check if any updated node has this name (excluding the node being checked itself)
+				for updatedKey, updatedNode := range gb.updatedNodes {
+					// Skip checking the node against itself
+					if updatedKey == excludeNodeKey {
+						continue
+					}
+					var updatedData map[string]any
+					if json.Unmarshal(updatedNode.Data, &updatedData) == nil {
+						// Look for the name in the nested entity data structure
+						if entityData, hasEntity := updatedData[strings.ToLower(updatedNode.NodeType)]; hasEntity {
+							if entityMap, ok := entityData.(map[string]any); ok {
+								if updatedName, ok := entityMap["name"]; ok && updatedName == nameStr {
+									// Check if the node types could be related (e.g., Manufacturer)
+									if gb.couldBeRelatedNodeType(updatedNode.NodeType, v) {
+										gb.logger.Debug("found reference that needs update",
+											"referring_name", nameStr,
+											"updated_node_type", updatedNode.NodeType,
+											"updated_node_id", updatedNode.ID)
+										return true
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Recursively check nested objects
+		for _, value := range v {
+			if gb.checkDataForUpdatedReferences(value, excludeNodeKey) {
+				return true
+			}
+		}
+	case []any:
+		// Check array elements
+		for _, item := range v {
+			if gb.checkDataForUpdatedReferences(item, excludeNodeKey) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// couldBeRelatedNodeType checks if an updated node type could be referenced by the given data
+func (gb *GraphBuilder) couldBeRelatedNodeType(updatedNodeType string, _ map[string]any) bool {
+	// The logic here is: if we updated a node of type X, and this referenceData
+	// represents a reference to type X (by having the same name), then it's related
+
+	// For now, we'll use a simple heuristic: if the reference data looks like
+	// it could represent the same type of entity (has similar structure)
+	switch updatedNodeType {
+	case "Manufacturer":
+		// Check if this reference data represents a manufacturer reference
+		// (it should have manufacturer-like fields)
+		return true // For manufacturer, any named reference could potentially be a manufacturer
+	case "DeviceType":
+		// Check if this could be a device type reference
+		return true
+	case "Platform":
+		// Check if this could be a platform reference
+		return true
+	case "Site":
+		// Check if this could be a site reference
+		return true
+	}
+
+	// Default to true for now - we can make this more sophisticated later
+	return true
+}
+
+// refreshNodeWithUpdatedReferences updates a node in the database with fresh data that includes updated references
+func (gb *GraphBuilder) refreshNodeWithUpdatedReferences(ctx context.Context, node *GraphNode) error {
+	// Find the existing node in the database to get its latest data
+	existingNode, err := gb.repo.FindGraphNode(ctx, postgres.FindGraphNodeParams{
+		NodeType:   node.NodeType,
+		ExternalID: node.ExternalID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to find existing node: %w", err)
+	}
+
+	// Parse the existing data to reconstruct the entity
+	var nodeData map[string]any
+	if err := json.Unmarshal(existingNode.Data, &nodeData); err != nil {
+		return fmt.Errorf("failed to parse existing node data: %w", err)
+	}
+
+	// Update references in the node data with the latest information from updated nodes
+	gb.updateReferencesInNodeData(nodeData)
+
+	// Re-serialize the updated data
+	updatedData, err := json.Marshal(nodeData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated node data: %w", err)
+	}
+
+	// Update the node in the database using request-level duplicate counting
+	requestKey := fmt.Sprintf("%s:%s", existingNode.NodeType, existingNode.ExternalID)
+
+	if gb.seenInThisRequest[requestKey] {
+		// Already seen in this request - update data but don't increment duplicate count
+		_, err = gb.repo.UpdateGraphNodeData(ctx, postgres.UpdateGraphNodeDataParams{
+			NodeType:              existingNode.NodeType,
+			ExternalID:            existingNode.ExternalID,
+			Data:                  updatedData,
+			MatchingSchemaVersion: existingNode.MatchingSchemaVersion, // Keep existing schema version for reference updates
+		})
+	} else {
+		// First time seeing this node in this request - increment duplicate count
+		_, err = gb.repo.UpsertGraphNode(ctx, postgres.UpsertGraphNodeParams{
+			ExternalID:            existingNode.ExternalID,
+			NodeType:              existingNode.NodeType,
+			Data:                  updatedData,
+			MatchingSchemaVersion: existingNode.MatchingSchemaVersion, // Keep existing schema version for reference updates
+		})
+		gb.seenInThisRequest[requestKey] = true
+	}
+	if err != nil {
+		return fmt.Errorf("failed to update refreshed node: %w", err)
+	}
+
+	return nil
+}
+
+// updateReferencesInNodeData recursively updates references in node data with latest information from updated nodes
+func (gb *GraphBuilder) updateReferencesInNodeData(data map[string]any) {
+	for _, value := range data {
+		switch v := value.(type) {
+		case map[string]any:
+			// Check if this nested object represents a reference that should be updated
+			if name, hasName := v["name"]; hasName {
+				if nameStr, ok := name.(string); ok {
+					// Find matching updated node and update the reference
+					for _, updatedNode := range gb.updatedNodes {
+						var updatedData map[string]any
+						if json.Unmarshal(updatedNode.Data, &updatedData) == nil {
+							// Look for the name in the nested entity data structure
+							if entityData, hasEntity := updatedData[strings.ToLower(updatedNode.NodeType)]; hasEntity {
+								if entityMap, ok := entityData.(map[string]any); ok {
+									if updatedName, ok := entityMap["name"]; ok && updatedName == nameStr {
+										// Update this reference with the latest entity data
+										maps.Copy(v, entityMap)
+										gb.logger.Debug("updated reference in node data",
+											"reference_name", nameStr,
+											"updated_node_type", updatedNode.NodeType,
+											"updated_fields", len(entityMap))
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			// Recursively update nested references
+			gb.updateReferencesInNodeData(v)
+		case []any:
+			// Handle array of references
+			for _, item := range v {
+				if itemMap, ok := item.(map[string]any); ok {
+					gb.updateReferencesInNodeData(itemMap)
+				}
+			}
+		}
+	}
+}

--- a/diode-server/reconciler/graph_builder.go
+++ b/diode-server/reconciler/graph_builder.go
@@ -435,35 +435,7 @@ func (gb *GraphBuilder) processEntityRecursively(ctx context.Context, entity *di
 	}
 
 	// Try confidence-based matching first before creating new node
-	var matchedNode *GraphNode
-	var matchConfidence matching.MatchConfidence
-	var matchReason string
-	var bestMatch *matching.MatchResult
-
-	if gb.entityMatcher != nil {
-		var matchErr error
-		bestMatch, matchErr = gb.entityMatcher.FindBestMatch(ctx, entity)
-		if matchErr != nil {
-			gb.logger.Warn("failed to find entity matches", "error", matchErr, "entity_type", nodeType)
-		} else if bestMatch != nil && bestMatch.NodeID != nil {
-			// Found a confident match, use existing node
-			matchedNode = &GraphNode{
-				ID:         *bestMatch.NodeID,
-				ExternalID: externalID, // Keep new external ID for this observation
-				NodeType:   nodeType,
-				Data:       bestMatch.ExistingData,
-			}
-			matchConfidence = bestMatch.Confidence
-			matchReason = bestMatch.MatchReason
-
-			gb.logger.Info("found confident match for entity",
-				"entity_type", nodeType,
-				"matched_node_id", *bestMatch.NodeID,
-				"confidence", float64(bestMatch.Confidence),
-				"reason", bestMatch.MatchReason,
-				"matching_fields", bestMatch.MatchingFields)
-		}
-	}
+	bestMatch := gb.findEntityMatch(ctx, entity, nodeType)
 
 	// Marshal entity data
 	entityData, err := protojson.Marshal(entity)
@@ -471,121 +443,14 @@ func (gb *GraphBuilder) processEntityRecursively(ctx context.Context, entity *di
 		return nil, fmt.Errorf("failed to marshal entity: %w", err)
 	}
 
+	// Process node: either update matched node or create new one
 	var node *GraphNode
-
-	if matchedNode != nil {
-		// Found a confident match - use the existing node's external ID to find and update it
-		if bestMatch.ExternalID == nil {
-			return nil, fmt.Errorf("matched node missing external ID")
-		}
-
-		existingNode, err := gb.repo.FindGraphNode(ctx, postgres.FindGraphNodeParams{
-			NodeType:   nodeType,
-			ExternalID: *bestMatch.ExternalID,
-		})
+	if bestMatch != nil && bestMatch.NodeID != nil {
+		node, err = gb.updateMatchedNode(ctx, bestMatch, nodeType, entityData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find existing matched node: %w", err)
+			return nil, err
 		}
-
-		// Extract matching attributes from the new entity data
-		matchingData, err := gb.extractMatchingAttributes(nodeType, entityData)
-		if err != nil {
-			gb.logger.Warn("failed to extract matching attributes, using full data", "error", err, "node_type", nodeType)
-			matchingData = entityData
-		}
-
-		// Convert FindGraphNodeRow to GraphNode for schema checks
-		existingGraphNode := &postgres.GraphNode{
-			ID:                    existingNode.ID,
-			ExternalID:            existingNode.ExternalID,
-			NodeType:              existingNode.NodeType,
-			Data:                  existingNode.Data,
-			DuplicateCount:        existingNode.DuplicateCount,
-			MatchingSchemaVersion: existingNode.MatchingSchemaVersion,
-		}
-
-		// Check if existing node needs schema update (lazy migration)
-		if gb.needsSchemaUpdate(existingGraphNode) {
-			gb.logger.Info("updating node matching data due to schema change",
-				"node_type", nodeType,
-				"external_id", existingNode.ExternalID,
-				"old_version", existingNode.MatchingSchemaVersion,
-				"new_version", CurrentSchemaVersion)
-
-			err = gb.updateNodeMatchingData(ctx, existingGraphNode, entityData)
-			if err != nil {
-				gb.logger.Warn("failed to update node schema, continuing", "error", err)
-			}
-		}
-
-		// Create a unique key for this node in this request
-		requestKey := fmt.Sprintf("%s:%s", nodeType, existingNode.ExternalID)
-
-		var result postgres.UpsertGraphNodeRow
-		if gb.seenInThisRequest[requestKey] {
-			// Already seen in this request - update data but don't increment duplicate count
-			updateResult, err := gb.repo.UpdateGraphNodeData(ctx, postgres.UpdateGraphNodeDataParams{
-				NodeType:              nodeType,
-				ExternalID:            existingNode.ExternalID,
-				Data:                  matchingData,
-				MatchingSchemaVersion: CurrentSchemaVersion,
-			})
-			if err == nil {
-				// Convert UpdateGraphNodeDataRow to UpsertGraphNodeRow format
-				result = postgres.UpsertGraphNodeRow(updateResult)
-			}
-			gb.logger.Debug("updated matched node data without incrementing duplicate count",
-				"node_type", nodeType,
-				"external_id", existingNode.ExternalID)
-		} else {
-			// First time seeing this node in this request - normal upsert with duplicate count increment
-			params := postgres.UpsertGraphNodeParams{
-				ExternalID:            existingNode.ExternalID, // Keep existing external ID
-				NodeType:              nodeType,
-				Data:                  matchingData, // Use extracted matching data
-				MatchingSchemaVersion: CurrentSchemaVersion,
-			}
-			result, err = gb.repo.UpsertGraphNode(ctx, params)
-			// Mark this node as seen in this request
-			gb.seenInThisRequest[requestKey] = true
-			gb.logger.Debug("updated matched node with duplicate count increment",
-				"node_type", nodeType,
-				"external_id", existingNode.ExternalID,
-				"duplicate_count", result.DuplicateCount)
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to update matched node: %w", err)
-		}
-
-		// Create snapshot with full entity data
-		err = gb.createSnapshot(ctx, result.ID, entityData)
-		if err != nil {
-			gb.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
-			// Don't fail the entire operation for snapshot issues
-		}
-
-		node = &GraphNode{
-			ID:                    result.ID,
-			ExternalID:            result.ExternalID,
-			NodeType:              result.NodeType,
-			Data:                  result.Data,
-			DuplicateCount:        result.DuplicateCount,
-			MatchingSchemaVersion: result.MatchingSchemaVersion,
-		}
-
-		// Track this node as updated for propagation
-		nodeKey := fmt.Sprintf("%s:%s", nodeType, result.ExternalID)
-		gb.updatedNodes[nodeKey] = node
-
-		gb.logger.Info("reused existing matched node",
-			"matched_node_id", matchedNode.ID,
-			"confidence", float64(matchConfidence),
-			"reason", matchReason,
-			"duplicate_count", node.DuplicateCount,
-			"external_id", result.ExternalID)
 	} else {
-		// Create or update node in database (no match found)
 		node, err = gb.upsertNode(ctx, externalID, nodeType, entityData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to upsert node: %w", err)
@@ -602,27 +467,182 @@ func (gb *GraphBuilder) processEntityRecursively(ctx context.Context, entity *di
 		"node_id", node.ID)
 
 	// Recursively process all nested entities and create edges
+	gb.createEdgesForNode(ctx, entity, node, nodeType, externalID)
+
+	return node, nil
+}
+
+// findEntityMatch attempts to find an existing entity match using confidence-based matching.
+// Returns nil if no match found or if entity matcher is not configured.
+func (gb *GraphBuilder) findEntityMatch(ctx context.Context, entity *diodepb.Entity, nodeType string) *matching.MatchResult {
+	if gb.entityMatcher == nil {
+		return nil
+	}
+
+	bestMatch, err := gb.entityMatcher.FindBestMatch(ctx, entity)
+	if err != nil {
+		gb.logger.Warn("failed to find entity matches", "error", err, "entity_type", nodeType)
+		return nil
+	}
+
+	if bestMatch != nil && bestMatch.NodeID != nil {
+		gb.logger.Info("found confident match for entity",
+			"entity_type", nodeType,
+			"matched_node_id", *bestMatch.NodeID,
+			"confidence", float64(bestMatch.Confidence),
+			"reason", bestMatch.MatchReason,
+			"matching_fields", bestMatch.MatchingFields)
+		return bestMatch
+	}
+
+	return nil
+}
+
+// updateMatchedNode updates an existing matched node with new entity data.
+func (gb *GraphBuilder) updateMatchedNode(ctx context.Context, bestMatch *matching.MatchResult, nodeType string, entityData json.RawMessage) (*GraphNode, error) {
+	if bestMatch.ExternalID == nil {
+		return nil, fmt.Errorf("matched node missing external ID")
+	}
+
+	existingNode, err := gb.repo.FindGraphNode(ctx, postgres.FindGraphNodeParams{
+		NodeType:   nodeType,
+		ExternalID: *bestMatch.ExternalID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find existing matched node: %w", err)
+	}
+
+	// Extract matching attributes from the new entity data
+	matchingData, err := gb.extractMatchingAttributes(nodeType, entityData)
+	if err != nil {
+		gb.logger.Warn("failed to extract matching attributes, using full data", "error", err, "node_type", nodeType)
+		matchingData = entityData
+	}
+
+	// Check if existing node needs schema update (lazy migration)
+	gb.maybeUpdateNodeSchema(ctx, &existingNode, nodeType, entityData)
+
+	// Upsert the node with appropriate duplicate count handling
+	result, err := gb.upsertMatchedNodeData(ctx, nodeType, existingNode.ExternalID, matchingData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update matched node: %w", err)
+	}
+
+	// Create snapshot with full entity data
+	if err := gb.createSnapshot(ctx, result.ID, entityData); err != nil {
+		gb.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
+	}
+
+	node := &GraphNode{
+		ID:                    result.ID,
+		ExternalID:            result.ExternalID,
+		NodeType:              result.NodeType,
+		Data:                  result.Data,
+		DuplicateCount:        result.DuplicateCount,
+		MatchingSchemaVersion: result.MatchingSchemaVersion,
+	}
+
+	// Track this node as updated for propagation
+	nodeKey := fmt.Sprintf("%s:%s", nodeType, result.ExternalID)
+	gb.updatedNodes[nodeKey] = node
+
+	gb.logger.Info("reused existing matched node",
+		"matched_node_id", *bestMatch.NodeID,
+		"confidence", float64(bestMatch.Confidence),
+		"reason", bestMatch.MatchReason,
+		"duplicate_count", node.DuplicateCount,
+		"external_id", result.ExternalID)
+
+	return node, nil
+}
+
+// maybeUpdateNodeSchema checks if a node needs schema migration and updates it if necessary.
+func (gb *GraphBuilder) maybeUpdateNodeSchema(ctx context.Context, existingNode *postgres.FindGraphNodeRow, nodeType string, entityData json.RawMessage) {
+	existingGraphNode := &postgres.GraphNode{
+		ID:                    existingNode.ID,
+		ExternalID:            existingNode.ExternalID,
+		NodeType:              existingNode.NodeType,
+		Data:                  existingNode.Data,
+		DuplicateCount:        existingNode.DuplicateCount,
+		MatchingSchemaVersion: existingNode.MatchingSchemaVersion,
+	}
+
+	if gb.needsSchemaUpdate(existingGraphNode) {
+		gb.logger.Info("updating node matching data due to schema change",
+			"node_type", nodeType,
+			"external_id", existingNode.ExternalID,
+			"old_version", existingNode.MatchingSchemaVersion,
+			"new_version", CurrentSchemaVersion)
+
+		if err := gb.updateNodeMatchingData(ctx, existingGraphNode, entityData); err != nil {
+			gb.logger.Warn("failed to update node schema, continuing", "error", err)
+		}
+	}
+}
+
+// upsertMatchedNodeData handles the upsert logic for a matched node, respecting duplicate count rules.
+func (gb *GraphBuilder) upsertMatchedNodeData(ctx context.Context, nodeType, externalID string, matchingData json.RawMessage) (postgres.UpsertGraphNodeRow, error) {
+	requestKey := fmt.Sprintf("%s:%s", nodeType, externalID)
+
+	if gb.seenInThisRequest[requestKey] {
+		// Already seen in this request - update data but don't increment duplicate count
+		updateResult, err := gb.repo.UpdateGraphNodeData(ctx, postgres.UpdateGraphNodeDataParams{
+			NodeType:              nodeType,
+			ExternalID:            externalID,
+			Data:                  matchingData,
+			MatchingSchemaVersion: CurrentSchemaVersion,
+		})
+		if err != nil {
+			return postgres.UpsertGraphNodeRow{}, err
+		}
+		gb.logger.Debug("updated matched node data without incrementing duplicate count",
+			"node_type", nodeType,
+			"external_id", externalID)
+		return postgres.UpsertGraphNodeRow(updateResult), nil
+	}
+
+	// First time seeing this node in this request - normal upsert with duplicate count increment
+	params := postgres.UpsertGraphNodeParams{
+		ExternalID:            externalID,
+		NodeType:              nodeType,
+		Data:                  matchingData,
+		MatchingSchemaVersion: CurrentSchemaVersion,
+	}
+	result, err := gb.repo.UpsertGraphNode(ctx, params)
+	if err != nil {
+		return postgres.UpsertGraphNodeRow{}, err
+	}
+
+	gb.seenInThisRequest[requestKey] = true
+	gb.logger.Debug("updated matched node with duplicate count increment",
+		"node_type", nodeType,
+		"external_id", externalID,
+		"duplicate_count", result.DuplicateCount)
+
+	return result, nil
+}
+
+// createEdgesForNode extracts and creates all edges for a node.
+func (gb *GraphBuilder) createEdgesForNode(ctx context.Context, entity *diodepb.Entity, node *GraphNode, nodeType, externalID string) {
 	edges, err := gb.extractEdgesRecursively(ctx, entity, node)
 	if err != nil {
 		gb.logger.Warn("failed to extract edges recursively",
 			"node_type", nodeType,
 			"external_id", externalID,
 			"error", err)
-	} else {
-		// Create all edges
-		for _, edge := range edges {
-			if err := gb.upsertEdge(ctx, edge); err != nil {
-				gb.logger.Warn("failed to create edge",
-					"source_id", edge.SourceNodeID,
-					"target_id", edge.TargetNodeID,
-					"edge_type", edge.EdgeType,
-					"error", err)
-			}
-		}
-		gb.logger.Debug("processed edges for node", "count", len(edges), "node_id", node.ID)
+		return
 	}
 
-	return node, nil
+	for _, edge := range edges {
+		if err := gb.upsertEdge(ctx, edge); err != nil {
+			gb.logger.Warn("failed to create edge",
+				"source_id", edge.SourceNodeID,
+				"target_id", edge.TargetNodeID,
+				"edge_type", edge.EdgeType,
+				"error", err)
+		}
+	}
+	gb.logger.Debug("processed edges for node", "count", len(edges), "node_id", node.ID)
 }
 
 // extractEdgesRecursively finds all relationships within the entity and creates edges recursively

--- a/diode-server/reconciler/graph_builder.go
+++ b/diode-server/reconciler/graph_builder.go
@@ -689,6 +689,23 @@ func (gb *GraphBuilder) extractEdgesRecursively(ctx context.Context, entity *dio
 			}
 			edges = append(edges, sliceEdges...)
 		}
+
+		// Process oneof fields (interface types in generated Go code)
+		if field.Kind() == reflect.Interface && !field.IsNil() {
+			gb.logger.Debug("processing oneof/interface field", "field", fieldName, "type", fmt.Sprintf("%T", field.Interface()))
+			// Unwrap the interface to get the concrete value
+			concreteValue := reflect.ValueOf(field.Interface())
+			if concreteValue.IsValid() && concreteValue.Kind() == reflect.Ptr && !concreteValue.IsNil() {
+				fieldEdges, err := gb.processFieldRecursively(ctx, sourceNode, concreteValue, fieldName)
+				if err != nil {
+					gb.logger.Warn("failed to process oneof field recursively", "field", fieldName, "error", err)
+					continue
+				}
+				if len(fieldEdges) > 0 {
+					edges = append(edges, fieldEdges...)
+				}
+			}
+		}
 	}
 
 	return edges, nil
@@ -827,7 +844,18 @@ func (gb *GraphBuilder) processSliceFieldRecursively(ctx context.Context, source
 
 	for i := 0; i < field.Len(); i++ {
 		item := field.Index(i)
-		if !item.IsValid() || item.IsNil() {
+		if !item.IsValid() {
+			continue
+		}
+
+		// Only check IsNil for types that support it (ptr, map, slice, chan, func, interface)
+		// Scalar types like string, int, etc. will panic on IsNil
+		if canBeNil(item) && item.IsNil() {
+			continue
+		}
+
+		// Skip scalar types (string, int, etc.) - they don't represent entity references
+		if !canBeNil(item) && item.Kind() != reflect.Struct {
 			continue
 		}
 
@@ -1022,6 +1050,16 @@ func (gb *GraphBuilder) upsertEdge(ctx context.Context, edge *GraphEdge) error {
 		EdgeType:     edge.EdgeType,
 		Properties:   edge.Properties,
 	})
+}
+
+// canBeNil returns true if the reflect.Value's kind supports nil checks.
+// Calling IsNil on other types (string, int, struct, etc.) will panic.
+func canBeNil(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return true
+	}
+	return false
 }
 
 // getEntityTypeName extracts the entity type name from an entity using proto names

--- a/diode-server/reconciler/graph_builder.go
+++ b/diode-server/reconciler/graph_builder.go
@@ -47,15 +47,7 @@ type GraphBuilder struct {
 // Note: EntityMatcher is nil by default. Use NewGraphBuilderWithMatcher or SetEntityMatcher
 // to enable confidence-based entity matching.
 func NewGraphBuilder(repo GraphRepository, logger *slog.Logger) *GraphBuilder {
-	return &GraphBuilder{
-		repo:              repo,
-		logger:            logger,
-		nodeCache:         make(map[string]*GraphNode),
-		entityMatcher:     nil, // Set via NewGraphBuilderWithMatcher or SetEntityMatcher
-		updatedNodes:      make(map[string]*GraphNode),
-		seenInThisRequest: make(map[string]bool),
-		snapshotRetention: DefaultSnapshotRetention,
-	}
+	return NewGraphBuilderWithMatcher(repo, logger, nil)
 }
 
 // NewGraphBuilderWithMatcher creates a new GraphBuilder instance with custom entity matcher
@@ -768,13 +760,13 @@ func (gb *GraphBuilder) extractEdgeProperties(fieldValue any) json.RawMessage {
 	// Extract each configured edge property field
 	for _, fieldName := range propertyFieldNames {
 		if field := val.FieldByName(fieldName); field.IsValid() && field.CanInterface() {
-			fieldValue := field.Interface()
+			fv := field.Interface()
 
 			// Only include non-zero values
-			if !reflect.DeepEqual(fieldValue, reflect.Zero(field.Type()).Interface()) {
+			if !reflect.DeepEqual(fv, reflect.Zero(field.Type()).Interface()) {
 				// Convert field name to snake_case for JSON
 				jsonFieldName := strcase.ToSnakeCase(fieldName)
-				properties[jsonFieldName] = fieldValue
+				properties[jsonFieldName] = fv
 			}
 		}
 	}

--- a/diode-server/reconciler/graph_builder.go
+++ b/diode-server/reconciler/graph_builder.go
@@ -5,21 +5,23 @@ package reconciler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
 	"reflect"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/netboxlabs/diode/diode-server/entityhash"
 	"github.com/netboxlabs/diode/diode-server/gen/dbstore/postgres"
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
-	"github.com/netboxlabs/diode/diode-server/gen/netbox"
 	"github.com/netboxlabs/diode/diode-server/gen/protograph"
 	"github.com/netboxlabs/diode/diode-server/matching"
+	"github.com/netboxlabs/diode/diode-server/strcase"
 )
 
 const (
@@ -667,13 +669,13 @@ func (gb *GraphBuilder) extractEdgesRecursively(ctx context.Context, entity *dio
 		// Process single entity field
 		if field.Kind() == reflect.Ptr && !field.IsNil() {
 			gb.logger.Debug("processing pointer field", "field", fieldName, "type", fmt.Sprintf("%T", field.Interface()))
-			edge, err := gb.processFieldRecursively(ctx, sourceNode, field, fieldName)
+			fieldEdges, err := gb.processFieldRecursively(ctx, sourceNode, field, fieldName)
 			if err != nil {
 				gb.logger.Warn("failed to process field recursively", "field", fieldName, "error", err)
 				continue
 			}
-			if edge != nil {
-				edges = append(edges, edge)
+			if len(fieldEdges) > 0 {
+				edges = append(edges, fieldEdges...)
 			}
 		}
 
@@ -692,10 +694,10 @@ func (gb *GraphBuilder) extractEdgesRecursively(ctx context.Context, entity *dio
 	return edges, nil
 }
 
-// extractEdgeProperties extracts properties to be stored on an edge based on reflection
+// extractEdgeProperties extracts properties to be stored on an edge based on reflection.
 // It automatically identifies fields that should be edge properties (not node properties)
 // based on the edge_property_fields configuration in the matching config.
-func (gb *GraphBuilder) extractEdgeProperties(fieldValue any, _ string) json.RawMessage {
+func (gb *GraphBuilder) extractEdgeProperties(fieldValue any) json.RawMessage {
 	if fieldValue == nil {
 		return json.RawMessage("{}")
 	}
@@ -734,7 +736,7 @@ func (gb *GraphBuilder) extractEdgeProperties(fieldValue any, _ string) json.Raw
 			// Only include non-zero values
 			if !reflect.DeepEqual(fieldValue, reflect.Zero(field.Type()).Interface()) {
 				// Convert field name to snake_case for JSON
-				jsonFieldName := gb.toSnakeCase(fieldName)
+				jsonFieldName := strcase.ToSnakeCase(fieldName)
 				properties[jsonFieldName] = fieldValue
 			}
 		}
@@ -770,25 +772,9 @@ func (gb *GraphBuilder) getEntityTypeNameFromValue(fieldValue any) string {
 	return typ.Name()
 }
 
-// toSnakeCase converts a PascalCase or camelCase string to snake_case
-func (gb *GraphBuilder) toSnakeCase(s string) string {
-	if s == "" {
-		return ""
-	}
-
-	var result strings.Builder
-	for i, r := range s {
-		if i > 0 && r >= 'A' && r <= 'Z' {
-			result.WriteRune('_')
-		}
-		result.WriteRune(r)
-	}
-
-	return strings.ToLower(result.String())
-}
-
-// processFieldRecursively processes a single field and creates an edge if it references another entity, recursively processing nested entities
-func (gb *GraphBuilder) processFieldRecursively(ctx context.Context, sourceNode *GraphNode, field reflect.Value, fieldName string) (*GraphEdge, error) {
+// processFieldRecursively processes a single field and creates bidirectional edges if it references another entity.
+// Returns both forward (BELONGS_TO) and reverse (HAS) edges.
+func (gb *GraphBuilder) processFieldRecursively(ctx context.Context, sourceNode *GraphNode, field reflect.Value, fieldName string) ([]*GraphEdge, error) {
 	if !field.IsValid() || field.IsNil() {
 		return nil, nil
 	}
@@ -796,7 +782,7 @@ func (gb *GraphBuilder) processFieldRecursively(ctx context.Context, sourceNode 
 	fieldInterface := field.Interface()
 
 	// Try to recursively process this field as a nested entity first
-	targetNode, err := gb.processNestedEntityRecursively(ctx, fieldInterface, fieldName)
+	targetNode, err := gb.processNestedEntityRecursively(ctx, fieldInterface)
 	if err != nil {
 		return nil, err
 	}
@@ -813,18 +799,29 @@ func (gb *GraphBuilder) processFieldRecursively(ctx context.Context, sourceNode 
 		return nil, nil
 	}
 
-	// Create edge based on field name
-	edgeType := gb.getEdgeTypeFromFieldName(fieldName)
+	// Create bidirectional edges
+	edgeTypes := gb.getEdgeTypesForField(fieldName, sourceNode.NodeType)
 
-	return &GraphEdge{
-		SourceNodeID: sourceNode.ID,
-		TargetNodeID: targetNode.ID,
-		EdgeType:     edgeType,
-		Properties:   json.RawMessage("{}"),
+	return []*GraphEdge{
+		{
+			// Forward: Source BELONGS_TO Target (e.g., Device BELONGS_TO_SITE Site)
+			SourceNodeID: sourceNode.ID,
+			TargetNodeID: targetNode.ID,
+			EdgeType:     edgeTypes.Forward,
+			Properties:   json.RawMessage("{}"),
+		},
+		{
+			// Reverse: Target HAS Source (e.g., Site HAS_DEVICE Device)
+			SourceNodeID: targetNode.ID,
+			TargetNodeID: sourceNode.ID,
+			EdgeType:     edgeTypes.Reverse,
+			Properties:   json.RawMessage("{}"),
+		},
 	}, nil
 }
 
-// processSliceFieldRecursively processes slice fields that may contain multiple references, recursively processing each nested entity
+// processSliceFieldRecursively processes slice fields that may contain multiple references.
+// Creates bidirectional edges (forward and reverse) for each nested entity.
 func (gb *GraphBuilder) processSliceFieldRecursively(ctx context.Context, sourceNode *GraphNode, field reflect.Value, fieldName string) ([]*GraphEdge, error) {
 	var edges []*GraphEdge
 
@@ -835,9 +832,9 @@ func (gb *GraphBuilder) processSliceFieldRecursively(ctx context.Context, source
 		}
 
 		// Extract edge properties before processing (for ServicePort, extract port_state)
-		edgeProperties := gb.extractEdgeProperties(item.Interface(), fieldName)
+		edgeProperties := gb.extractEdgeProperties(item.Interface())
 
-		targetNode, err := gb.processNestedEntityRecursively(ctx, item.Interface(), fieldName)
+		targetNode, err := gb.processNestedEntityRecursively(ctx, item.Interface())
 		if err != nil {
 			gb.logger.Warn("failed to process slice item", "field", fieldName, "index", i, "error", err)
 			continue
@@ -847,11 +844,22 @@ func (gb *GraphBuilder) processSliceFieldRecursively(ctx context.Context, source
 			continue
 		}
 
-		edgeType := gb.getEdgeTypeFromFieldName(fieldName)
+		// Create bidirectional edges
+		edgeTypes := gb.getEdgeTypesForField(fieldName, sourceNode.NodeType)
+
+		// Forward: Source BELONGS_TO Target
 		edges = append(edges, &GraphEdge{
 			SourceNodeID: sourceNode.ID,
 			TargetNodeID: targetNode.ID,
-			EdgeType:     edgeType,
+			EdgeType:     edgeTypes.Forward,
+			Properties:   edgeProperties,
+		})
+
+		// Reverse: Target HAS Source
+		edges = append(edges, &GraphEdge{
+			SourceNodeID: targetNode.ID,
+			TargetNodeID: sourceNode.ID,
+			EdgeType:     edgeTypes.Reverse,
 			Properties:   edgeProperties,
 		})
 	}
@@ -859,8 +867,8 @@ func (gb *GraphBuilder) processSliceFieldRecursively(ctx context.Context, source
 	return edges, nil
 }
 
-// processNestedEntityRecursively attempts to process a nested entity recursively
-func (gb *GraphBuilder) processNestedEntityRecursively(ctx context.Context, fieldValue any, _ string) (*GraphNode, error) {
+// processNestedEntityRecursively attempts to process a nested entity recursively.
+func (gb *GraphBuilder) processNestedEntityRecursively(ctx context.Context, fieldValue any) (*GraphNode, error) {
 	// Use generated function to create entity from field value
 	entity := protograph.CreateEntityFromInterface(fieldValue)
 	if entity == nil {
@@ -920,7 +928,7 @@ func (gb *GraphBuilder) upsertNode(ctx context.Context, externalID, nodeType str
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("upserting node %s/%s: %w", nodeType, externalID, err)
 	}
 
 	// Create snapshot with full entity data
@@ -991,10 +999,10 @@ func (gb *GraphBuilder) findNodeByTypeAndID(ctx context.Context, nodeType, exter
 	})
 	if err != nil {
 		// Check if this is a "no rows" error - return nil, nil if so
-		if err.Error() == "no rows in result set" {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("finding node %s/%s: %w", nodeType, externalID, err)
 	}
 
 	return &GraphNode{
@@ -1038,178 +1046,16 @@ func getEntityTypeName(entity *diodepb.Entity) string {
 	return typeName
 }
 
-// getEdgeTypeFromFieldName maps field names to semantic edge types
-func (gb *GraphBuilder) getEdgeTypeFromFieldName(fieldName string) string {
-	switch fieldName {
-	// Hierarchical relationships
-	case "Device", "device":
-		return "BELONGS_TO_DEVICE"
-	case "Site", "site":
-		return "BELONGS_TO_SITE"
-	case "Location", "location":
-		return "LOCATED_IN"
-	case "Rack", "rack":
-		return "POSITIONED_IN_RACK"
-	case "Region", "region":
-		return "BELONGS_TO_REGION"
-	case "SiteGroup", "site_group":
-		return "BELONGS_TO_SITE_GROUP"
-	case "Cluster", "cluster":
-		return "BELONGS_TO_CLUSTER"
-	case "ClusterGroup", "cluster_group":
-		return "BELONGS_TO_CLUSTER_GROUP"
-	case "VirtualMachine", "virtual_machine":
-		return "BELONGS_TO_VM"
-
-	// Network relationships
-	case "Vrf", "vrf":
-		return "MEMBER_OF_VRF"
-	case "TaggedVlans", "tagged_vlans", "Vlan", "vlan":
-		return "TAGGED_WITH_VLAN"
-	case "UntaggedVlan", "untagged_vlan":
-		return "UNTAGGED_VLAN"
-	case "Interface", "interface":
-		return "CONNECTS_TO_INTERFACE"
-	case "VMInterface", "vm_interface":
-		return "CONNECTS_TO_VM_INTERFACE"
-
-	// Organizational relationships
-	case "Tags", "tags", "Tag", "tag":
-		return "TAGGED_WITH"
-	case "Tenant", "tenant":
-		return "BELONGS_TO_TENANT"
-	case "TenantGroup", "tenant_group":
-		return "BELONGS_TO_TENANT_GROUP"
-	case "Contact", "contact":
-		return "ASSIGNED_CONTACT"
-	case "ContactGroup", "contact_group":
-		return "BELONGS_TO_CONTACT_GROUP"
-	case "ContactRole", "contact_role":
-		return "HAS_CONTACT_ROLE"
-
-	// Type relationships
-	case "DeviceType", "device_type":
-		return "INSTANCE_OF_DEVICE_TYPE"
-	case "DeviceRole", "device_role":
-		return "HAS_DEVICE_ROLE"
-	case "Platform", "platform":
-		return "RUNS_ON_PLATFORM"
-	case "Manufacturer", "manufacturer":
-		return "MANUFACTURED_BY"
-	case "ClusterType", "cluster_type":
-		return "INSTANCE_OF_CLUSTER_TYPE"
-	case "RackType", "rack_type":
-		return "INSTANCE_OF_RACK_TYPE"
-	case "RackRole", "rack_role":
-		return "HAS_RACK_ROLE"
-
-	// Circuit relationships
-	case "Provider", "provider":
-		return "PROVIDED_BY"
-	case "Circuit", "circuit":
-		return "BELONGS_TO_CIRCUIT"
-	case "CircuitType", "circuit_type":
-		return "INSTANCE_OF_CIRCUIT_TYPE"
-
-	// Cable relationships
-	case "Cable", "cable":
-		return "CONNECTED_BY_CABLE"
-	case "ATerminations", "a_terminations":
-		return "CABLE_A_SIDE"
-	case "BTerminations", "b_terminations":
-		return "CABLE_B_SIDE"
-
-	// Power relationships
-	case "PowerFeed", "power_feed":
-		return "POWERED_BY"
-	case "PowerPanel", "power_panel":
-		return "POWERED_FROM_PANEL"
-	case "PowerOutlet", "power_outlet":
-		return "CONNECTS_TO_POWER_OUTLET"
-	case "PowerPort", "power_port":
-		return "CONNECTS_TO_POWER_PORT"
-
-	// Parent/child relationships
-	case "Parent", "parent":
-		return "CHILD_OF"
-	case "ParentInterface", "parent_interface":
-		return "CHILD_OF_INTERFACE"
-
-	// Service port relationships
-	case "ServicePorts", "service_ports", "ServicePort", "service_port":
-		return "HAS_SERVICE_PORT"
-
-	default:
-		return "REFERENCES"
-	}
+// getEdgeTypesForField returns both forward and reverse edge types for bidirectional relationships.
+// Forward: BELONGS_TO_X (source references target)
+// Reverse: HAS_X (target contains source)
+func (gb *GraphBuilder) getEdgeTypesForField(fieldName, sourceEntityType string) protograph.EdgeTypePair {
+	return protograph.GetEdgeTypesForField(fieldName, sourceEntityType)
 }
 
-// getNodeTypeFromFieldName maps field names to netbox object types using existing constants
+// getNodeTypeFromFieldName returns the node type (entity type name) for a given field name using generated mappings.
 func (gb *GraphBuilder) getNodeTypeFromFieldName(fieldName string) string {
-	switch fieldName {
-	case "Device", "device":
-		return netbox.DeviceObjectType
-	case "Site", "site":
-		return netbox.SiteObjectType
-	case "Location", "location":
-		return netbox.LocationObjectType
-	case "Rack", "rack":
-		return netbox.RackObjectType
-	case "Vrf", "vrf":
-		return netbox.VRFObjectType
-	case "TaggedVlans", "tagged_vlans", "Vlan", "vlan":
-		return netbox.VLANObjectType
-	case "Tags", "tags", "Tag", "tag":
-		return netbox.TagObjectType
-	case "Tenant", "tenant":
-		return netbox.TenantObjectType
-	case "DeviceType", "device_type":
-		return netbox.DeviceTypeObjectType
-	case "DeviceRole", "device_role":
-		return netbox.DeviceRoleObjectType
-	case "Platform", "platform":
-		return netbox.PlatformObjectType
-	case "Manufacturer", "manufacturer":
-		return netbox.ManufacturerObjectType
-	case "Interface", "interface":
-		return netbox.InterfaceObjectType
-	case "Region", "region":
-		return netbox.RegionObjectType
-	case "SiteGroup", "site_group":
-		return netbox.SiteGroupObjectType
-	case "TenantGroup", "tenant_group":
-		return netbox.TenantGroupObjectType
-	case "RackRole", "rack_role":
-		return netbox.RackRoleObjectType
-	case "RackType", "rack_type":
-		return netbox.RackTypeObjectType
-	case "Cluster", "cluster":
-		return netbox.ClusterObjectType
-	case "ClusterType", "cluster_type":
-		return netbox.ClusterTypeObjectType
-	case "ClusterGroup", "cluster_group":
-		return netbox.ClusterGroupObjectType
-	case "VirtualMachine", "virtual_machine":
-		return netbox.VirtualMachineObjectType
-	case "VMInterface", "vm_interface":
-		return netbox.VMInterfaceObjectType
-	case "Contact", "contact":
-		return netbox.ContactObjectType
-	case "ContactGroup", "contact_group":
-		return netbox.ContactGroupObjectType
-	case "ContactRole", "contact_role":
-		return netbox.ContactRoleObjectType
-	case "Provider", "provider":
-		return netbox.ProviderObjectType
-	case "Circuit", "circuit":
-		return netbox.CircuitObjectType
-	case "CircuitType", "circuit_type":
-		return netbox.CircuitTypeObjectType
-	case "Cable", "cable":
-		return netbox.CableObjectType
-	default:
-		return "unknown"
-	}
+	return protograph.GetNodeTypeForField(fieldName)
 }
 
 // propagateNodeUpdates finds nodes that reference updated nodes and refreshes them with the latest data
@@ -1299,7 +1145,7 @@ func (gb *GraphBuilder) checkDataForUpdatedReferences(data any, excludeNodeKey s
 							if entityMap, ok := entityData.(map[string]any); ok {
 								if updatedName, ok := entityMap["name"]; ok && updatedName == nameStr {
 									// Check if the node types could be related (e.g., Manufacturer)
-									if gb.couldBeRelatedNodeType(updatedNode.NodeType, v) {
+									if gb.couldBeRelatedNodeType(updatedNode.NodeType) {
 										gb.logger.Debug("found reference that needs update",
 											"referring_name", nameStr,
 											"updated_node_type", updatedNode.NodeType,
@@ -1331,8 +1177,8 @@ func (gb *GraphBuilder) checkDataForUpdatedReferences(data any, excludeNodeKey s
 	return false
 }
 
-// couldBeRelatedNodeType checks if an updated node type could be referenced by the given data
-func (gb *GraphBuilder) couldBeRelatedNodeType(updatedNodeType string, _ map[string]any) bool {
+// couldBeRelatedNodeType checks if an updated node type could be referenced by the given data.
+func (gb *GraphBuilder) couldBeRelatedNodeType(updatedNodeType string) bool {
 	// The logic here is: if we updated a node of type X, and this referenceData
 	// represents a reference to type X (by having the same name), then it's related
 

--- a/diode-server/reconciler/graph_builder_test.go
+++ b/diode-server/reconciler/graph_builder_test.go
@@ -1,0 +1,482 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/diode/diode-server/gen/dbstore/postgres"
+	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
+	"github.com/netboxlabs/diode/diode-server/reconciler/mocks"
+)
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestNewGraphBuilder(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+
+	gb := NewGraphBuilder(repo, logger)
+
+	assert.NotNil(t, gb)
+	assert.NotNil(t, gb.nodeCache)
+	assert.NotNil(t, gb.updatedNodes)
+	assert.NotNil(t, gb.seenInThisRequest)
+	assert.Equal(t, DefaultSnapshotRetention, gb.snapshotRetention)
+	assert.Nil(t, gb.entityMatcher)
+}
+
+func TestNewGraphBuilderWithMatcher(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+
+	// Test with nil matcher
+	gb := NewGraphBuilderWithMatcher(repo, logger, nil)
+
+	assert.NotNil(t, gb)
+	assert.Nil(t, gb.entityMatcher)
+}
+
+func TestSetSnapshotRetention(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	// Test setting valid retention
+	gb.SetSnapshotRetention(10)
+	assert.Equal(t, 10, gb.snapshotRetention)
+
+	// Test setting zero (should not change)
+	gb.SetSnapshotRetention(0)
+	assert.Equal(t, 10, gb.snapshotRetention)
+
+	// Test setting negative (should not change)
+	gb.SetSnapshotRetention(-5)
+	assert.Equal(t, 10, gb.snapshotRetention)
+}
+
+func TestExtractGraph_NilEntity(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	err := gb.ExtractGraph(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "entity or entity content is nil")
+}
+
+func TestExtractGraph_EmptyEntity(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	entity := &diodepb.Entity{}
+	err := gb.ExtractGraph(context.Background(), entity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "entity or entity content is nil")
+}
+
+func TestExtractGraph_SimpleDevice(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	ctx := context.Background()
+
+	// Create a simple device entity
+	device := &diodepb.Device{
+		Name: ptrString("test-device"),
+	}
+	entity := &diodepb.Entity{
+		Entity: &diodepb.Entity_Device{Device: device},
+	}
+
+	// Setup mock expectations
+	repo.EXPECT().UpsertGraphNode(ctx, mock.AnythingOfType("postgres.UpsertGraphNodeParams")).
+		Return(postgres.UpsertGraphNodeRow{
+			ID:                    1,
+			ExternalID:            "test-hash",
+			NodeType:              "Device",
+			Data:                  json.RawMessage(`{}`),
+			DuplicateCount:        1,
+			MatchingSchemaVersion: 1,
+		}, nil).Once()
+
+	repo.EXPECT().InsertSnapshot(ctx, mock.AnythingOfType("postgres.InsertSnapshotParams")).
+		Return(postgres.GraphNodeSnapshot{}, nil).Once()
+
+	repo.EXPECT().CleanupOldSnapshots(ctx, mock.AnythingOfType("postgres.CleanupOldSnapshotsParams")).
+		Return(nil).Once()
+
+	err := gb.ExtractGraph(ctx, entity)
+	assert.NoError(t, err)
+
+	repo.AssertExpectations(t)
+}
+
+func TestExtractGraph_DeviceWithSite(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	ctx := context.Background()
+
+	// Create a device with a site reference
+	site := &diodepb.Site{
+		Name: "test-site",
+	}
+	device := &diodepb.Device{
+		Name: ptrString("test-device"),
+		Site: site,
+	}
+	entity := &diodepb.Entity{
+		Entity: &diodepb.Entity_Device{Device: device},
+	}
+
+	// Setup mock expectations for device node
+	repo.EXPECT().UpsertGraphNode(ctx, mock.MatchedBy(func(params postgres.UpsertGraphNodeParams) bool {
+		return params.NodeType == "Device"
+	})).Return(postgres.UpsertGraphNodeRow{
+		ID:                    1,
+		ExternalID:            "device-hash",
+		NodeType:              "Device",
+		Data:                  json.RawMessage(`{}`),
+		DuplicateCount:        1,
+		MatchingSchemaVersion: 1,
+	}, nil).Once()
+
+	repo.EXPECT().InsertSnapshot(ctx, mock.MatchedBy(func(params postgres.InsertSnapshotParams) bool {
+		return params.NodeID == 1
+	})).Return(postgres.GraphNodeSnapshot{}, nil).Once()
+
+	repo.EXPECT().CleanupOldSnapshots(ctx, mock.MatchedBy(func(params postgres.CleanupOldSnapshotsParams) bool {
+		return params.NodeID == 1
+	})).Return(nil).Once()
+
+	// Setup mock expectations for site node
+	repo.EXPECT().UpsertGraphNode(ctx, mock.MatchedBy(func(params postgres.UpsertGraphNodeParams) bool {
+		return params.NodeType == "Site"
+	})).Return(postgres.UpsertGraphNodeRow{
+		ID:                    2,
+		ExternalID:            "site-hash",
+		NodeType:              "Site",
+		Data:                  json.RawMessage(`{}`),
+		DuplicateCount:        1,
+		MatchingSchemaVersion: 1,
+	}, nil).Once()
+
+	repo.EXPECT().InsertSnapshot(ctx, mock.MatchedBy(func(params postgres.InsertSnapshotParams) bool {
+		return params.NodeID == 2
+	})).Return(postgres.GraphNodeSnapshot{}, nil).Once()
+
+	repo.EXPECT().CleanupOldSnapshots(ctx, mock.MatchedBy(func(params postgres.CleanupOldSnapshotsParams) bool {
+		return params.NodeID == 2
+	})).Return(nil).Once()
+
+	// Setup mock expectations for edges (bidirectional)
+	repo.EXPECT().UpsertGraphEdge(ctx, mock.MatchedBy(func(params postgres.UpsertGraphEdgeParams) bool {
+		return params.EdgeType == "BELONGS_TO_SITE"
+	})).Return(nil).Once()
+
+	repo.EXPECT().UpsertGraphEdge(ctx, mock.MatchedBy(func(params postgres.UpsertGraphEdgeParams) bool {
+		return params.EdgeType == "HAS_DEVICE"
+	})).Return(nil).Once()
+
+	err := gb.ExtractGraph(ctx, entity)
+	assert.NoError(t, err)
+
+	repo.AssertExpectations(t)
+}
+
+func TestFindNodeByTypeAndID_Found(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	ctx := context.Background()
+
+	repo.EXPECT().FindGraphNode(ctx, postgres.FindGraphNodeParams{
+		NodeType:   "Device",
+		ExternalID: "test-id",
+	}).Return(postgres.FindGraphNodeRow{
+		ID:             1,
+		ExternalID:     "test-id",
+		NodeType:       "Device",
+		Data:           json.RawMessage(`{}`),
+		DuplicateCount: 1,
+	}, nil).Once()
+
+	node, err := gb.findNodeByTypeAndID(ctx, "Device", "test-id")
+	require.NoError(t, err)
+	assert.NotNil(t, node)
+	assert.Equal(t, int64(1), node.ID)
+	assert.Equal(t, "test-id", node.ExternalID)
+	assert.Equal(t, "Device", node.NodeType)
+
+	repo.AssertExpectations(t)
+}
+
+func TestFindNodeByTypeAndID_NotFound(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	ctx := context.Background()
+
+	repo.EXPECT().FindGraphNode(ctx, postgres.FindGraphNodeParams{
+		NodeType:   "Device",
+		ExternalID: "nonexistent",
+	}).Return(postgres.FindGraphNodeRow{}, pgx.ErrNoRows).Once()
+
+	node, err := gb.findNodeByTypeAndID(ctx, "Device", "nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, node)
+
+	repo.AssertExpectations(t)
+}
+
+func TestCanBeNil(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected bool
+	}{
+		{"pointer", new(string), true},
+		{"nil pointer", (*string)(nil), true},
+		{"slice", []string{}, true},
+		{"map", map[string]string{}, true},
+		{"interface", any(nil), true},
+		{"string", "test", false},
+		{"int", 42, false},
+		{"struct", struct{}{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := reflect.ValueOf(tt.value)
+			// For nil interface, create an interface-typed reflect.Value
+			if tt.name == "interface" {
+				var i any
+				v = reflect.ValueOf(&i).Elem()
+			}
+			result := canBeNil(v)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetEntityTypeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		entity   *diodepb.Entity
+		expected string
+	}{
+		{
+			name:     "nil entity",
+			entity:   nil,
+			expected: "",
+		},
+		{
+			name:     "empty entity",
+			entity:   &diodepb.Entity{},
+			expected: "",
+		},
+		{
+			name: "device entity",
+			entity: &diodepb.Entity{
+				Entity: &diodepb.Entity_Device{Device: &diodepb.Device{}},
+			},
+			expected: "Device",
+		},
+		{
+			name: "site entity",
+			entity: &diodepb.Entity{
+				Entity: &diodepb.Entity_Site{Site: &diodepb.Site{}},
+			},
+			expected: "Site",
+		},
+		{
+			name: "interface entity",
+			entity: &diodepb.Entity{
+				Entity: &diodepb.Entity_Interface{Interface: &diodepb.Interface{}},
+			},
+			expected: "Interface",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getEntityTypeName(tt.entity)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractFieldByPath(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	data := map[string]any{
+		"name": "test",
+		"device": map[string]any{
+			"name": "test-device",
+			"site": map[string]any{
+				"name": "test-site",
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected any
+	}{
+		{"simple field", "name", "test"},
+		{"nested field", "device.name", "test-device"},
+		{"deeply nested", "device.site.name", "test-site"},
+		{"nonexistent field", "nonexistent", nil},
+		{"nonexistent nested", "device.nonexistent", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gb.extractFieldByPath(data, tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSetFieldByPath(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	tests := []struct {
+		name     string
+		path     string
+		value    any
+		expected map[string]any
+	}{
+		{
+			name:     "simple field",
+			path:     "name",
+			value:    "test",
+			expected: map[string]any{"name": "test"},
+		},
+		{
+			name:  "nested field",
+			path:  "device.name",
+			value: "test-device",
+			expected: map[string]any{
+				"device": map[string]any{
+					"name": "test-device",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make(map[string]any)
+			gb.setFieldByPath(data, tt.path, tt.value)
+			assert.Equal(t, tt.expected, data)
+		})
+	}
+}
+
+func TestGetCompleteNodeData(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	ctx := context.Background()
+
+	repo.EXPECT().GetNodeWithLatestSnapshot(ctx, postgres.GetNodeWithLatestSnapshotParams{
+		NodeType:   "Device",
+		ExternalID: "test-id",
+	}).Return(postgres.GetNodeWithLatestSnapshotRow{
+		ID:                    1,
+		ExternalID:            "test-id",
+		NodeType:              "Device",
+		MatchingData:          json.RawMessage(`{"name":"test"}`),
+		SnapshotData:          json.RawMessage(`{"name":"test","serial":"123"}`),
+		DuplicateCount:        1,
+		MatchingSchemaVersion: 1,
+		SequenceNumber:        1,
+		SnapshotCreatedAt:     pgtype.Timestamptz{Valid: true},
+	}, nil).Once()
+
+	result, err := gb.GetCompleteNodeData(ctx, "Device", "test-id")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(1), result.ID)
+	assert.Equal(t, "test-id", result.ExternalID)
+	assert.Equal(t, json.RawMessage(`{"name":"test","serial":"123"}`), result.CompleteData)
+
+	repo.AssertExpectations(t)
+}
+
+func TestGetNodeSnapshots(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	ctx := context.Background()
+
+	expectedSnapshots := []postgres.GraphNodeSnapshot{
+		{ID: 1, NodeID: 1, SequenceNumber: 1, SnapshotData: json.RawMessage(`{}`)},
+		{ID: 2, NodeID: 1, SequenceNumber: 2, SnapshotData: json.RawMessage(`{}`)},
+	}
+
+	repo.EXPECT().GetSnapshotsByNode(ctx, postgres.GetSnapshotsByNodeParams{
+		NodeID: 1,
+		Limit:  10,
+		Offset: 0,
+	}).Return(expectedSnapshots, nil).Once()
+
+	snapshots, err := gb.GetNodeSnapshots(ctx, 1, 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, snapshots, 2)
+
+	repo.AssertExpectations(t)
+}
+
+func TestNeedsSchemaUpdate(t *testing.T) {
+	repo := new(mocks.GraphRepository)
+	logger := newTestLogger()
+	gb := NewGraphBuilder(repo, logger)
+
+	tests := []struct {
+		name     string
+		version  int32
+		expected bool
+	}{
+		{"older version", 0, true},
+		{"current version", CurrentSchemaVersion, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &postgres.GraphNode{MatchingSchemaVersion: tt.version}
+			result := gb.needsSchemaUpdate(node)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to create string pointer
+func ptrString(s string) *string {
+	return &s
+}

--- a/diode-server/reconciler/graph_repository.go
+++ b/diode-server/reconciler/graph_repository.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/netboxlabs/diode/diode-server/gen/dbstore/postgres"
 )
@@ -9,13 +10,39 @@ import (
 // GraphNode is an alias to the SQLC-generated GraphNode type
 type GraphNode = postgres.GraphNode
 
+// GraphEdge represents an edge between two nodes
+type GraphEdge struct {
+	ID           int64           `json:"id"`
+	SourceNodeID int64           `json:"source_node_id"`
+	TargetNodeID int64           `json:"target_node_id"`
+	EdgeType     string          `json:"edge_type"`
+	Properties   json.RawMessage `json:"properties"`
+}
+
 // GraphRepository defines the interface for graph database operations.
 // This interface wraps the SQLC-generated Queries to allow for mocking in tests.
 // Used by EntityMatcher and GraphBuilder.
 type GraphRepository interface {
-	// FindNodesByFieldMatch finds nodes by matching JSON fields
-	FindNodesByFieldMatch(ctx context.Context, arg postgres.FindNodesByFieldMatchParams) ([]postgres.GraphNode, error)
+	// Node operations
+	UpsertGraphNode(ctx context.Context, arg postgres.UpsertGraphNodeParams) (postgres.UpsertGraphNodeRow, error)
+	UpdateGraphNodeData(ctx context.Context, arg postgres.UpdateGraphNodeDataParams) (postgres.UpdateGraphNodeDataRow, error)
+	FindGraphNode(ctx context.Context, arg postgres.FindGraphNodeParams) (postgres.FindGraphNodeRow, error)
 
-	// GetGraphNodesByType retrieves nodes of a specific type with pagination
+	// Edge operations
+	UpsertGraphEdge(ctx context.Context, arg postgres.UpsertGraphEdgeParams) error
+
+	// Entity matching queries
+	FindNodesByFieldMatch(ctx context.Context, arg postgres.FindNodesByFieldMatchParams) ([]postgres.GraphNode, error)
+	FindNodesByMultiFieldMatch(ctx context.Context, arg postgres.FindNodesByMultiFieldMatchParams) ([]postgres.GraphNode, error)
 	GetGraphNodesByType(ctx context.Context, arg postgres.GetGraphNodesByTypeParams) ([]postgres.GraphNode, error)
+
+	// Snapshot management
+	InsertSnapshot(ctx context.Context, arg postgres.InsertSnapshotParams) (postgres.GraphNodeSnapshot, error)
+	GetLatestSnapshot(ctx context.Context, nodeID int64) (postgres.GraphNodeSnapshot, error)
+	CleanupOldSnapshots(ctx context.Context, arg postgres.CleanupOldSnapshotsParams) error
+	GetNodeWithLatestSnapshot(ctx context.Context, arg postgres.GetNodeWithLatestSnapshotParams) (postgres.GetNodeWithLatestSnapshotRow, error)
+	GetSnapshotsByNode(ctx context.Context, arg postgres.GetSnapshotsByNodeParams) ([]postgres.GraphNodeSnapshot, error)
+
+	// Schema update queries
+	FindNodesNeedingSchemaUpdate(ctx context.Context, arg postgres.FindNodesNeedingSchemaUpdateParams) ([]postgres.GraphNode, error)
 }

--- a/diode-server/reconciler/mocks/graphrepository.go
+++ b/diode-server/reconciler/mocks/graphrepository.go
@@ -22,6 +22,110 @@ func (_m *GraphRepository) EXPECT() *GraphRepository_Expecter {
 	return &GraphRepository_Expecter{mock: &_m.Mock}
 }
 
+// CleanupOldSnapshots provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) CleanupOldSnapshots(ctx context.Context, arg postgres.CleanupOldSnapshotsParams) error {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CleanupOldSnapshots")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.CleanupOldSnapshotsParams) error); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GraphRepository_CleanupOldSnapshots_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CleanupOldSnapshots'
+type GraphRepository_CleanupOldSnapshots_Call struct {
+	*mock.Call
+}
+
+// CleanupOldSnapshots is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.CleanupOldSnapshotsParams
+func (_e *GraphRepository_Expecter) CleanupOldSnapshots(ctx interface{}, arg interface{}) *GraphRepository_CleanupOldSnapshots_Call {
+	return &GraphRepository_CleanupOldSnapshots_Call{Call: _e.mock.On("CleanupOldSnapshots", ctx, arg)}
+}
+
+func (_c *GraphRepository_CleanupOldSnapshots_Call) Run(run func(ctx context.Context, arg postgres.CleanupOldSnapshotsParams)) *GraphRepository_CleanupOldSnapshots_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.CleanupOldSnapshotsParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_CleanupOldSnapshots_Call) Return(_a0 error) *GraphRepository_CleanupOldSnapshots_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *GraphRepository_CleanupOldSnapshots_Call) RunAndReturn(run func(context.Context, postgres.CleanupOldSnapshotsParams) error) *GraphRepository_CleanupOldSnapshots_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindGraphNode provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) FindGraphNode(ctx context.Context, arg postgres.FindGraphNodeParams) (postgres.FindGraphNodeRow, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindGraphNode")
+	}
+
+	var r0 postgres.FindGraphNodeRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.FindGraphNodeParams) (postgres.FindGraphNodeRow, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.FindGraphNodeParams) postgres.FindGraphNodeRow); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(postgres.FindGraphNodeRow)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.FindGraphNodeParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_FindGraphNode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindGraphNode'
+type GraphRepository_FindGraphNode_Call struct {
+	*mock.Call
+}
+
+// FindGraphNode is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.FindGraphNodeParams
+func (_e *GraphRepository_Expecter) FindGraphNode(ctx interface{}, arg interface{}) *GraphRepository_FindGraphNode_Call {
+	return &GraphRepository_FindGraphNode_Call{Call: _e.mock.On("FindGraphNode", ctx, arg)}
+}
+
+func (_c *GraphRepository_FindGraphNode_Call) Run(run func(ctx context.Context, arg postgres.FindGraphNodeParams)) *GraphRepository_FindGraphNode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.FindGraphNodeParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_FindGraphNode_Call) Return(_a0 postgres.FindGraphNodeRow, _a1 error) *GraphRepository_FindGraphNode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_FindGraphNode_Call) RunAndReturn(run func(context.Context, postgres.FindGraphNodeParams) (postgres.FindGraphNodeRow, error)) *GraphRepository_FindGraphNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindNodesByFieldMatch provides a mock function with given fields: ctx, arg
 func (_m *GraphRepository) FindNodesByFieldMatch(ctx context.Context, arg postgres.FindNodesByFieldMatchParams) ([]postgres.GraphNode, error) {
 	ret := _m.Called(ctx, arg)
@@ -81,6 +185,124 @@ func (_c *GraphRepository_FindNodesByFieldMatch_Call) RunAndReturn(run func(cont
 	return _c
 }
 
+// FindNodesByMultiFieldMatch provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) FindNodesByMultiFieldMatch(ctx context.Context, arg postgres.FindNodesByMultiFieldMatchParams) ([]postgres.GraphNode, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindNodesByMultiFieldMatch")
+	}
+
+	var r0 []postgres.GraphNode
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.FindNodesByMultiFieldMatchParams) ([]postgres.GraphNode, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.FindNodesByMultiFieldMatchParams) []postgres.GraphNode); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]postgres.GraphNode)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.FindNodesByMultiFieldMatchParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_FindNodesByMultiFieldMatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindNodesByMultiFieldMatch'
+type GraphRepository_FindNodesByMultiFieldMatch_Call struct {
+	*mock.Call
+}
+
+// FindNodesByMultiFieldMatch is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.FindNodesByMultiFieldMatchParams
+func (_e *GraphRepository_Expecter) FindNodesByMultiFieldMatch(ctx interface{}, arg interface{}) *GraphRepository_FindNodesByMultiFieldMatch_Call {
+	return &GraphRepository_FindNodesByMultiFieldMatch_Call{Call: _e.mock.On("FindNodesByMultiFieldMatch", ctx, arg)}
+}
+
+func (_c *GraphRepository_FindNodesByMultiFieldMatch_Call) Run(run func(ctx context.Context, arg postgres.FindNodesByMultiFieldMatchParams)) *GraphRepository_FindNodesByMultiFieldMatch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.FindNodesByMultiFieldMatchParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_FindNodesByMultiFieldMatch_Call) Return(_a0 []postgres.GraphNode, _a1 error) *GraphRepository_FindNodesByMultiFieldMatch_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_FindNodesByMultiFieldMatch_Call) RunAndReturn(run func(context.Context, postgres.FindNodesByMultiFieldMatchParams) ([]postgres.GraphNode, error)) *GraphRepository_FindNodesByMultiFieldMatch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindNodesNeedingSchemaUpdate provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) FindNodesNeedingSchemaUpdate(ctx context.Context, arg postgres.FindNodesNeedingSchemaUpdateParams) ([]postgres.GraphNode, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindNodesNeedingSchemaUpdate")
+	}
+
+	var r0 []postgres.GraphNode
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.FindNodesNeedingSchemaUpdateParams) ([]postgres.GraphNode, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.FindNodesNeedingSchemaUpdateParams) []postgres.GraphNode); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]postgres.GraphNode)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.FindNodesNeedingSchemaUpdateParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_FindNodesNeedingSchemaUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindNodesNeedingSchemaUpdate'
+type GraphRepository_FindNodesNeedingSchemaUpdate_Call struct {
+	*mock.Call
+}
+
+// FindNodesNeedingSchemaUpdate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.FindNodesNeedingSchemaUpdateParams
+func (_e *GraphRepository_Expecter) FindNodesNeedingSchemaUpdate(ctx interface{}, arg interface{}) *GraphRepository_FindNodesNeedingSchemaUpdate_Call {
+	return &GraphRepository_FindNodesNeedingSchemaUpdate_Call{Call: _e.mock.On("FindNodesNeedingSchemaUpdate", ctx, arg)}
+}
+
+func (_c *GraphRepository_FindNodesNeedingSchemaUpdate_Call) Run(run func(ctx context.Context, arg postgres.FindNodesNeedingSchemaUpdateParams)) *GraphRepository_FindNodesNeedingSchemaUpdate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.FindNodesNeedingSchemaUpdateParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_FindNodesNeedingSchemaUpdate_Call) Return(_a0 []postgres.GraphNode, _a1 error) *GraphRepository_FindNodesNeedingSchemaUpdate_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_FindNodesNeedingSchemaUpdate_Call) RunAndReturn(run func(context.Context, postgres.FindNodesNeedingSchemaUpdateParams) ([]postgres.GraphNode, error)) *GraphRepository_FindNodesNeedingSchemaUpdate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGraphNodesByType provides a mock function with given fields: ctx, arg
 func (_m *GraphRepository) GetGraphNodesByType(ctx context.Context, arg postgres.GetGraphNodesByTypeParams) ([]postgres.GraphNode, error) {
 	ret := _m.Called(ctx, arg)
@@ -136,6 +358,397 @@ func (_c *GraphRepository_GetGraphNodesByType_Call) Return(_a0 []postgres.GraphN
 }
 
 func (_c *GraphRepository_GetGraphNodesByType_Call) RunAndReturn(run func(context.Context, postgres.GetGraphNodesByTypeParams) ([]postgres.GraphNode, error)) *GraphRepository_GetGraphNodesByType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLatestSnapshot provides a mock function with given fields: ctx, nodeID
+func (_m *GraphRepository) GetLatestSnapshot(ctx context.Context, nodeID int64) (postgres.GraphNodeSnapshot, error) {
+	ret := _m.Called(ctx, nodeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLatestSnapshot")
+	}
+
+	var r0 postgres.GraphNodeSnapshot
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) (postgres.GraphNodeSnapshot, error)); ok {
+		return rf(ctx, nodeID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64) postgres.GraphNodeSnapshot); ok {
+		r0 = rf(ctx, nodeID)
+	} else {
+		r0 = ret.Get(0).(postgres.GraphNodeSnapshot)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, nodeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_GetLatestSnapshot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLatestSnapshot'
+type GraphRepository_GetLatestSnapshot_Call struct {
+	*mock.Call
+}
+
+// GetLatestSnapshot is a helper method to define mock.On call
+//   - ctx context.Context
+//   - nodeID int64
+func (_e *GraphRepository_Expecter) GetLatestSnapshot(ctx interface{}, nodeID interface{}) *GraphRepository_GetLatestSnapshot_Call {
+	return &GraphRepository_GetLatestSnapshot_Call{Call: _e.mock.On("GetLatestSnapshot", ctx, nodeID)}
+}
+
+func (_c *GraphRepository_GetLatestSnapshot_Call) Run(run func(ctx context.Context, nodeID int64)) *GraphRepository_GetLatestSnapshot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_GetLatestSnapshot_Call) Return(_a0 postgres.GraphNodeSnapshot, _a1 error) *GraphRepository_GetLatestSnapshot_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_GetLatestSnapshot_Call) RunAndReturn(run func(context.Context, int64) (postgres.GraphNodeSnapshot, error)) *GraphRepository_GetLatestSnapshot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetNodeWithLatestSnapshot provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) GetNodeWithLatestSnapshot(ctx context.Context, arg postgres.GetNodeWithLatestSnapshotParams) (postgres.GetNodeWithLatestSnapshotRow, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNodeWithLatestSnapshot")
+	}
+
+	var r0 postgres.GetNodeWithLatestSnapshotRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.GetNodeWithLatestSnapshotParams) (postgres.GetNodeWithLatestSnapshotRow, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.GetNodeWithLatestSnapshotParams) postgres.GetNodeWithLatestSnapshotRow); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(postgres.GetNodeWithLatestSnapshotRow)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.GetNodeWithLatestSnapshotParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_GetNodeWithLatestSnapshot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNodeWithLatestSnapshot'
+type GraphRepository_GetNodeWithLatestSnapshot_Call struct {
+	*mock.Call
+}
+
+// GetNodeWithLatestSnapshot is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.GetNodeWithLatestSnapshotParams
+func (_e *GraphRepository_Expecter) GetNodeWithLatestSnapshot(ctx interface{}, arg interface{}) *GraphRepository_GetNodeWithLatestSnapshot_Call {
+	return &GraphRepository_GetNodeWithLatestSnapshot_Call{Call: _e.mock.On("GetNodeWithLatestSnapshot", ctx, arg)}
+}
+
+func (_c *GraphRepository_GetNodeWithLatestSnapshot_Call) Run(run func(ctx context.Context, arg postgres.GetNodeWithLatestSnapshotParams)) *GraphRepository_GetNodeWithLatestSnapshot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.GetNodeWithLatestSnapshotParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_GetNodeWithLatestSnapshot_Call) Return(_a0 postgres.GetNodeWithLatestSnapshotRow, _a1 error) *GraphRepository_GetNodeWithLatestSnapshot_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_GetNodeWithLatestSnapshot_Call) RunAndReturn(run func(context.Context, postgres.GetNodeWithLatestSnapshotParams) (postgres.GetNodeWithLatestSnapshotRow, error)) *GraphRepository_GetNodeWithLatestSnapshot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSnapshotsByNode provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) GetSnapshotsByNode(ctx context.Context, arg postgres.GetSnapshotsByNodeParams) ([]postgres.GraphNodeSnapshot, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSnapshotsByNode")
+	}
+
+	var r0 []postgres.GraphNodeSnapshot
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.GetSnapshotsByNodeParams) ([]postgres.GraphNodeSnapshot, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.GetSnapshotsByNodeParams) []postgres.GraphNodeSnapshot); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]postgres.GraphNodeSnapshot)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.GetSnapshotsByNodeParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_GetSnapshotsByNode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSnapshotsByNode'
+type GraphRepository_GetSnapshotsByNode_Call struct {
+	*mock.Call
+}
+
+// GetSnapshotsByNode is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.GetSnapshotsByNodeParams
+func (_e *GraphRepository_Expecter) GetSnapshotsByNode(ctx interface{}, arg interface{}) *GraphRepository_GetSnapshotsByNode_Call {
+	return &GraphRepository_GetSnapshotsByNode_Call{Call: _e.mock.On("GetSnapshotsByNode", ctx, arg)}
+}
+
+func (_c *GraphRepository_GetSnapshotsByNode_Call) Run(run func(ctx context.Context, arg postgres.GetSnapshotsByNodeParams)) *GraphRepository_GetSnapshotsByNode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.GetSnapshotsByNodeParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_GetSnapshotsByNode_Call) Return(_a0 []postgres.GraphNodeSnapshot, _a1 error) *GraphRepository_GetSnapshotsByNode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_GetSnapshotsByNode_Call) RunAndReturn(run func(context.Context, postgres.GetSnapshotsByNodeParams) ([]postgres.GraphNodeSnapshot, error)) *GraphRepository_GetSnapshotsByNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InsertSnapshot provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) InsertSnapshot(ctx context.Context, arg postgres.InsertSnapshotParams) (postgres.GraphNodeSnapshot, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InsertSnapshot")
+	}
+
+	var r0 postgres.GraphNodeSnapshot
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.InsertSnapshotParams) (postgres.GraphNodeSnapshot, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.InsertSnapshotParams) postgres.GraphNodeSnapshot); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(postgres.GraphNodeSnapshot)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.InsertSnapshotParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_InsertSnapshot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InsertSnapshot'
+type GraphRepository_InsertSnapshot_Call struct {
+	*mock.Call
+}
+
+// InsertSnapshot is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.InsertSnapshotParams
+func (_e *GraphRepository_Expecter) InsertSnapshot(ctx interface{}, arg interface{}) *GraphRepository_InsertSnapshot_Call {
+	return &GraphRepository_InsertSnapshot_Call{Call: _e.mock.On("InsertSnapshot", ctx, arg)}
+}
+
+func (_c *GraphRepository_InsertSnapshot_Call) Run(run func(ctx context.Context, arg postgres.InsertSnapshotParams)) *GraphRepository_InsertSnapshot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.InsertSnapshotParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_InsertSnapshot_Call) Return(_a0 postgres.GraphNodeSnapshot, _a1 error) *GraphRepository_InsertSnapshot_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_InsertSnapshot_Call) RunAndReturn(run func(context.Context, postgres.InsertSnapshotParams) (postgres.GraphNodeSnapshot, error)) *GraphRepository_InsertSnapshot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateGraphNodeData provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) UpdateGraphNodeData(ctx context.Context, arg postgres.UpdateGraphNodeDataParams) (postgres.UpdateGraphNodeDataRow, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateGraphNodeData")
+	}
+
+	var r0 postgres.UpdateGraphNodeDataRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.UpdateGraphNodeDataParams) (postgres.UpdateGraphNodeDataRow, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.UpdateGraphNodeDataParams) postgres.UpdateGraphNodeDataRow); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(postgres.UpdateGraphNodeDataRow)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.UpdateGraphNodeDataParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_UpdateGraphNodeData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGraphNodeData'
+type GraphRepository_UpdateGraphNodeData_Call struct {
+	*mock.Call
+}
+
+// UpdateGraphNodeData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.UpdateGraphNodeDataParams
+func (_e *GraphRepository_Expecter) UpdateGraphNodeData(ctx interface{}, arg interface{}) *GraphRepository_UpdateGraphNodeData_Call {
+	return &GraphRepository_UpdateGraphNodeData_Call{Call: _e.mock.On("UpdateGraphNodeData", ctx, arg)}
+}
+
+func (_c *GraphRepository_UpdateGraphNodeData_Call) Run(run func(ctx context.Context, arg postgres.UpdateGraphNodeDataParams)) *GraphRepository_UpdateGraphNodeData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.UpdateGraphNodeDataParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_UpdateGraphNodeData_Call) Return(_a0 postgres.UpdateGraphNodeDataRow, _a1 error) *GraphRepository_UpdateGraphNodeData_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_UpdateGraphNodeData_Call) RunAndReturn(run func(context.Context, postgres.UpdateGraphNodeDataParams) (postgres.UpdateGraphNodeDataRow, error)) *GraphRepository_UpdateGraphNodeData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertGraphEdge provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) UpsertGraphEdge(ctx context.Context, arg postgres.UpsertGraphEdgeParams) error {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertGraphEdge")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.UpsertGraphEdgeParams) error); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GraphRepository_UpsertGraphEdge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertGraphEdge'
+type GraphRepository_UpsertGraphEdge_Call struct {
+	*mock.Call
+}
+
+// UpsertGraphEdge is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.UpsertGraphEdgeParams
+func (_e *GraphRepository_Expecter) UpsertGraphEdge(ctx interface{}, arg interface{}) *GraphRepository_UpsertGraphEdge_Call {
+	return &GraphRepository_UpsertGraphEdge_Call{Call: _e.mock.On("UpsertGraphEdge", ctx, arg)}
+}
+
+func (_c *GraphRepository_UpsertGraphEdge_Call) Run(run func(ctx context.Context, arg postgres.UpsertGraphEdgeParams)) *GraphRepository_UpsertGraphEdge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.UpsertGraphEdgeParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_UpsertGraphEdge_Call) Return(_a0 error) *GraphRepository_UpsertGraphEdge_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *GraphRepository_UpsertGraphEdge_Call) RunAndReturn(run func(context.Context, postgres.UpsertGraphEdgeParams) error) *GraphRepository_UpsertGraphEdge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertGraphNode provides a mock function with given fields: ctx, arg
+func (_m *GraphRepository) UpsertGraphNode(ctx context.Context, arg postgres.UpsertGraphNodeParams) (postgres.UpsertGraphNodeRow, error) {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertGraphNode")
+	}
+
+	var r0 postgres.UpsertGraphNodeRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.UpsertGraphNodeParams) (postgres.UpsertGraphNodeRow, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, postgres.UpsertGraphNodeParams) postgres.UpsertGraphNodeRow); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(postgres.UpsertGraphNodeRow)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, postgres.UpsertGraphNodeParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GraphRepository_UpsertGraphNode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertGraphNode'
+type GraphRepository_UpsertGraphNode_Call struct {
+	*mock.Call
+}
+
+// UpsertGraphNode is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg postgres.UpsertGraphNodeParams
+func (_e *GraphRepository_Expecter) UpsertGraphNode(ctx interface{}, arg interface{}) *GraphRepository_UpsertGraphNode_Call {
+	return &GraphRepository_UpsertGraphNode_Call{Call: _e.mock.On("UpsertGraphNode", ctx, arg)}
+}
+
+func (_c *GraphRepository_UpsertGraphNode_Call) Run(run func(ctx context.Context, arg postgres.UpsertGraphNodeParams)) *GraphRepository_UpsertGraphNode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(postgres.UpsertGraphNodeParams))
+	})
+	return _c
+}
+
+func (_c *GraphRepository_UpsertGraphNode_Call) Return(_a0 postgres.UpsertGraphNodeRow, _a1 error) *GraphRepository_UpsertGraphNode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GraphRepository_UpsertGraphNode_Call) RunAndReturn(run func(context.Context, postgres.UpsertGraphNodeParams) (postgres.UpsertGraphNodeRow, error)) *GraphRepository_UpsertGraphNode_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/diode-server/strcase/strcase.go
+++ b/diode-server/strcase/strcase.go
@@ -1,0 +1,43 @@
+// Package strcase provides string case conversion utilities.
+package strcase
+
+import "strings"
+
+// ToSnakeCase converts PascalCase or camelCase to snake_case.
+// e.g., "DeviceType" -> "device_type", "Site" -> "site"
+func ToSnakeCase(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	var result strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			result.WriteRune('_')
+		}
+		result.WriteRune(r)
+	}
+
+	return strings.ToLower(result.String())
+}
+
+// ToUpperSnakeCase converts PascalCase or camelCase to UPPER_SNAKE_CASE.
+// e.g., "DeviceType" -> "DEVICE_TYPE", "site" -> "SITE"
+func ToUpperSnakeCase(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	var result strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			result.WriteRune('_')
+		}
+		if r >= 'a' && r <= 'z' {
+			r = r - 'a' + 'A'
+		}
+		result.WriteRune(r)
+	}
+
+	return result.String()
+}

--- a/diode-server/strcase/strcase.go
+++ b/diode-server/strcase/strcase.go
@@ -4,16 +4,26 @@ package strcase
 import "strings"
 
 // ToSnakeCase converts PascalCase or camelCase to snake_case.
-// e.g., "DeviceType" -> "device_type", "Site" -> "site"
+// Handles acronyms correctly: "IPAddress" -> "ip_address", "DeviceID" -> "device_id"
 func ToSnakeCase(s string) string {
 	if s == "" {
 		return ""
 	}
 
+	runes := []rune(s)
 	var result strings.Builder
-	for i, r := range s {
+
+	for i, r := range runes {
 		if i > 0 && r >= 'A' && r <= 'Z' {
-			result.WriteRune('_')
+			prev := runes[i-1]
+			// Add underscore if:
+			// 1. Previous char is lowercase (normal word boundary): "deviceType" -> "device_Type"
+			// 2. Previous char is uppercase AND next char is lowercase (end of acronym): "IPAddress" -> "IP_Address"
+			if prev >= 'a' && prev <= 'z' {
+				result.WriteRune('_')
+			} else if prev >= 'A' && prev <= 'Z' && i+1 < len(runes) && runes[i+1] >= 'a' && runes[i+1] <= 'z' {
+				result.WriteRune('_')
+			}
 		}
 		result.WriteRune(r)
 	}
@@ -22,22 +32,25 @@ func ToSnakeCase(s string) string {
 }
 
 // ToUpperSnakeCase converts PascalCase or camelCase to UPPER_SNAKE_CASE.
-// e.g., "DeviceType" -> "DEVICE_TYPE", "site" -> "SITE"
+// Handles acronyms correctly: "IPAddress" -> "IP_ADDRESS", "DeviceID" -> "DEVICE_ID"
 func ToUpperSnakeCase(s string) string {
+	return strings.ToUpper(ToSnakeCase(s))
+}
+
+// ToPascalCase converts snake_case to PascalCase.
+// e.g., "tagged_vlans" -> "TaggedVlans", "site" -> "Site"
+func ToPascalCase(s string) string {
 	if s == "" {
 		return ""
 	}
 
+	parts := strings.Split(s, "_")
 	var result strings.Builder
-	for i, r := range s {
-		if i > 0 && r >= 'A' && r <= 'Z' {
-			result.WriteRune('_')
+	for _, part := range parts {
+		if len(part) > 0 {
+			result.WriteString(strings.ToUpper(part[:1]))
+			result.WriteString(part[1:])
 		}
-		if r >= 'a' && r <= 'z' {
-			r = r - 'a' + 'A'
-		}
-		result.WriteRune(r)
 	}
-
 	return result.String()
 }

--- a/diode-server/strcase/strcase_test.go
+++ b/diode-server/strcase/strcase_test.go
@@ -11,9 +11,12 @@ func TestToSnakeCase(t *testing.T) {
 		{"empty", "", ""},
 		{"single_word", "Site", "site"},
 		{"two_words", "DeviceType", "device_type"},
-		{"consecutive_caps", "IPAddress", "i_p_address"},
+		{"acronym_start", "IPAddress", "ip_address"},
+		{"acronym_end", "DeviceID", "device_id"},
+		{"acronym_middle", "GetHTTPResponse", "get_http_response"},
 		{"already_snake", "already_snake", "already_snake"},
-		{"all_caps", "ABC", "a_b_c"},
+		{"all_caps", "ABC", "abc"},
+		{"camelCase", "deviceType", "device_type"},
 	}
 
 	for _, tt := range tests {
@@ -35,6 +38,8 @@ func TestToUpperSnakeCase(t *testing.T) {
 		{"empty", "", ""},
 		{"single_word_caps", "Site", "SITE"},
 		{"two_words", "DeviceType", "DEVICE_TYPE"},
+		{"acronym_start", "IPAddress", "IP_ADDRESS"},
+		{"acronym_end", "DeviceID", "DEVICE_ID"},
 		{"lowercase", "site", "SITE"},
 		{"already_snake", "already_snake", "ALREADY_SNAKE"},
 	}
@@ -44,6 +49,29 @@ func TestToUpperSnakeCase(t *testing.T) {
 			got := ToUpperSnakeCase(tt.input)
 			if got != tt.want {
 				t.Errorf("ToUpperSnakeCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToPascalCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"single_word", "site", "Site"},
+		{"two_words", "device_type", "DeviceType"},
+		{"multiple_words", "tagged_vlans", "TaggedVlans"},
+		{"already_pascal", "Site", "Site"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToPascalCase(tt.input)
+			if got != tt.want {
+				t.Errorf("ToPascalCase(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/diode-server/strcase/strcase_test.go
+++ b/diode-server/strcase/strcase_test.go
@@ -1,0 +1,50 @@
+package strcase
+
+import "testing"
+
+func TestToSnakeCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"single_word", "Site", "site"},
+		{"two_words", "DeviceType", "device_type"},
+		{"consecutive_caps", "IPAddress", "i_p_address"},
+		{"already_snake", "already_snake", "already_snake"},
+		{"all_caps", "ABC", "a_b_c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToSnakeCase(tt.input)
+			if got != tt.want {
+				t.Errorf("ToSnakeCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToUpperSnakeCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"single_word_caps", "Site", "SITE"},
+		{"two_words", "DeviceType", "DEVICE_TYPE"},
+		{"lowercase", "site", "SITE"},
+		{"already_snake", "already_snake", "ALREADY_SNAKE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToUpperSnakeCase(tt.input)
+			if got != tt.want {
+				t.Errorf("ToUpperSnakeCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds GraphBuilder for recursive entity extraction with bidirectional edge relationships and confidence-based entity matching support. Some of methods/functions not used here yet, to be utilized in next PR.

Key Features
- Recursive Entity Extraction: GraphBuilder processes entities and all nested entities recursively, creating graph nodes and edges
- Bidirectional Edges: Implements both relationship directions:
  - BELONGS_TO_X (e.g., Device → BELONGS_TO_SITE → Site)
  - HAS_X (e.g., Site → HAS_DEVICE → Device)
- Confidence-Based Matching: Integration with EntityMatcher for finding existing nodes based on configurable matching rules
- Snapshot Support: Creates snapshots of full entity data while storing only matching-relevant data in nodes
- Duplicate Tracking: Tracks duplicate observations per ingestion request

New Packages
- strcase: Shared string case conversion utilities (ToSnakeCase, ToUpperSnakeCase)
- entitymatcher: Confidence-based entity matching with primary/secondary rules

🤖