### PR TITLE
feat(reconciler): add CreateEntity RPC for synchronous entity creation

### DIFF
--- a/diode-proto/diode/v1/reconciler.proto
+++ b/diode-proto/diode/v1/reconciler.proto
@@ -169,6 +169,18 @@ message ListEntitiesResponse {
   string next_page_token = 2; // Token for the next page, if any
 }
 
+// Request to create an entity in the graph database (idempotent)
+message CreateEntityRequest {
+  diode.v1.Entity entity = 1 [(validate.rules).message.required = true]; // The entity to create
+  google.protobuf.Struct metadata = 2; // Optional metadata (agent_id, policy_id, etc.)
+}
+
+// Response from creating an entity
+message CreateEntityResponse {
+  string id = 1; // Diode entity ID (UUID)
+  string object_type = 2; // Entity type
+}
+
 // Reconciler service API
 service ReconcilerService {
   // Retrieves ingestion logs
@@ -184,4 +196,7 @@ service ReconcilerService {
 
   // List observed entities with filtering
   rpc ListEntities(ListEntitiesRequest) returns (ListEntitiesResponse);
+
+  // Create an entity synchronously in the graph database (idempotent - returns existing ID if entity already exists)
+  rpc CreateEntity(CreateEntityRequest) returns (CreateEntityResponse);
 }

--- a/diode-server/gen/diode/v1/reconcilerpb/reconciler.pb.go
+++ b/diode-server/gen/diode/v1/reconcilerpb/reconciler.pb.go
@@ -1330,6 +1330,112 @@ func (x *ListEntitiesResponse) GetNextPageToken() string {
 	return ""
 }
 
+// Request to create an entity in the graph database (idempotent)
+type CreateEntityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entity        *diodepb.Entity        `protobuf:"bytes,1,opt,name=entity,proto3" json:"entity,omitempty"`     // The entity to create
+	Metadata      *structpb.Struct       `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"` // Optional metadata (agent_id, policy_id, etc.)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateEntityRequest) Reset() {
+	*x = CreateEntityRequest{}
+	mi := &file_diode_v1_reconciler_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEntityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEntityRequest) ProtoMessage() {}
+
+func (x *CreateEntityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_diode_v1_reconciler_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEntityRequest.ProtoReflect.Descriptor instead.
+func (*CreateEntityRequest) Descriptor() ([]byte, []int) {
+	return file_diode_v1_reconciler_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *CreateEntityRequest) GetEntity() *diodepb.Entity {
+	if x != nil {
+		return x.Entity
+	}
+	return nil
+}
+
+func (x *CreateEntityRequest) GetMetadata() *structpb.Struct {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+// Response from creating an entity
+type CreateEntityResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                   // Diode entity ID (UUID)
+	ObjectType    string                 `protobuf:"bytes,2,opt,name=object_type,json=objectType,proto3" json:"object_type,omitempty"` // Entity type
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateEntityResponse) Reset() {
+	*x = CreateEntityResponse{}
+	mi := &file_diode_v1_reconciler_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEntityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEntityResponse) ProtoMessage() {}
+
+func (x *CreateEntityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_diode_v1_reconciler_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEntityResponse.ProtoReflect.Descriptor instead.
+func (*CreateEntityResponse) Descriptor() ([]byte, []int) {
+	return file_diode_v1_reconciler_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CreateEntityResponse) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *CreateEntityResponse) GetObjectType() string {
+	if x != nil {
+		return x.ObjectType
+	}
+	return ""
+}
+
 var File_diode_v1_reconciler_proto protoreflect.FileDescriptor
 
 const file_diode_v1_reconciler_proto_rawDesc = "" +
@@ -1474,7 +1580,14 @@ const file_diode_v1_reconciler_proto_rawDesc = "" +
 	"\x11_ingestion_ts_end\"q\n" +
 	"\x14ListEntitiesResponse\x121\n" +
 	"\bentities\x18\x01 \x03(\v2\x15.diode.v1.DiodeEntityR\bentities\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken*w\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"~\n" +
+	"\x13CreateEntityRequest\x122\n" +
+	"\x06entity\x18\x01 \x01(\v2\x10.diode.v1.EntityB\b\xfaB\x05\x8a\x01\x02\x10\x01R\x06entity\x123\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x17.google.protobuf.StructR\bmetadata\"G\n" +
+	"\x14CreateEntityResponse\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
+	"\vobject_type\x18\x02 \x01(\tR\n" +
+	"objectType*w\n" +
 	"\x05State\x12\x15\n" +
 	"\x11STATE_UNSPECIFIED\x10\x00\x12\n" +
 	"\n" +
@@ -1486,12 +1599,13 @@ const file_diode_v1_reconciler_proto_rawDesc = "" +
 	"\n" +
 	"NO_CHANGES\x10\x05\x12\v\n" +
 	"\aIGNORED\x10\x06\x12\v\n" +
-	"\aERRORED\x10\a2\x9c\x03\n" +
+	"\aERRORED\x10\a2\xeb\x03\n" +
 	"\x11ReconcilerService\x12m\n" +
 	"\x15RetrieveIngestionLogs\x12&.diode.v1.RetrieveIngestionLogsRequest\x1a'.diode.v1.RetrieveIngestionLogsResponse\"\x03\x88\x02\x01\x12_\n" +
 	"\x12RetrieveDeviations\x12#.diode.v1.RetrieveDeviationsRequest\x1a$.diode.v1.RetrieveDeviationsResponse\x12h\n" +
 	"\x15RetrieveDeviationByID\x12&.diode.v1.RetrieveDeviationByIDRequest\x1a'.diode.v1.RetrieveDeviationByIDResponse\x12M\n" +
-	"\fListEntities\x12\x1d.diode.v1.ListEntitiesRequest\x1a\x1e.diode.v1.ListEntitiesResponseB\xa4\x01\n" +
+	"\fListEntities\x12\x1d.diode.v1.ListEntitiesRequest\x1a\x1e.diode.v1.ListEntitiesResponse\x12M\n" +
+	"\fCreateEntity\x12\x1d.diode.v1.CreateEntityRequest\x1a\x1e.diode.v1.CreateEntityResponseB\xa4\x01\n" +
 	"\fcom.diode.v1B\x0fReconcilerProtoP\x01ZBgithub.com/netboxlabs/diode/diode-server/gen/diode/v1/reconcilerpb\xa2\x02\x03DXX\xaa\x02\bDiode.V1\xca\x02\bDiode\\V1\xe2\x02\x14Diode\\V1\\GPBMetadata\xea\x02\tDiode::V1b\x06proto3"
 
 var (
@@ -1507,7 +1621,7 @@ func file_diode_v1_reconciler_proto_rawDescGZIP() []byte {
 }
 
 var file_diode_v1_reconciler_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_diode_v1_reconciler_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_diode_v1_reconciler_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_diode_v1_reconciler_proto_goTypes = []any{
 	(State)(0),                            // 0: diode.v1.State
 	(*IngestionMetrics)(nil),              // 1: diode.v1.IngestionMetrics
@@ -1525,12 +1639,14 @@ var file_diode_v1_reconciler_proto_goTypes = []any{
 	(*DiodeEntity)(nil),                   // 13: diode.v1.DiodeEntity
 	(*ListEntitiesRequest)(nil),           // 14: diode.v1.ListEntitiesRequest
 	(*ListEntitiesResponse)(nil),          // 15: diode.v1.ListEntitiesResponse
-	(*diodepb.Entity)(nil),                // 16: diode.v1.Entity
-	(*structpb.Struct)(nil),               // 17: google.protobuf.Struct
+	(*CreateEntityRequest)(nil),           // 16: diode.v1.CreateEntityRequest
+	(*CreateEntityResponse)(nil),          // 17: diode.v1.CreateEntityResponse
+	(*diodepb.Entity)(nil),                // 18: diode.v1.Entity
+	(*structpb.Struct)(nil),               // 19: google.protobuf.Struct
 }
 var file_diode_v1_reconciler_proto_depIdxs = []int32{
 	0,  // 0: diode.v1.IngestionLog.state:type_name -> diode.v1.State
-	16, // 1: diode.v1.IngestionLog.entity:type_name -> diode.v1.Entity
+	18, // 1: diode.v1.IngestionLog.entity:type_name -> diode.v1.Entity
 	7,  // 2: diode.v1.IngestionLog.error:type_name -> diode.v1.DeviationError
 	2,  // 3: diode.v1.IngestionLog.change_set:type_name -> diode.v1.ChangeSet
 	0,  // 4: diode.v1.RetrieveIngestionLogsRequest.state:type_name -> diode.v1.State
@@ -1538,28 +1654,32 @@ var file_diode_v1_reconciler_proto_depIdxs = []int32{
 	1,  // 6: diode.v1.RetrieveIngestionLogsResponse.metrics:type_name -> diode.v1.IngestionMetrics
 	0,  // 7: diode.v1.RetrieveDeviationsRequest.state:type_name -> diode.v1.State
 	0,  // 8: diode.v1.Deviation.state:type_name -> diode.v1.State
-	16, // 9: diode.v1.Deviation.ingested_entity:type_name -> diode.v1.Entity
+	18, // 9: diode.v1.Deviation.ingested_entity:type_name -> diode.v1.Entity
 	7,  // 10: diode.v1.Deviation.error:type_name -> diode.v1.DeviationError
 	8,  // 11: diode.v1.Deviation.changes:type_name -> diode.v1.Change
 	9,  // 12: diode.v1.RetrieveDeviationsResponse.deviations:type_name -> diode.v1.Deviation
 	9,  // 13: diode.v1.RetrieveDeviationByIDResponse.deviation:type_name -> diode.v1.Deviation
-	16, // 14: diode.v1.DiodeEntity.entity:type_name -> diode.v1.Entity
-	17, // 15: diode.v1.DiodeEntity.source_metadata:type_name -> google.protobuf.Struct
-	17, // 16: diode.v1.ListEntitiesRequest.metadata_filters:type_name -> google.protobuf.Struct
+	18, // 14: diode.v1.DiodeEntity.entity:type_name -> diode.v1.Entity
+	19, // 15: diode.v1.DiodeEntity.source_metadata:type_name -> google.protobuf.Struct
+	19, // 16: diode.v1.ListEntitiesRequest.metadata_filters:type_name -> google.protobuf.Struct
 	13, // 17: diode.v1.ListEntitiesResponse.entities:type_name -> diode.v1.DiodeEntity
-	4,  // 18: diode.v1.ReconcilerService.RetrieveIngestionLogs:input_type -> diode.v1.RetrieveIngestionLogsRequest
-	6,  // 19: diode.v1.ReconcilerService.RetrieveDeviations:input_type -> diode.v1.RetrieveDeviationsRequest
-	11, // 20: diode.v1.ReconcilerService.RetrieveDeviationByID:input_type -> diode.v1.RetrieveDeviationByIDRequest
-	14, // 21: diode.v1.ReconcilerService.ListEntities:input_type -> diode.v1.ListEntitiesRequest
-	5,  // 22: diode.v1.ReconcilerService.RetrieveIngestionLogs:output_type -> diode.v1.RetrieveIngestionLogsResponse
-	10, // 23: diode.v1.ReconcilerService.RetrieveDeviations:output_type -> diode.v1.RetrieveDeviationsResponse
-	12, // 24: diode.v1.ReconcilerService.RetrieveDeviationByID:output_type -> diode.v1.RetrieveDeviationByIDResponse
-	15, // 25: diode.v1.ReconcilerService.ListEntities:output_type -> diode.v1.ListEntitiesResponse
-	22, // [22:26] is the sub-list for method output_type
-	18, // [18:22] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	18, // 18: diode.v1.CreateEntityRequest.entity:type_name -> diode.v1.Entity
+	19, // 19: diode.v1.CreateEntityRequest.metadata:type_name -> google.protobuf.Struct
+	4,  // 20: diode.v1.ReconcilerService.RetrieveIngestionLogs:input_type -> diode.v1.RetrieveIngestionLogsRequest
+	6,  // 21: diode.v1.ReconcilerService.RetrieveDeviations:input_type -> diode.v1.RetrieveDeviationsRequest
+	11, // 22: diode.v1.ReconcilerService.RetrieveDeviationByID:input_type -> diode.v1.RetrieveDeviationByIDRequest
+	14, // 23: diode.v1.ReconcilerService.ListEntities:input_type -> diode.v1.ListEntitiesRequest
+	16, // 24: diode.v1.ReconcilerService.CreateEntity:input_type -> diode.v1.CreateEntityRequest
+	5,  // 25: diode.v1.ReconcilerService.RetrieveIngestionLogs:output_type -> diode.v1.RetrieveIngestionLogsResponse
+	10, // 26: diode.v1.ReconcilerService.RetrieveDeviations:output_type -> diode.v1.RetrieveDeviationsResponse
+	12, // 27: diode.v1.ReconcilerService.RetrieveDeviationByID:output_type -> diode.v1.RetrieveDeviationByIDResponse
+	15, // 28: diode.v1.ReconcilerService.ListEntities:output_type -> diode.v1.ListEntitiesResponse
+	17, // 29: diode.v1.ReconcilerService.CreateEntity:output_type -> diode.v1.CreateEntityResponse
+	25, // [25:30] is the sub-list for method output_type
+	20, // [20:25] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_diode_v1_reconciler_proto_init() }
@@ -1578,7 +1698,7 @@ func file_diode_v1_reconciler_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_diode_v1_reconciler_proto_rawDesc), len(file_diode_v1_reconciler_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/diode-server/gen/diode/v1/reconcilerpb/reconciler.pb.validate.go
+++ b/diode-server/gen/diode/v1/reconcilerpb/reconciler.pb.validate.go
@@ -2126,3 +2126,280 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = ListEntitiesResponseValidationError{}
+
+// Validate checks the field values on CreateEntityRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *CreateEntityRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on CreateEntityRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// CreateEntityRequestMultiError, or nil if none found.
+func (m *CreateEntityRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *CreateEntityRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if m.GetEntity() == nil {
+		err := CreateEntityRequestValidationError{
+			field:  "Entity",
+			reason: "value is required",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if all {
+		switch v := interface{}(m.GetEntity()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CreateEntityRequestValidationError{
+					field:  "Entity",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CreateEntityRequestValidationError{
+					field:  "Entity",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetEntity()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CreateEntityRequestValidationError{
+				field:  "Entity",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetMetadata()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CreateEntityRequestValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CreateEntityRequestValidationError{
+					field:  "Metadata",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetMetadata()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CreateEntityRequestValidationError{
+				field:  "Metadata",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return CreateEntityRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// CreateEntityRequestMultiError is an error wrapping multiple validation
+// errors returned by CreateEntityRequest.ValidateAll() if the designated
+// constraints aren't met.
+type CreateEntityRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m CreateEntityRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m CreateEntityRequestMultiError) AllErrors() []error { return m }
+
+// CreateEntityRequestValidationError is the validation error returned by
+// CreateEntityRequest.Validate if the designated constraints aren't met.
+type CreateEntityRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e CreateEntityRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e CreateEntityRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e CreateEntityRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e CreateEntityRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e CreateEntityRequestValidationError) ErrorName() string {
+	return "CreateEntityRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e CreateEntityRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sCreateEntityRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = CreateEntityRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = CreateEntityRequestValidationError{}
+
+// Validate checks the field values on CreateEntityResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *CreateEntityResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on CreateEntityResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// CreateEntityResponseMultiError, or nil if none found.
+func (m *CreateEntityResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *CreateEntityResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Id
+
+	// no validation rules for ObjectType
+
+	if len(errors) > 0 {
+		return CreateEntityResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// CreateEntityResponseMultiError is an error wrapping multiple validation
+// errors returned by CreateEntityResponse.ValidateAll() if the designated
+// constraints aren't met.
+type CreateEntityResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m CreateEntityResponseMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m CreateEntityResponseMultiError) AllErrors() []error { return m }
+
+// CreateEntityResponseValidationError is the validation error returned by
+// CreateEntityResponse.Validate if the designated constraints aren't met.
+type CreateEntityResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e CreateEntityResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e CreateEntityResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e CreateEntityResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e CreateEntityResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e CreateEntityResponseValidationError) ErrorName() string {
+	return "CreateEntityResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e CreateEntityResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sCreateEntityResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = CreateEntityResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = CreateEntityResponseValidationError{}

--- a/diode-server/gen/diode/v1/reconcilerpb/reconciler_grpc.pb.go
+++ b/diode-server/gen/diode/v1/reconcilerpb/reconciler_grpc.pb.go
@@ -23,6 +23,7 @@ const (
 	ReconcilerService_RetrieveDeviations_FullMethodName    = "/diode.v1.ReconcilerService/RetrieveDeviations"
 	ReconcilerService_RetrieveDeviationByID_FullMethodName = "/diode.v1.ReconcilerService/RetrieveDeviationByID"
 	ReconcilerService_ListEntities_FullMethodName          = "/diode.v1.ReconcilerService/ListEntities"
+	ReconcilerService_CreateEntity_FullMethodName          = "/diode.v1.ReconcilerService/CreateEntity"
 )
 
 // ReconcilerServiceClient is the client API for ReconcilerService service.
@@ -38,6 +39,8 @@ type ReconcilerServiceClient interface {
 	RetrieveDeviationByID(ctx context.Context, in *RetrieveDeviationByIDRequest, opts ...grpc.CallOption) (*RetrieveDeviationByIDResponse, error)
 	// List observed entities with filtering
 	ListEntities(ctx context.Context, in *ListEntitiesRequest, opts ...grpc.CallOption) (*ListEntitiesResponse, error)
+	// Create an entity synchronously in the graph database (idempotent - returns existing ID if entity already exists)
+	CreateEntity(ctx context.Context, in *CreateEntityRequest, opts ...grpc.CallOption) (*CreateEntityResponse, error)
 }
 
 type reconcilerServiceClient struct {
@@ -85,6 +88,15 @@ func (c *reconcilerServiceClient) ListEntities(ctx context.Context, in *ListEnti
 	return out, nil
 }
 
+func (c *reconcilerServiceClient) CreateEntity(ctx context.Context, in *CreateEntityRequest, opts ...grpc.CallOption) (*CreateEntityResponse, error) {
+	out := new(CreateEntityResponse)
+	err := c.cc.Invoke(ctx, ReconcilerService_CreateEntity_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ReconcilerServiceServer is the server API for ReconcilerService service.
 // All implementations must embed UnimplementedReconcilerServiceServer
 // for forward compatibility
@@ -98,6 +110,8 @@ type ReconcilerServiceServer interface {
 	RetrieveDeviationByID(context.Context, *RetrieveDeviationByIDRequest) (*RetrieveDeviationByIDResponse, error)
 	// List observed entities with filtering
 	ListEntities(context.Context, *ListEntitiesRequest) (*ListEntitiesResponse, error)
+	// Create an entity synchronously in the graph database (idempotent - returns existing ID if entity already exists)
+	CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error)
 	mustEmbedUnimplementedReconcilerServiceServer()
 }
 
@@ -116,6 +130,9 @@ func (UnimplementedReconcilerServiceServer) RetrieveDeviationByID(context.Contex
 }
 func (UnimplementedReconcilerServiceServer) ListEntities(context.Context, *ListEntitiesRequest) (*ListEntitiesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListEntities not implemented")
+}
+func (UnimplementedReconcilerServiceServer) CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateEntity not implemented")
 }
 func (UnimplementedReconcilerServiceServer) mustEmbedUnimplementedReconcilerServiceServer() {}
 
@@ -202,6 +219,24 @@ func _ReconcilerService_ListEntities_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ReconcilerService_CreateEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateEntityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReconcilerServiceServer).CreateEntity(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReconcilerService_CreateEntity_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReconcilerServiceServer).CreateEntity(ctx, req.(*CreateEntityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ReconcilerService_ServiceDesc is the grpc.ServiceDesc for ReconcilerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -224,6 +259,10 @@ var ReconcilerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListEntities",
 			Handler:    _ReconcilerService_ListEntities_Handler,
+		},
+		{
+			MethodName: "CreateEntity",
+			Handler:    _ReconcilerService_CreateEntity_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -121,3 +121,8 @@ func (s *Server) RetrieveDeviationByID(ctx context.Context, req *reconcilerpb.Re
 func (s *Server) ListEntities(_ context.Context, _ *reconcilerpb.ListEntitiesRequest) (*reconcilerpb.ListEntitiesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListEntities not implemented")
 }
+
+// CreateEntity creates an entity synchronously in the graph database (idempotent - returns existing ID if entity already exists)
+func (s *Server) CreateEntity(_ context.Context, _ *reconcilerpb.CreateEntityRequest) (*reconcilerpb.CreateEntityResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateEntity not implemented")
+}

--- a/docs/diode-proto.md
+++ b/docs/diode-proto.md
@@ -196,6 +196,8 @@
 - [diode/v1/reconciler.proto](#diode_v1_reconciler-proto)
     - [Change](#diode-v1-Change)
     - [ChangeSet](#diode-v1-ChangeSet)
+    - [CreateEntityRequest](#diode-v1-CreateEntityRequest)
+    - [CreateEntityResponse](#diode-v1-CreateEntityResponse)
     - [Deviation](#diode-v1-Deviation)
     - [DeviationError](#diode-v1-DeviationError)
     - [DiodeEntity](#diode-v1-DiodeEntity)
@@ -4949,6 +4951,38 @@ A change set
 
 
 
+<a name="diode-v1-CreateEntityRequest"></a>
+
+### CreateEntityRequest
+Request to create an entity in the graph database (idempotent)
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entity | [Entity](#diode-v1-Entity) |  | The entity to create |
+| metadata | [google.protobuf.Struct](#google-protobuf-Struct) |  | Optional metadata (agent_id, policy_id, etc.) |
+
+
+
+
+
+
+<a name="diode-v1-CreateEntityResponse"></a>
+
+### CreateEntityResponse
+Response from creating an entity
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | Diode entity ID (UUID) |
+| object_type | [string](#string) |  | Entity type |
+
+
+
+
+
+
 <a name="diode-v1-Deviation"></a>
 
 ### Deviation
@@ -5243,6 +5277,7 @@ Reconciler service API
 | RetrieveDeviations | [RetrieveDeviationsRequest](#diode-v1-RetrieveDeviationsRequest) | [RetrieveDeviationsResponse](#diode-v1-RetrieveDeviationsResponse) | Retrieve deviations |
 | RetrieveDeviationByID | [RetrieveDeviationByIDRequest](#diode-v1-RetrieveDeviationByIDRequest) | [RetrieveDeviationByIDResponse](#diode-v1-RetrieveDeviationByIDResponse) | Retrieve deviation by ID |
 | ListEntities | [ListEntitiesRequest](#diode-v1-ListEntitiesRequest) | [ListEntitiesResponse](#diode-v1-ListEntitiesResponse) | List observed entities with filtering |
+| CreateEntity | [CreateEntityRequest](#diode-v1-CreateEntityRequest) | [CreateEntityResponse](#diode-v1-CreateEntityResponse) | Create an entity synchronously in the graph database (idempotent - returns existing ID if entity already exists) |
 
  
 


### PR DESCRIPTION
Add idempotent CreateEntity RPC to ReconcilerService that creates an entity in the graph database and returns its Diode ID. If the entity already exists, returns the existing ID.

- Add CreateEntityRequest with required entity and optional metadata
- Add CreateEntityResponse with id and object_type
- Add unimplemented stub in server.go
- Regenerate Go code and update docs