### PR TITLE
feat: add container scanning for all diode services

### DIFF
--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -1,0 +1,89 @@
+name: Scheduled Container Rescan
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  rescan:
+    name: Rescan ${{ matrix.app }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [auth, ingester, reconciler]
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+
+    steps:
+      - name: Pull image
+        env:
+          APP: ${{ matrix.app }}
+        run: docker pull "docker.io/netboxlabs/diode-${APP}:latest"
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: docker.io/netboxlabs/diode-${{ matrix.app }}:latest
+          format: json
+          output: trivy-output.json
+          vuln-type: os,library
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          ignore-unfixed: true
+          exit-code: "0"
+
+      - name: Build rescan summary
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          APP: ${{ matrix.app }}
+        with:
+          script: |
+            const fs = require('fs');
+            const app = process.env.APP;
+            const data = JSON.parse(fs.readFileSync('trivy-output.json', 'utf8'));
+            const vulns = (data.Results || []).flatMap(r =>
+              (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
+            );
+
+            const SEVERITY_LABEL = {
+              CRITICAL: '🔴 **CRITICAL**',
+              HIGH: '🟠 **HIGH**',
+              MEDIUM: '🟡 MEDIUM',
+              LOW: '⚪ LOW'
+            };
+
+            let summary = `### Rescan Complete — diode-${app}\n\n`;
+            summary += `**Image:** \`docker.io/netboxlabs/diode-${app}:latest\`\n`;
+            summary += `**Scanned at:** ${new Date().toISOString().replace('T', ' ').split('.')[0]} UTC\n\n`;
+
+            if (vulns.length === 0) {
+              summary += '_No vulnerabilities found._\n';
+            } else {
+              summary += `| Library | CVE | Severity | Installed | Fixed | Title |\n`;
+              summary += `|---|---|---|---|---|---|\n`;
+              for (const v of vulns) {
+                const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
+                const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
+                summary += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+              }
+            }
+
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+      - name: Convert scan results to SARIF
+        if: "!cancelled()"
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-output.json
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: "!cancelled()"
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: trivy-results.sarif
+          category: diode-${{ matrix.app }}-rescan

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -1,0 +1,201 @@
+name: Container Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "diode-server/**"
+      - "!diode-server/docker/**"
+      - "!diode-server/Makefile"
+      - "!diode-server/README.md"
+      - ".github/workflows/container-scan.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.25'
+
+jobs:
+  build-and-scan:
+    name: ${{ matrix.app }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [auth, ingester, reconciler]
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Set build info
+        env:
+          APP: ${{ matrix.app }}
+        run: |
+          echo ${GITHUB_SHA::7} > ./diode-server/version/BUILD_COMMIT.txt
+          LATEST_RELEASE=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r '.tag_name')
+          echo $LATEST_RELEASE > ./diode-server/version/BUILD_VERSION.txt
+
+      - name: Build image
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        with:
+          context: diode-server
+          file: diode-server/docker/Dockerfile-build.${{ matrix.app }}
+          load: true
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,scope=${{ matrix.app }},mode=max
+          build-args: |
+            SVC=${{ matrix.app }}
+          tags: diode-${{ matrix.app }}:scan
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: diode-${{ matrix.app }}:scan
+          format: json
+          output: trivy-output.json
+          vuln-type: os,library
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          ignore-unfixed: true
+          exit-code: "0"
+          list-all-pkgs: "true"
+
+      - name: Build scan summary
+        id: scan-summary
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          APP: ${{ matrix.app }}
+        with:
+          script: |
+            const fs = require('fs');
+            const app = process.env.APP;
+            const data = JSON.parse(fs.readFileSync('trivy-output.json', 'utf8'));
+            const vulns = (data.Results || []).flatMap(r =>
+              (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
+            );
+
+            const blockingSeverities = new Set(app === 'auth' ? ['CRITICAL'] : ['CRITICAL', 'HIGH']);
+
+            const SEVERITY_LABEL = {
+              CRITICAL: '🔴 **CRITICAL**',
+              HIGH: '🟠 **HIGH**',
+              MEDIUM: '🟡 MEDIUM',
+              LOW: '⚪ LOW'
+            };
+
+            const counts = { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0 };
+            for (const v of vulns) {
+              if (counts[v.Severity] !== undefined) counts[v.Severity]++;
+            }
+
+            const hasBlocking = vulns.some(v => blockingSeverities.has(v.Severity));
+            core.setOutput('has_blocking', hasBlocking.toString());
+
+            const buildTable = (vulns) => {
+              if (vulns.length === 0) return '_No vulnerabilities found._\n';
+              let t = '| Library | CVE | Severity | Installed | Fixed | Title |\n';
+              t += '|---|---|---|---|---|---|\n';
+              for (const v of vulns) {
+                const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
+                const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
+                t += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+              }
+              return t;
+            };
+
+            const table = buildTable(vulns);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,
+              `## Vulnerability Scan Results — diode-${app}\n\n` + table
+            );
+
+            const artifact = JSON.stringify({ table, hasBlocking, counts });
+            fs.writeFileSync('scan-result.json', artifact);
+
+      - name: Post scan results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          APP: ${{ matrix.app }}
+          COMMIT_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const app = process.env.APP;
+            const { table, hasBlocking } = JSON.parse(fs.readFileSync('scan-result.json', 'utf8'));
+
+            const heading = hasBlocking
+              ? `## Vulnerability Scan: Failed — diode-${app}`
+              : `## Vulnerability Scan: Passed — diode-${app}`;
+
+            const commitSha = process.env.COMMIT_SHA;
+            const marker = `<!-- trivy-scan-diode-${app} -->`;
+            const body = `${marker}\n${heading}\n\n**Image:** \`diode-${app}:scan\`\n\n${table}\n*Commit: ${commitSha}*`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on blocking vulnerabilities
+        if: steps.scan-summary.outputs.has_blocking == 'true'
+        env:
+          APP: ${{ matrix.app }}
+        run: |
+          echo "Blocking vulnerabilities found for diode-${APP}. Failing build."
+          exit 1
+
+      - name: Convert scan results to SBOM
+        if: "!cancelled()"
+        run: trivy convert --format cyclonedx --output sbom.cdx.json trivy-output.json
+
+      - name: Upload SBOM artifact
+        if: "!cancelled()"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: sbom-diode-${{ matrix.app }}-${{ github.sha }}
+          path: sbom.cdx.json
+          retention-days: 90
+
+      - name: Convert scan results to SARIF
+        if: "!cancelled()"
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-output.json
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: "!cancelled()"
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: trivy-results.sarif
+          category: diode-${{ matrix.app }}

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -90,9 +90,9 @@ jobs:
               (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
             );
 
-            // auth copies oryd/hydra:v25.4.0 which carries unfixed CRITICAL and HIGH CVEs
+            // auth copies oryd/hydra:v26.2.0 built with Go 1.26.0 which carries unfixed HIGH CVEs
             // Tracked: https://github.com/ory/hydra/issues/4080
-            const blockingSeverities = new Set(app === 'auth' ? [] : ['CRITICAL', 'HIGH']);
+            const blockingSeverities = new Set(app === 'auth' ? ['CRITICAL'] : ['CRITICAL', 'HIGH']);
 
             const SEVERITY_LABEL = {
               CRITICAL: '🔴 **CRITICAL**',

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -90,7 +90,9 @@ jobs:
               (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
             );
 
-            const blockingSeverities = new Set(app === 'auth' ? ['CRITICAL'] : ['CRITICAL', 'HIGH']);
+            // auth copies oryd/hydra:v25.4.0 which carries unfixed CRITICAL and HIGH CVEs
+            // Tracked: https://github.com/ory/hydra/issues/4080
+            const blockingSeverities = new Set(app === 'auth' ? [] : ['CRITICAL', 'HIGH']);
 
             const SEVERITY_LABEL = {
               CRITICAL: '🔴 **CRITICAL**',


### PR DESCRIPTION
## Summary

Adds Trivy container vulnerability scanning for all three diode service images (auth, ingester, reconciler).

### New workflows

**`container-scan.yaml`** — PR scan workflow
- Triggered on PRs affecting `diode-server/` and manual dispatch
- Builds all 3 service images (single-platform linux/amd64)
- Scans each with Trivy in parallel (matrix strategy)
- Per-service PR comments with vulnerability tables
- Per-service CycloneDX SBOMs (90-day retention)
- SARIF upload to GitHub Code Scanning
- **auth**: blocks on CRITICAL only (carries `oryd/hydra:v25.4.0` with unfixed HIGHs)
- **ingester, reconciler**: block on CRITICAL and HIGH

**`container-rescan.yaml`** — Daily rescan
- Runs daily at 06:00 UTC + manual dispatch
- Pulls published images from Docker Hub (`netboxlabs/diode-{auth,ingester,reconciler}:latest`)
- Renders vulnerability table in step summary
- SARIF upload to Code Scanning

### Pipeline flow

```
build-and-scan (matrix: auth, ingester, reconciler)
  ├── Build image
  ├── Trivy scan (JSON)
  ├── PR comment per service
  ├── Severity gate (CRITICAL for auth, CRITICAL+HIGH for others)
  ├── SBOM (CycloneDX)
  └── SARIF upload
```

### Known issues

- `oryd/hydra:v25.4.0` in auth carries unfixed HIGHs — auth severity relaxed to CRITICAL only
- Go `1.25.4` and grpc `v1.72.1` have known CVEs — separate PR to bump dependencies

## Test plan

- [ ] Trigger via `workflow_dispatch` to test all 3 services
- [ ] Each service gets its own PR comment
- [ ] SARIF results appear in Security → Code Scanning
- [ ] SBOM artifacts uploaded per service
- [ ] Rescan via `workflow_dispatch` scans published Docker Hub images