### PR TITLE
feat: add optional pprof listeners to servers

### DIFF
--- a/diode-server/auth/config.go
+++ b/diode-server/auth/config.go
@@ -5,6 +5,7 @@ import "github.com/netboxlabs/diode/diode-server/telemetry"
 // Config is the configuration for the auth service
 type Config struct {
 	HTTPPort  int              `envconfig:"HTTP_PORT" default:"8080"`
+	PProfAddr string           `envconfig:"PPROF_ADDR" default:"localhost:6060"`
 	OAuth2    OAuth2Config     `envconfig:"OAUTH2"`
 	Telemetry telemetry.Config `envconfig:"TELEMETRY"`
 }

--- a/diode-server/cmd/auth/main.go
+++ b/diode-server/cmd/auth/main.go
@@ -21,9 +21,6 @@ const (
 
 	// used by open telemetry metrics
 	telemetryServiceName = "netboxlabs/diode/auth"
-
-	// PProfEnvVar is the environment variable for the optional pprof server address
-	PProfEnvVar = "DIODE_AUTH_PPROF_ADDR"
 )
 
 func main() {
@@ -33,12 +30,12 @@ func main() {
 
 	defer s.Recover(sentry.CurrentHub())
 
-	if pprofAddr := os.Getenv(PProfEnvVar); pprofAddr != "" {
-		go pprof.Listen(ctx, s.Logger(), pprofAddr)
-	}
-
 	var cfg auth.Config
 	envconfig.MustProcess("", &cfg)
+
+	if cfg.PProfAddr != "" {
+		go pprof.Listen(ctx, s.Logger(), cfg.PProfAddr)
+	}
 
 	// Set default telemetry configuration if not provided
 	if cfg.Telemetry.ServiceName == "" {

--- a/diode-server/cmd/auth/main.go
+++ b/diode-server/cmd/auth/main.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/netboxlabs/diode/diode-server/auth"
+	"github.com/netboxlabs/diode/diode-server/pprof"
 	"github.com/netboxlabs/diode/diode-server/server"
 	"github.com/netboxlabs/diode/diode-server/telemetry"
 	"github.com/netboxlabs/diode/diode-server/version"
@@ -20,6 +21,9 @@ const (
 
 	// used by open telemetry metrics
 	telemetryServiceName = "netboxlabs/diode/auth"
+
+	// PProfEnvVar is the environment variable for the optional pprof server address
+	PProfEnvVar = "DIODE_AUTH_PPROF_ADDR"
 )
 
 func main() {
@@ -28,6 +32,10 @@ func main() {
 	s := server.New(ctx, applicationName, version.Release())
 
 	defer s.Recover(sentry.CurrentHub())
+
+	if pprofAddr := os.Getenv(PProfEnvVar); pprofAddr != "" {
+		go pprof.Listen(ctx, s.Logger(), pprofAddr)
+	}
 
 	var cfg auth.Config
 	envconfig.MustProcess("", &cfg)

--- a/diode-server/cmd/ingester/main.go
+++ b/diode-server/cmd/ingester/main.go
@@ -25,9 +25,6 @@ const (
 
 	// used by open telemetry metrics
 	telemetryServiceName = "netboxlabs/diode/ingester"
-
-	// PProfEnvVar is the environment variable for the optional pprof server address
-	PProfEnvVar = "DIODE_INGESTER_PPROF_ADDR"
 )
 
 func main() {
@@ -36,13 +33,13 @@ func main() {
 
 	defer s.Recover(sentry.CurrentHub())
 
-	if pprofAddr := os.Getenv(PProfEnvVar); pprofAddr != "" {
-		go pprof.Listen(ctx, s.Logger(), pprofAddr)
-	}
-
 	// Load configuration
 	var cfg ingester.Config
 	envconfig.MustProcess("", &cfg)
+
+	if cfg.PProfAddr != "" {
+		go pprof.Listen(ctx, s.Logger(), cfg.PProfAddr)
+	}
 
 	// Set default telemetry configuration if not provided
 	if cfg.Telemetry.ServiceName == "" {

--- a/diode-server/cmd/ingester/main.go
+++ b/diode-server/cmd/ingester/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/netboxlabs/diode/diode-server/authutil"
 	"github.com/netboxlabs/diode/diode-server/ingester"
+	"github.com/netboxlabs/diode/diode-server/pprof"
 	"github.com/netboxlabs/diode/diode-server/server"
 	"github.com/netboxlabs/diode/diode-server/telemetry"
 	"github.com/netboxlabs/diode/diode-server/version"
@@ -24,6 +25,9 @@ const (
 
 	// used by open telemetry metrics
 	telemetryServiceName = "netboxlabs/diode/ingester"
+
+	// PProfEnvVar is the environment variable for the optional pprof server address
+	PProfEnvVar = "DIODE_INGESTER_PPROF_ADDR"
 )
 
 func main() {
@@ -31,6 +35,10 @@ func main() {
 	s := server.New(ctx, applicationName, version.Release())
 
 	defer s.Recover(sentry.CurrentHub())
+
+	if pprofAddr := os.Getenv(PProfEnvVar); pprofAddr != "" {
+		go pprof.Listen(ctx, s.Logger(), pprofAddr)
+	}
 
 	// Load configuration
 	var cfg ingester.Config

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netboxlabs/diode/diode-server/matching"
 	"github.com/netboxlabs/diode/diode-server/migrator"
 	"github.com/netboxlabs/diode/diode-server/netboxdiodeplugin"
+	"github.com/netboxlabs/diode/diode-server/pprof"
 	"github.com/netboxlabs/diode/diode-server/reconciler"
 	"github.com/netboxlabs/diode/diode-server/server"
 	"github.com/netboxlabs/diode/diode-server/telemetry"
@@ -33,6 +34,9 @@ const (
 
 	// used by open telemetry metrics
 	telemetryServiceName = "netboxlabs/diode/reconciler"
+
+	// PProfEnvVar is the environment variable for the optional pprof server address
+	PProfEnvVar = "DIODE_RECONCILER_PPROF_ADDR"
 )
 
 func main() {
@@ -40,6 +44,10 @@ func main() {
 	s := server.New(ctx, applicationName, version.Release())
 
 	defer s.Recover(sentry.CurrentHub())
+
+	if pprofAddr := os.Getenv(PProfEnvVar); pprofAddr != "" {
+		go pprof.Listen(ctx, s.Logger(), pprofAddr)
+	}
 
 	var cfg reconciler.Config
 	envconfig.MustProcess("", &cfg)

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -34,9 +34,6 @@ const (
 
 	// used by open telemetry metrics
 	telemetryServiceName = "netboxlabs/diode/reconciler"
-
-	// PProfEnvVar is the environment variable for the optional pprof server address
-	PProfEnvVar = "DIODE_RECONCILER_PPROF_ADDR"
 )
 
 func main() {
@@ -45,12 +42,12 @@ func main() {
 
 	defer s.Recover(sentry.CurrentHub())
 
-	if pprofAddr := os.Getenv(PProfEnvVar); pprofAddr != "" {
-		go pprof.Listen(ctx, s.Logger(), pprofAddr)
-	}
-
 	var cfg reconciler.Config
 	envconfig.MustProcess("", &cfg)
+
+	if cfg.PProfAddr != "" {
+		go pprof.Listen(ctx, s.Logger(), cfg.PProfAddr)
+	}
 
 	// Set default telemetry configuration if not provided
 	if cfg.Telemetry.ServiceName == "" {

--- a/diode-server/ingester/config.go
+++ b/diode-server/ingester/config.go
@@ -8,6 +8,7 @@ import (
 // Config is the configuration for the ingester service
 type Config struct {
 	GRPCPort      int    `envconfig:"GRPC_PORT" default:"8081"`
+	PProfAddr     string `envconfig:"PPROF_ADDR" default:"localhost:6061"`
 	RedisHost     string `envconfig:"REDIS_HOST" default:"127.0.0.1"`
 	RedisPort     string `envconfig:"REDIS_PORT" default:"6379"`
 	RedisUsername string `envconfig:"REDIS_USERNAME" default:""`

--- a/diode-server/pprof/pprof.go
+++ b/diode-server/pprof/pprof.go
@@ -1,0 +1,69 @@
+package pprof
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	_ "net/http/pprof" // Register pprof handlers
+	"time"
+)
+
+// Listen starts an HTTP server for pprof profiling endpoints on the specified address.
+// It gracefully shuts down when the provided context is canceled.
+//
+// The server exposes standard pprof endpoints at:
+//   - /debug/pprof/
+//   - /debug/pprof/cmdline
+//   - /debug/pprof/profile
+//   - /debug/pprof/symbol
+//   - /debug/pprof/trace
+//
+// NOTE: it is a blocking call; run it in a separate goroutine.
+func Listen(ctx context.Context, logger *slog.Logger, addr string) {
+	if addr == "" {
+		logger.Error("pprof address cannot be empty")
+	}
+
+	mux := http.NewServeMux()
+	// The pprof handlers are automatically registered at /debug/pprof/ when we import _ "net/http/pprof"
+	// We use DefaultServeMux which has the pprof handlers registered
+	mux.Handle("/debug/", http.DefaultServeMux)
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           http.DefaultServeMux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	// Channel to signal server startup errors
+	errChan := make(chan error, 1)
+
+	// Start server in a goroutine
+	go func() {
+		logger.Info("starting pprof server", "addr", addr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("pprof server error", "error", err)
+			errChan <- err
+		}
+	}()
+
+	// Wait for context cancellation or server error
+	select {
+	case <-ctx.Done():
+		logger.Info("shutting down pprof server", "reason", ctx.Err())
+
+		// Create shutdown context with timeout
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			logger.Error("pprof server shutdown error", "error", err)
+		}
+
+		logger.Info("pprof server stopped")
+
+	case err := <-errChan:
+		logger.Error("pprof server encountered an error", "error", err)
+	}
+}

--- a/diode-server/pprof/pprof.go
+++ b/diode-server/pprof/pprof.go
@@ -23,6 +23,7 @@ import (
 func Listen(ctx context.Context, logger *slog.Logger, addr string) {
 	if addr == "" {
 		logger.Error("pprof address cannot be empty")
+		return
 	}
 
 	mux := http.NewServeMux()

--- a/diode-server/reconciler/config.go
+++ b/diode-server/reconciler/config.go
@@ -8,6 +8,7 @@ import (
 // Config is the configuration for the reconciler service
 type Config struct {
 	GRPCPort                      int    `envconfig:"GRPC_PORT" default:"8081"`
+	PProfAddr                     string `envconfig:"PPROF_ADDR" default:"localhost:6062"`
 	RedisHost                     string `envconfig:"REDIS_HOST" default:"127.0.0.1"`
 	RedisPort                     string `envconfig:"REDIS_PORT" default:"6379"`
 	RedisUsername                 string `envconfig:"REDIS_USERNAME" default:""`


### PR DESCRIPTION
If the service pprof environment variable is set with a valid listening address:port it will provide http pprof endpoints for analyzing live servers.

In service of OBS-1991