### PR TITLE
fix: centralize Redis client options to prevent missing ACL username

### DIFF
--- a/diode-server/cmd/ingester/main.go
+++ b/diode-server/cmd/ingester/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/netboxlabs/diode/diode-server/pprof"
 	"github.com/netboxlabs/diode/diode-server/server"
 	"github.com/netboxlabs/diode/diode-server/telemetry"
+	diodetls "github.com/netboxlabs/diode/diode-server/tls"
 	"github.com/netboxlabs/diode/diode-server/version"
 )
 
@@ -66,23 +67,11 @@ func main() {
 
 	metricRecorder.SetServiceInfo(ctx, fmt.Sprintf("%s.%s", version.GetBuildVersion(), version.GetBuildCommit()))
 
-	redisTLSConfig, err := cfg.RedisTLS.ToTLSConfig()
+	redisOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisStreamDB, &cfg.RedisTLS)
 	if err != nil {
-		s.Logger().Error("failed to create TLS config for Redis", "error", err)
+		s.Logger().Error("failed to create Redis options", "error", err)
 		metricRecorder.RecordServiceStartupAttempt(ctx, false)
 		os.Exit(1)
-	}
-
-	redisOptions := redis.Options{
-		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		DB:        cfg.RedisStreamDB,
-		TLSConfig: redisTLSConfig,
-	}
-	if cfg.RedisUsername != "" {
-		redisOptions.Username = cfg.RedisUsername
-	}
-	if cfg.RedisPassword != "" {
-		redisOptions.Password = cfg.RedisPassword
 	}
 	redisStreamClient := redis.NewClient(&redisOptions)
 

--- a/diode-server/cmd/ingester/main.go
+++ b/diode-server/cmd/ingester/main.go
@@ -67,7 +67,14 @@ func main() {
 
 	metricRecorder.SetServiceInfo(ctx, fmt.Sprintf("%s.%s", version.GetBuildVersion(), version.GetBuildCommit()))
 
-	redisOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisStreamDB, &cfg.RedisTLS)
+	redisOptions, err := diodetls.NewRedisOptions(diodetls.RedisParams{
+		Host:     cfg.RedisHost,
+		Port:     cfg.RedisPort,
+		Username: cfg.RedisUsername,
+		Password: cfg.RedisPassword,
+		DB:       cfg.RedisStreamDB,
+		TLS:      &cfg.RedisTLS,
+	})
 	if err != nil {
 		s.Logger().Error("failed to create Redis options", "error", err)
 		metricRecorder.RecordServiceStartupAttempt(ctx, false)

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/netboxlabs/diode/diode-server/reconciler"
 	"github.com/netboxlabs/diode/diode-server/server"
 	"github.com/netboxlabs/diode/diode-server/telemetry"
+	diodetls "github.com/netboxlabs/diode/diode-server/tls"
 	"github.com/netboxlabs/diode/diode-server/version"
 )
 
@@ -85,23 +86,11 @@ func main() {
 		}
 	}
 
-	redisTLSConfig, err := cfg.RedisTLS.ToTLSConfig()
+	redisOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisDB, &cfg.RedisTLS)
 	if err != nil {
-		s.Logger().Error("failed to create TLS config for Redis", "error", err)
+		s.Logger().Error("failed to create Redis options", "error", err)
 		metricRecorder.RecordServiceStartupAttempt(ctx, false)
 		os.Exit(1)
-	}
-
-	redisOptions := redis.Options{
-		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		DB:        cfg.RedisDB,
-		TLSConfig: redisTLSConfig,
-	}
-	if cfg.RedisUsername != "" {
-		redisOptions.Username = cfg.RedisUsername
-	}
-	if cfg.RedisPassword != "" {
-		redisOptions.Password = cfg.RedisPassword
 	}
 	redisClient := redis.NewClient(&redisOptions)
 
@@ -111,16 +100,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	redisStreamOptions := redis.Options{
-		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		DB:        cfg.RedisStreamDB,
-		TLSConfig: redisTLSConfig,
-	}
-	if cfg.RedisUsername != "" {
-		redisStreamOptions.Username = cfg.RedisUsername
-	}
-	if cfg.RedisPassword != "" {
-		redisStreamOptions.Password = cfg.RedisPassword
+	redisStreamOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisStreamDB, &cfg.RedisTLS)
+	if err != nil {
+		s.Logger().Error("failed to create Redis stream options", "error", err)
+		metricRecorder.RecordServiceStartupAttempt(ctx, false)
+		os.Exit(1)
 	}
 	redisStreamClient := redis.NewClient(&redisStreamOptions)
 

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -86,7 +86,14 @@ func main() {
 		}
 	}
 
-	redisOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisDB, &cfg.RedisTLS)
+	redisOptions, err := diodetls.NewRedisOptions(diodetls.RedisParams{
+		Host:     cfg.RedisHost,
+		Port:     cfg.RedisPort,
+		Username: cfg.RedisUsername,
+		Password: cfg.RedisPassword,
+		DB:       cfg.RedisDB,
+		TLS:      &cfg.RedisTLS,
+	})
 	if err != nil {
 		s.Logger().Error("failed to create Redis options", "error", err)
 		metricRecorder.RecordServiceStartupAttempt(ctx, false)
@@ -100,7 +107,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	redisStreamOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisStreamDB, &cfg.RedisTLS)
+	redisStreamOptions, err := diodetls.NewRedisOptions(diodetls.RedisParams{
+		Host:     cfg.RedisHost,
+		Port:     cfg.RedisPort,
+		Username: cfg.RedisUsername,
+		Password: cfg.RedisPassword,
+		DB:       cfg.RedisStreamDB,
+		TLS:      &cfg.RedisTLS,
+	})
 	if err != nil {
 		s.Logger().Error("failed to create Redis stream options", "error", err)
 		metricRecorder.RecordServiceStartupAttempt(ctx, false)

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -107,19 +107,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	redisStreamOptions, err := diodetls.NewRedisOptions(diodetls.RedisParams{
-		Host:     cfg.RedisHost,
-		Port:     cfg.RedisPort,
-		Username: cfg.RedisUsername,
-		Password: cfg.RedisPassword,
-		DB:       cfg.RedisStreamDB,
-		TLS:      &cfg.RedisTLS,
-	})
-	if err != nil {
-		s.Logger().Error("failed to create Redis stream options", "error", err)
-		metricRecorder.RecordServiceStartupAttempt(ctx, false)
-		os.Exit(1)
-	}
+	// The stream client shares the same connection settings; only the DB
+	// differs, so copy the options rather than rebuilding the TLS config.
+	redisStreamOptions := redisOptions
+	redisStreamOptions.DB = cfg.RedisStreamDB
 	redisStreamClient := redis.NewClient(&redisStreamOptions)
 
 	if _, err := redisStreamClient.Ping(ctx).Result(); err != nil {

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -34,7 +34,14 @@ func NewServer(ctx context.Context, logger *slog.Logger, repository Repository, 
 	var cfg Config
 	envconfig.MustProcess("", &cfg)
 
-	redisOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisDB, &cfg.RedisTLS)
+	redisOptions, err := diodetls.NewRedisOptions(diodetls.RedisParams{
+		Host:     cfg.RedisHost,
+		Port:     cfg.RedisPort,
+		Username: cfg.RedisUsername,
+		Password: cfg.RedisPassword,
+		DB:       cfg.RedisDB,
+		TLS:      &cfg.RedisTLS,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Redis options: %v", err)
 	}

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/reconcilerpb"
 	"github.com/netboxlabs/diode/diode-server/grpckeepalive"
+	diodetls "github.com/netboxlabs/diode/diode-server/tls"
 )
 
 // Server is a reconciler Server
@@ -33,21 +34,9 @@ func NewServer(ctx context.Context, logger *slog.Logger, repository Repository, 
 	var cfg Config
 	envconfig.MustProcess("", &cfg)
 
-	redisTLSConfig, err := cfg.RedisTLS.ToTLSConfig()
+	redisOptions, err := diodetls.NewRedisOptions(cfg.RedisHost, cfg.RedisPort, cfg.RedisUsername, cfg.RedisPassword, cfg.RedisDB, &cfg.RedisTLS)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create TLS config for Redis: %v", err)
-	}
-
-	redisOptions := redis.Options{
-		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		DB:        cfg.RedisDB,
-		TLSConfig: redisTLSConfig,
-	}
-	if cfg.RedisUsername != "" {
-		redisOptions.Username = cfg.RedisUsername
-	}
-	if cfg.RedisPassword != "" {
-		redisOptions.Password = cfg.RedisPassword
+		return nil, fmt.Errorf("failed to create Redis options: %v", err)
 	}
 	redisClient := redis.NewClient(&redisOptions)
 

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -43,7 +43,7 @@ func NewServer(ctx context.Context, logger *slog.Logger, repository Repository, 
 		TLS:      &cfg.RedisTLS,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Redis options: %v", err)
+		return nil, fmt.Errorf("failed to create Redis options: %w", err)
 	}
 	redisClient := redis.NewClient(&redisOptions)
 

--- a/diode-server/tls/redis.go
+++ b/diode-server/tls/redis.go
@@ -6,29 +6,35 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// RedisParams holds the connection parameters for building redis.Options.
+type RedisParams struct {
+	Host     string
+	Port     string
+	Username string
+	Password string
+	DB       int
+	TLS      *Config
+}
+
 // NewRedisOptions builds redis.Options with consistent TLS and ACL username
 // handling. All Redis client creation should use this helper to ensure the
 // username is never accidentally omitted (which would cause go-redis to
 // authenticate as the "default" Redis user instead of the intended ACL user).
-func NewRedisOptions(host, port, username, password string, db int, tlsCfg *Config) (redis.Options, error) {
-	if tlsCfg == nil {
+func NewRedisOptions(p RedisParams) (redis.Options, error) {
+	if p.TLS == nil {
 		return redis.Options{}, fmt.Errorf("TLS config must not be nil (use &tls.Config{} for no TLS)")
 	}
 
-	goTLS, err := tlsCfg.ToTLSConfig()
+	goTLS, err := p.TLS.ToTLSConfig()
 	if err != nil {
 		return redis.Options{}, fmt.Errorf("failed to create TLS config for Redis: %w", err)
 	}
 
-	opts := redis.Options{
-		Addr:      fmt.Sprintf("%s:%s", host, port),
-		Password:  password,
-		DB:        db,
+	return redis.Options{
+		Addr:      fmt.Sprintf("%s:%s", p.Host, p.Port),
+		Username:  p.Username,
+		Password:  p.Password,
+		DB:        p.DB,
 		TLSConfig: goTLS,
-	}
-	if username != "" {
-		opts.Username = username
-	}
-
-	return opts, nil
+	}, nil
 }

--- a/diode-server/tls/redis.go
+++ b/diode-server/tls/redis.go
@@ -1,0 +1,34 @@
+package tls
+
+import (
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// NewRedisOptions builds redis.Options with consistent TLS and ACL username
+// handling. All Redis client creation should use this helper to ensure the
+// username is never accidentally omitted (which would cause go-redis to
+// authenticate as the "default" Redis user instead of the intended ACL user).
+func NewRedisOptions(host, port, username, password string, db int, tlsCfg *Config) (redis.Options, error) {
+	if tlsCfg == nil {
+		return redis.Options{}, fmt.Errorf("TLS config must not be nil (use &tls.Config{} for no TLS)")
+	}
+
+	goTLS, err := tlsCfg.ToTLSConfig()
+	if err != nil {
+		return redis.Options{}, fmt.Errorf("failed to create TLS config for Redis: %w", err)
+	}
+
+	opts := redis.Options{
+		Addr:      fmt.Sprintf("%s:%s", host, port),
+		Password:  password,
+		DB:        db,
+		TLSConfig: goTLS,
+	}
+	if username != "" {
+		opts.Username = username
+	}
+
+	return opts, nil
+}

--- a/diode-server/tls/redis_test.go
+++ b/diode-server/tls/redis_test.go
@@ -24,7 +24,10 @@ func TestNewRedisOptions(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "basic options without TLS",
+			// Core fix: an empty username must leave Username empty rather than
+			// being set to "". go-redis treats an empty Username as "use the
+			// default Redis user", which is correct when no ACL user is set.
+			name:     "empty username is not set",
 			host:     "localhost",
 			port:     "6379",
 			username: "",
@@ -38,6 +41,9 @@ func TestNewRedisOptions(t *testing.T) {
 			wantTLS:  false,
 		},
 		{
+			// Core fix: a provided username MUST propagate to Username, else
+			// go-redis authenticates as the "default" user and hits WRONGPASS
+			// when that user is disabled or has a different password.
 			name:     "with ACL username",
 			host:     "redis.example.com",
 			port:     "6380",
@@ -66,20 +72,6 @@ func TestNewRedisOptions(t *testing.T) {
 			wantTLS:  true,
 		},
 		{
-			name:     "empty username is not set",
-			host:     "localhost",
-			port:     "6379",
-			username: "",
-			password: "secret",
-			db:       0,
-			tlsCfg:   &Config{Enabled: false},
-			wantAddr: "localhost:6379",
-			wantUser: "",
-			wantPass: "secret",
-			wantDB:   0,
-			wantTLS:  false,
-		},
-		{
 			name:     "nil TLS config returns error",
 			host:     "localhost",
 			port:     "6379",
@@ -103,7 +95,14 @@ func TestNewRedisOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts, err := NewRedisOptions(tt.host, tt.port, tt.username, tt.password, tt.db, tt.tlsCfg)
+			opts, err := NewRedisOptions(RedisParams{
+				Host:     tt.host,
+				Port:     tt.port,
+				Username: tt.username,
+				Password: tt.password,
+				DB:       tt.db,
+				TLS:      tt.tlsCfg,
+			})
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -122,26 +121,4 @@ func TestNewRedisOptions(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestNewRedisOptionsUsernameNotSetWhenEmpty(t *testing.T) {
-	// This test specifically verifies the core fix: when username is empty,
-	// the Username field on redis.Options must remain empty ("") rather than
-	// being set to "". go-redis treats an empty Username as "use the default
-	// Redis user", which is the correct behavior when no ACL username is
-	// configured.
-	opts, err := NewRedisOptions("localhost", "6379", "", "pass", 0, &Config{})
-	require.NoError(t, err)
-	assert.Empty(t, opts.Username)
-}
-
-func TestNewRedisOptionsUsernameSetWhenProvided(t *testing.T) {
-	// This test verifies the core fix: when a username IS provided, it MUST
-	// be propagated to redis.Options.Username. Missing this causes go-redis
-	// to authenticate as the "default" Redis user instead of the intended
-	// ACL user, resulting in WRONGPASS errors when the default user is
-	// disabled or has a different password.
-	opts, err := NewRedisOptions("localhost", "6379", "my-acl-user", "pass", 0, &Config{})
-	require.NoError(t, err)
-	assert.Equal(t, "my-acl-user", opts.Username)
 }

--- a/diode-server/tls/redis_test.go
+++ b/diode-server/tls/redis_test.go
@@ -1,0 +1,147 @@
+package tls
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRedisOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     string
+		username string
+		password string
+		db       int
+		tlsCfg   *Config
+		wantAddr string
+		wantUser string
+		wantPass string
+		wantDB   int
+		wantTLS  bool
+		wantErr  bool
+	}{
+		{
+			name:     "basic options without TLS",
+			host:     "localhost",
+			port:     "6379",
+			username: "",
+			password: "secret",
+			db:       0,
+			tlsCfg:   &Config{Enabled: false},
+			wantAddr: "localhost:6379",
+			wantUser: "",
+			wantPass: "secret",
+			wantDB:   0,
+			wantTLS:  false,
+		},
+		{
+			name:     "with ACL username",
+			host:     "redis.example.com",
+			port:     "6380",
+			username: "redis-user",
+			password: "secret",
+			db:       1,
+			tlsCfg:   &Config{Enabled: false},
+			wantAddr: "redis.example.com:6380",
+			wantUser: "redis-user",
+			wantPass: "secret",
+			wantDB:   1,
+			wantTLS:  false,
+		},
+		{
+			name:     "with TLS enabled",
+			host:     "redis.example.com",
+			port:     "6380",
+			username: "redis-user",
+			password: "secret",
+			db:       0,
+			tlsCfg:   &Config{Enabled: true, SkipVerify: true},
+			wantAddr: "redis.example.com:6380",
+			wantUser: "redis-user",
+			wantPass: "secret",
+			wantDB:   0,
+			wantTLS:  true,
+		},
+		{
+			name:     "empty username is not set",
+			host:     "localhost",
+			port:     "6379",
+			username: "",
+			password: "secret",
+			db:       0,
+			tlsCfg:   &Config{Enabled: false},
+			wantAddr: "localhost:6379",
+			wantUser: "",
+			wantPass: "secret",
+			wantDB:   0,
+			wantTLS:  false,
+		},
+		{
+			name:     "nil TLS config returns error",
+			host:     "localhost",
+			port:     "6379",
+			username: "",
+			password: "secret",
+			db:       0,
+			tlsCfg:   nil,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid CA path returns error",
+			host:     "localhost",
+			port:     "6379",
+			username: "",
+			password: "secret",
+			db:       0,
+			tlsCfg:   &Config{Enabled: true, CaPath: "/nonexistent/ca.crt"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := NewRedisOptions(tt.host, tt.port, tt.username, tt.password, tt.db, tt.tlsCfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantAddr, opts.Addr)
+			assert.Equal(t, tt.wantUser, opts.Username)
+			assert.Equal(t, tt.wantPass, opts.Password)
+			assert.Equal(t, tt.wantDB, opts.DB)
+
+			if tt.wantTLS {
+				assert.NotNil(t, opts.TLSConfig, "TLSConfig should be set when TLS is enabled")
+			} else {
+				assert.Nil(t, opts.TLSConfig, "TLSConfig should be nil when TLS is disabled")
+			}
+		})
+	}
+}
+
+func TestNewRedisOptionsUsernameNotSetWhenEmpty(t *testing.T) {
+	// This test specifically verifies the core fix: when username is empty,
+	// the Username field on redis.Options must remain empty ("") rather than
+	// being set to "". go-redis treats an empty Username as "use the default
+	// Redis user", which is the correct behavior when no ACL username is
+	// configured.
+	opts, err := NewRedisOptions("localhost", "6379", "", "pass", 0, &Config{})
+	require.NoError(t, err)
+	assert.Empty(t, opts.Username)
+}
+
+func TestNewRedisOptionsUsernameSetWhenProvided(t *testing.T) {
+	// This test verifies the core fix: when a username IS provided, it MUST
+	// be propagated to redis.Options.Username. Missing this causes go-redis
+	// to authenticate as the "default" Redis user instead of the intended
+	// ACL user, resulting in WRONGPASS errors when the default user is
+	// disabled or has a different password.
+	opts, err := NewRedisOptions("localhost", "6379", "my-acl-user", "pass", 0, &Config{})
+	require.NoError(t, err)
+	assert.Equal(t, "my-acl-user", opts.Username)
+}


### PR DESCRIPTION
## What this does

Centralizes Redis client option construction so the ACL username is never
accidentally omitted. Previously each entrypoint built `redis.Options` inline;
when the username was left out, go-redis authenticated as the `default` Redis
user instead of the configured ACL user (causing `WRONGPASS` when the default
user is disabled).

- Adds a `NewRedisOptions` helper in `diode-server/tls/` that builds
  `redis.Options` with consistent TLS and ACL username/password handling.
- Adopts the helper at all three production call sites: `cmd/ingester`,
  `cmd/reconciler` (both the main and stream clients), and `reconciler/server.go`.

## Pre-PR review

Ran the analyzer suite (code review, semgrep, security audit, silent-failure,
variant hunt, simplifier). No P0/P1 findings — the core change is
behavior-preserving and is a net security improvement over the inline code.
All fixed items below are P2 quality cleanups.

### Fixed (P2)

- **`NewRedisOptions` signature** — replaced 6 positional params (two adjacent
  same-typed string pairs `host,port` / `username,password` were a
  transposition footgun, and 6 args exceeded the ≤5 guideline) with a
  `RedisParams` struct. Flagged independently by the security audit and the
  simplifier.
- **Redundant username guard** — `Username` is now assigned unconditionally in
  the struct literal; an empty value is identical to leaving it unset, and this
  better matches the helper's "never omit the username" intent.
- **Reconciler double TLS build** — the reconciler's two clients differ only by
  DB, so the options are built once and copied (overriding DB) instead of
  calling `NewRedisOptions`/`ToTLSConfig` twice and re-reading the CA file.
- **Error wrapping** — `reconciler/server.go` now wraps the options error with
  `%w` (was `%v`) so callers can inspect the underlying TLS error.
- **Test cleanup** — removed a duplicate table row and two standalone tests
  already covered by the `NewRedisOptions` table; intent comments preserved.

### Deferred

- 15 test-only `redis.Options{}` construction sites (in `ingestion_processor_test.go`,
  `component_test.go`, `component_internal_test.go`) were not migrated to the
  helper. They use miniredis with no ACL/TLS, so the default-user bug cannot
  manifest there. Left as-is by decision; not tracked separately.

### Reviewed and dismissed

- semgrep reported 7 warnings, all in unmodified files (TLS min-version in
  `netboxdiodeplugin/client.go`, unsafe usage in generated protobuf, plaintext
  HTTP in `telemetry/prometheus.go`) — pre-existing, outside this diff's scope.

Verified locally: `go build ./...`, `go vet`, `gofmt`, and `go test ./tls/ ./reconciler/`
all pass. (`golangci-lint` couldn't run locally due to a Go toolchain version
mismatch in the installed binary; CI runs the correct version.)
