### PR TITLE
feat(reconciler): integrate graph DB with feature flag

### DIFF
--- a/diode-server/Makefile
+++ b/diode-server/Makefile
@@ -1,6 +1,7 @@
 UTILITIES        = authmanager
+GENERATORS       = protograph
 BUILD_UTILITIES  = $(addprefix build-,$(UTILITIES))
-SERVICES         := $(filter-out $(UTILITIES),$(shell find ./cmd/* -type d -exec basename {} \;))
+SERVICES         := $(filter-out $(UTILITIES) $(GENERATORS),$(shell find ./cmd/* -type d -exec basename {} \;))
 BUILD_SERVICES   = $(addprefix build-,$(SERVICES))
 DOCKER_SERVICES  = $(addprefix docker-,$(SERVICES))
 BUILD_DIR        ?= ./build

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -17,6 +17,9 @@ import (
 
 	"github.com/netboxlabs/diode/diode-server/authutil"
 	"github.com/netboxlabs/diode/diode-server/dbstore/postgres"
+	"github.com/netboxlabs/diode/diode-server/entitymatcher"
+	dbpostgres "github.com/netboxlabs/diode/diode-server/gen/dbstore/postgres"
+	"github.com/netboxlabs/diode/diode-server/matching"
 	"github.com/netboxlabs/diode/diode-server/migrator"
 	"github.com/netboxlabs/diode/diode-server/netboxdiodeplugin"
 	"github.com/netboxlabs/diode/diode-server/reconciler"
@@ -128,6 +131,51 @@ func main() {
 
 	repository := postgres.NewRepository(dbPool)
 
+	// Initialize GraphBuilder if graph DB feature is enabled
+	var graphBuilderOpt reconciler.ProcessorOption
+	if cfg.EnableGraphDB {
+		s.Logger().Info("Graph DB feature enabled, initializing GraphBuilder")
+
+		// Load matching configuration if provided
+		var matchingConfig *matching.Config
+		if cfg.EntityMatchingConfigPath != "" {
+			var err error
+			matchingConfig, err = matching.LoadMatchingConfig(cfg.EntityMatchingConfigPath)
+			if err != nil {
+				s.Logger().Warn("failed to load entity matching config, using defaults",
+					"path", cfg.EntityMatchingConfigPath,
+					"error", err)
+			} else {
+				s.Logger().Info("loaded entity matching configuration",
+					"path", cfg.EntityMatchingConfigPath)
+			}
+		}
+
+		// Use SQLC-generated queries directly for graph operations
+		graphQueries := dbpostgres.New(dbPool)
+
+		// Create GraphBuilder with graph queries
+		graphBuilder := reconciler.NewGraphBuilder(graphQueries, s.Logger())
+
+		// Set up entity matcher if matching config was loaded
+		if matchingConfig != nil {
+			graphBuilder.SetMatchingConfig(matchingConfig)
+
+			// Create entity matcher for confidence-based matching
+			matcherConfig := &matching.EntityMatchingConfig{
+				Rules:          matchingConfig.GetFinalRules(),
+				GlobalMinConf:  matching.MatchConfidence(matchingConfig.GlobalSettings.DefaultMinConfidence),
+				EnableFallback: true,
+				CacheResults:   true,
+				MaxCacheSize:   1000,
+			}
+			entityMatcher := entitymatcher.NewMatcher(graphQueries, matcherConfig, s.Logger())
+			graphBuilder.SetEntityMatcher(entityMatcher)
+		}
+
+		graphBuilderOpt = reconciler.WithGraphBuilder(graphBuilder)
+	}
+
 	diodeToNetBoxMaxRetries := 3
 
 	nbClient, err := netboxdiodeplugin.NewClient(
@@ -149,7 +197,13 @@ func main() {
 
 	ops := reconciler.NewOps(repository, nbClient, s.Logger(), nil)
 
-	ingestionProcessor, err := reconciler.NewIngestionProcessor(ctx, s.Logger(), cfg, redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, ops, metricRecorder)
+	// Build processor options
+	var processorOpts []reconciler.ProcessorOption
+	if graphBuilderOpt != nil {
+		processorOpts = append(processorOpts, graphBuilderOpt)
+	}
+
+	ingestionProcessor, err := reconciler.NewIngestionProcessor(ctx, s.Logger(), cfg, redisClient, redisStreamClient, reconciler.DefaultRedisStreamID, reconciler.DefaultRedisConsumerGroup, ops, metricRecorder, processorOpts...)
 	if err != nil {
 		s.Logger().Error("failed to instantiate ingestion processor", "error", err)
 		metricRecorder.RecordServiceStartupAttempt(ctx, false)

--- a/diode-server/docker/docker-compose.yaml
+++ b/diode-server/docker/docker-compose.yaml
@@ -60,10 +60,14 @@ services:
       - DIODE_AUTH_TOKEN_URL=${DIODE_AUTH_TOKEN_URL}
       - DIODE_TO_NETBOX_CLIENT_ID=${DIODE_TO_NETBOX_CLIENT_ID}
       - DIODE_TO_NETBOX_CLIENT_SECRET=${DIODE_TO_NETBOX_CLIENT_SECRET}
+      - ENABLE_GRAPH_DB=${ENABLE_GRAPH_DB:-false}
+      - ENTITY_MATCHING_CONFIG_PATH=${ENTITY_MATCHING_CONFIG_PATH:-}
     restart: on-failure
     ports: [ ]
     volumes:
       - ./oauth2/client:/etc/config/oauth2/client:z,ro
+      # Uncomment to mount entity matching config when ENABLE_GRAPH_DB=true
+      # - ./examples/entity_matching_config.yaml:/etc/diode/entity_matching.yaml:z,ro
     depends_on:
       redis:
         condition: service_started

--- a/diode-server/docker/sample.env
+++ b/diode-server/docker/sample.env
@@ -38,3 +38,9 @@ OAUTH2_ADMIN_SERVER_URL=http://hydra:4445
 DIODE_AUTH_TOKEN_URL=http://diode-auth:8080/token
 DIODE_TO_NETBOX_CLIENT_ID=diode-to-netbox
 DIODE_TO_NETBOX_CLIENT_SECRET=<PLACEHOLDER_DIODE_TO_NETBOX_CLIENT_SECRET>
+
+# Graph DB feature (optional - disabled by default)
+# When enabled, entities are also stored in a graph database for relationship tracking
+ENABLE_GRAPH_DB=false
+# Path to entity matching configuration file (optional - used only when graph DB is enabled)
+# ENTITY_MATCHING_CONFIG_PATH=/etc/diode/entity_matching.yaml

--- a/diode-server/examples/entity_matching_config.yaml
+++ b/diode-server/examples/entity_matching_config.yaml
@@ -1,0 +1,159 @@
+# Example Entity Matching Configuration for Diode Graph DB
+#
+# This file configures how Diode matches incoming entities with existing graph nodes.
+# Enable graph DB with ENABLE_GRAPH_DB=true and point to this file with
+# ENTITY_MATCHING_CONFIG_PATH=/path/to/this/file.yaml
+
+global_settings:
+  # Default minimum confidence threshold for entity matching (0.0-1.0)
+  default_min_confidence: 0.7
+  # Whether all primary rules must match by default
+  default_require_all_primary: false
+  # Enable fuzzy string matching for name comparisons
+  enable_fuzzy_matching: true
+  # Default similarity threshold for fuzzy matching
+  default_fuzzy_threshold: 0.85
+
+# Entity-specific matching rules
+default_entity_rules:
+  # Device matching rules
+  Device:
+    min_confidence: 0.8
+    require_all_primary: false
+    primary_rules:
+      # Name is the primary identifier
+      - field_path: "device.name"
+        match_type: exact
+        weight: 1.0
+        required: true
+        confidence: 0.9
+    secondary_rules:
+      # Serial number as secondary match
+      - field_path: "device.serial"
+        match_type: exact
+        weight: 0.8
+        required: false
+        confidence: 0.7
+      # Asset tag as another secondary identifier
+      - field_path: "device.asset_tag"
+        match_type: exact
+        weight: 0.6
+        required: false
+        confidence: 0.6
+
+  # Site matching rules
+  Site:
+    min_confidence: 0.7
+    require_all_primary: true
+    primary_rules:
+      - field_path: "site.name"
+        match_type: exact
+        weight: 1.0
+        required: true
+        confidence: 0.95
+    secondary_rules:
+      - field_path: "site.slug"
+        match_type: exact
+        weight: 0.7
+        required: false
+        confidence: 0.6
+
+  # Interface matching rules
+  Interface:
+    min_confidence: 0.8
+    require_all_primary: true
+    primary_rules:
+      # Interface name within device context
+      - field_path: "interface.name"
+        match_type: exact
+        weight: 1.0
+        required: true
+        confidence: 0.9
+      # Device reference for scoping
+      - field_path: "interface.device.name"
+        match_type: exact
+        weight: 0.9
+        required: true
+        confidence: 0.8
+    secondary_rules:
+      - field_path: "interface.mac_address"
+        match_type: exact
+        weight: 0.7
+        required: false
+        confidence: 0.6
+
+  # IP Address matching rules
+  IPAddress:
+    min_confidence: 0.9
+    require_all_primary: true
+    primary_rules:
+      - field_path: "ip_address.address"
+        match_type: exact
+        weight: 1.0
+        required: true
+        confidence: 0.95
+
+  # Prefix matching rules
+  Prefix:
+    min_confidence: 0.9
+    require_all_primary: true
+    primary_rules:
+      - field_path: "prefix.prefix"
+        match_type: exact
+        weight: 1.0
+        required: true
+        confidence: 0.95
+
+  # VLAN matching rules
+  VLAN:
+    min_confidence: 0.8
+    require_all_primary: true
+    primary_rules:
+      - field_path: "vlan.vid"
+        match_type: exact
+        weight: 1.0
+        required: true
+        confidence: 0.9
+    secondary_rules:
+      - field_path: "vlan.name"
+        match_type: fuzzy
+        weight: 0.5
+        required: false
+        confidence: 0.5
+        fuzzy_options:
+          min_similarity: 0.8
+          case_ignore: true
+
+  # Manufacturer matching rules
+  Manufacturer:
+    min_confidence: 0.7
+    primary_rules:
+      - field_path: "manufacturer.name"
+        match_type: fuzzy
+        weight: 1.0
+        required: true
+        confidence: 0.8
+        fuzzy_options:
+          min_similarity: 0.85
+          case_ignore: true
+          normalize: true
+
+  # DeviceType matching rules
+  DeviceType:
+    min_confidence: 0.8
+    require_all_primary: true
+    primary_rules:
+      - field_path: "device_type.model"
+        match_type: exact
+        weight: 1.0
+        required: true
+        confidence: 0.9
+      - field_path: "device_type.manufacturer.name"
+        match_type: exact
+        weight: 0.8
+        required: true
+        confidence: 0.8
+
+# Environment-specific overrides (optional)
+# These override the default rules for specific environments
+entity_overrides: {}

--- a/diode-server/reconciler/config.go
+++ b/diode-server/reconciler/config.go
@@ -35,4 +35,11 @@ type Config struct {
 
 	RedisTLS  tls.Config       `envconfig:"REDIS_TLS"`
 	Telemetry telemetry.Config `envconfig:"TELEMETRY"`
+
+	// Experimental
+	EnableGraphDB bool `envconfig:"ENABLE_GRAPH_DB" default:"false"`
+
+	// Entity matching configuration file path (only used when graph DB is enabled)
+	// If empty, default matching rules are used
+	EntityMatchingConfigPath string `envconfig:"ENTITY_MATCHING_CONFIG_PATH" default:""`
 }

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -69,6 +69,7 @@ type IngestionProcessor struct {
 	metrics            Metrics
 	cancel             context.CancelFunc
 	mx                 sync.Mutex
+	graphBuilder       *GraphBuilder // nil when ENABLE_GRAPH_DB is false
 }
 
 // IngestionLogToProcess represents an ingestion log to process
@@ -89,8 +90,20 @@ type IngestionProcessorOps interface {
 	RefreshDefaultBranch(ctx context.Context) (*netboxdiodeplugin.Branch, error)
 }
 
+// ProcessorOption is a functional option for configuring IngestionProcessor
+type ProcessorOption func(*IngestionProcessor)
+
+// WithGraphBuilder sets the GraphBuilder for graph-based entity extraction.
+// When set, entities are also stored in the graph database for relationship tracking.
+// Pass nil to disable graph extraction.
+func WithGraphBuilder(gb *GraphBuilder) ProcessorOption {
+	return func(p *IngestionProcessor) {
+		p.graphBuilder = gb
+	}
+}
+
 // NewIngestionProcessor creates a new ingestion processor
-func NewIngestionProcessor(_ context.Context, logger *slog.Logger, cfg Config, redisClient, redisStreamClient RedisClient, redisStreamID string, redisConsumerGroup string, ops IngestionProcessorOps, metrics Metrics) (*IngestionProcessor, error) {
+func NewIngestionProcessor(_ context.Context, logger *slog.Logger, cfg Config, redisClient, redisStreamClient RedisClient, redisStreamID string, redisConsumerGroup string, ops IngestionProcessorOps, metrics Metrics, opts ...ProcessorOption) (*IngestionProcessor, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %v", err)
@@ -106,6 +119,11 @@ func NewIngestionProcessor(_ context.Context, logger *slog.Logger, cfg Config, r
 		redisConsumerGroup: redisConsumerGroup,
 		ops:                ops,
 		metrics:            metrics,
+	}
+
+	// Apply functional options
+	for _, opt := range opts {
+		opt(component)
 	}
 
 	return component, nil
@@ -435,6 +453,17 @@ func (p *IngestionProcessor) CreateIngestionLogs(ctx context.Context, ingestReq 
 		ctx = telemetry.ContextWithMetricAttributes(ctx, attrs...)
 
 		p.metrics.RecordIngestionLogCreate(ctx, true)
+
+		// Extract graph data if graph DB is enabled (non-blocking, errors logged but not fatal)
+		if p.graphBuilder != nil {
+			if err := p.graphBuilder.ExtractGraph(ctx, v); err != nil {
+				p.logger.Warn("graph extraction failed",
+					"error", err,
+					"ingestion_log_id", id,
+					"entity_type", objectType)
+				// Don't fail the main processing path - graph extraction is supplementary
+			}
+		}
 
 		if result.WasDuplicate && result.IngestionLog.State == reconcilerpb.State_IGNORED {
 			p.logger.Debug("skipping ingestion log because it is a duplicate of an ignored ingestion log", "id", id, "externalID", ingestionLog.GetId())


### PR DESCRIPTION
⚠️ Experimental ⚠️

Add optional graph database integration to the reconciler service:

- Add ENABLE_GRAPH_DB feature flag (default: false)
- Add ENTITY_MATCHING_CONFIG_PATH for configurable matching rules
- Implement ProcessorOption functional options pattern for GraphBuilder
- Initialize GraphBuilder conditionally in main.go when feature enabled
- Extract entities to graph DB during ingestion (non-blocking)
- Add example entity_matching_config.yaml with default rules
- Update sample.env with new environment variables

When enabled, entities are stored in the graph database for relationship tracking. Graph extraction failures are logged but don't block main ingestion processing.