### PR TITLE
feat: make Redis password optional across all services

### DIFF
--- a/diode-server/cmd/ingester/main.go
+++ b/diode-server/cmd/ingester/main.go
@@ -75,12 +75,14 @@ func main() {
 
 	redisOptions := redis.Options{
 		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		Password:  cfg.RedisPassword,
 		DB:        cfg.RedisStreamDB,
 		TLSConfig: redisTLSConfig,
 	}
 	if cfg.RedisUsername != "" {
 		redisOptions.Username = cfg.RedisUsername
+	}
+	if cfg.RedisPassword != "" {
+		redisOptions.Password = cfg.RedisPassword
 	}
 	redisStreamClient := redis.NewClient(&redisOptions)
 

--- a/diode-server/cmd/reconciler/main.go
+++ b/diode-server/cmd/reconciler/main.go
@@ -94,12 +94,14 @@ func main() {
 
 	redisOptions := redis.Options{
 		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		Password:  cfg.RedisPassword,
 		DB:        cfg.RedisDB,
 		TLSConfig: redisTLSConfig,
 	}
 	if cfg.RedisUsername != "" {
 		redisOptions.Username = cfg.RedisUsername
+	}
+	if cfg.RedisPassword != "" {
+		redisOptions.Password = cfg.RedisPassword
 	}
 	redisClient := redis.NewClient(&redisOptions)
 
@@ -111,12 +113,14 @@ func main() {
 
 	redisStreamOptions := redis.Options{
 		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		Password:  cfg.RedisPassword,
 		DB:        cfg.RedisStreamDB,
 		TLSConfig: redisTLSConfig,
 	}
 	if cfg.RedisUsername != "" {
 		redisStreamOptions.Username = cfg.RedisUsername
+	}
+	if cfg.RedisPassword != "" {
+		redisStreamOptions.Password = cfg.RedisPassword
 	}
 	redisStreamClient := redis.NewClient(&redisStreamOptions)
 

--- a/diode-server/ingester/config.go
+++ b/diode-server/ingester/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	RedisHost     string `envconfig:"REDIS_HOST" default:"127.0.0.1"`
 	RedisPort     string `envconfig:"REDIS_PORT" default:"6379"`
 	RedisUsername string `envconfig:"REDIS_USERNAME" default:""`
-	RedisPassword string `envconfig:"REDIS_PASSWORD" required:"true"`
+	RedisPassword string `envconfig:"REDIS_PASSWORD" default:""`
 	RedisStreamDB int    `envconfig:"REDIS_STREAM_DB" default:"1"`
 
 	RedisTLS  tls.Config       `envconfig:"REDIS_TLS"`

--- a/diode-server/reconciler/config.go
+++ b/diode-server/reconciler/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	RedisHost                     string `envconfig:"REDIS_HOST" default:"127.0.0.1"`
 	RedisPort                     string `envconfig:"REDIS_PORT" default:"6379"`
 	RedisUsername                 string `envconfig:"REDIS_USERNAME" default:""`
-	RedisPassword                 string `envconfig:"REDIS_PASSWORD" required:"true"`
+	RedisPassword                 string `envconfig:"REDIS_PASSWORD" default:""`
 	RedisDB                       int    `envconfig:"REDIS_DB" default:"0"`
 	RedisStreamDB                 int    `envconfig:"REDIS_STREAM_DB" default:"1"`
 	MigrationEnabled              bool   `envconfig:"MIGRATION_ENABLED" default:"true"`

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -39,12 +39,14 @@ func NewServer(ctx context.Context, logger *slog.Logger, repository Repository, 
 
 	redisOptions := redis.Options{
 		Addr:      fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
-		Password:  cfg.RedisPassword,
 		DB:        cfg.RedisDB,
 		TLSConfig: redisTLSConfig,
 	}
 	if cfg.RedisUsername != "" {
 		redisOptions.Username = cfg.RedisUsername
+	}
+	if cfg.RedisPassword != "" {
+		redisOptions.Password = cfg.RedisPassword
 	}
 	redisClient := redis.NewClient(&redisOptions)
 


### PR DESCRIPTION
Only set RedisPassword on redis.Options when the value is non-empty, matching the existing RedisUsername behavior.