### PR TITLE
fix: upgrade Hydra from v25.4.0 to v26.2.0

### DIFF
--- a/charts/diode/Chart.lock
+++ b/charts/diode/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 16.6.3
 - name: hydra
   repository: https://k8s.ory.sh/helm/charts
-  version: 0.60.0
+  version: 0.61.0
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.12.1
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.12.0
-digest: sha256:dd4c00db9ec4b73f3301cf1e280f728e67c98c3068bce92a0ebb4012f097a032
-generated: "2025-12-10T21:25:59.501367+01:00"
+digest: sha256:bd094e512de6fbf45af54363823369e5cf08becbb7dc70084040e79698e3e08e
+generated: "2026-03-25T08:03:42.398394-04:00"

--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: "1.13.1"
+version: "1.13.2"
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:
@@ -28,7 +28,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: hydra
-    version: 0.60.0
+    version: 0.61.0
     repository: https://k8s.ory.sh/helm/charts
     condition: hydra.enabled
   - name: ingress-nginx

--- a/diode-server/auth/manager_hydra_integration_test.go
+++ b/diode-server/auth/manager_hydra_integration_test.go
@@ -32,7 +32,7 @@ func TestHydraClientManager(t *testing.T) {
 	ctx := context.Background()
 
 	req := testcontainers.ContainerRequest{
-		Image:        "oryd/hydra:v25.4.0",
+		Image:        "oryd/hydra:v26.2.0",
 		ExposedPorts: []string{"4445/tcp"},
 		WaitingFor:   wait.ForLog("Setting up http server on 0.0.0.0:4445"),
 		Cmd:          []string{"serve", "all", "--dev"},

--- a/diode-server/auth/server_hydra_integration_test.go
+++ b/diode-server/auth/server_hydra_integration_test.go
@@ -30,7 +30,7 @@ func TestServerHydraIntegration(t *testing.T) {
 	defer cancel()
 
 	creq := testcontainers.ContainerRequest{
-		Image:        "oryd/hydra:v25.4.0",
+		Image:        "oryd/hydra:v26.2.0",
 		ExposedPorts: []string{"4445/tcp", "4444/tcp"},
 		WaitingFor:   wait.ForLog("Setting up http server on 0.0.0.0:4445"),
 		Cmd:          []string{"serve", "all", "--dev"},

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -24,7 +24,7 @@ RUN apk add --no-cache jq
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-COPY --chown=appuser:appgroup --from=oryd/hydra:v25.4.0 /usr/bin/hydra /usr/bin/hydra
+COPY --chown=appuser:appgroup --from=oryd/hydra:v26.2.0@sha256:ff67c7fb5f95074fa53374d41151713554960504b340cd3f95b09e65deaea2a9 /usr/bin/hydra /usr/bin/hydra
 
 ARG SVC
 

--- a/diode-server/docker/Dockerfile.auth
+++ b/diode-server/docker/Dockerfile.auth
@@ -4,7 +4,7 @@ RUN apk add --no-cache jq
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-COPY --chown=appuser:appgroup --from=oryd/hydra:v25.4.0 /usr/bin/hydra /usr/bin/hydra
+COPY --chown=appuser:appgroup --from=oryd/hydra:v26.2.0@sha256:ff67c7fb5f95074fa53374d41151713554960504b340cd3f95b09e65deaea2a9 /usr/bin/hydra /usr/bin/hydra
 
 ARG SVC
 

--- a/diode-server/docker/docker-compose.yaml
+++ b/diode-server/docker/docker-compose.yaml
@@ -141,7 +141,7 @@ services:
           size: 1000000
 
   hydra:
-    image: oryd/hydra:v25.4.0
+    image: oryd/hydra:v26.2.0
     pull_policy: always
     expose:
       - "4444" # Public port
@@ -162,7 +162,7 @@ services:
       - postgres
 
   hydra-migrate:
-    image: oryd/hydra:v25.4.0
+    image: oryd/hydra:v26.2.0
     pull_policy: always
     command: migrate sql up -e --yes
     environment:


### PR DESCRIPTION
## Summary

Upgrades the Ory Hydra binary in the auth service from `v25.4.0` to `v26.2.0`, resolving multiple CVEs detected by container scanning.

### CVEs resolved

| CVE | Library | Severity |
|-----|---------|----------|
| CVE-2026-33186 | `google.golang.org/grpc` | CRITICAL |
| CVE-2025-68121 | Go stdlib | CRITICAL |
| CVE-2025-61726 | Go stdlib | HIGH |
| CVE-2025-61728 | Go stdlib | HIGH |
| CVE-2025-61729 | Go stdlib | HIGH |
| CVE-2026-24051 | `go.opentelemetry.io/otel/sdk` | HIGH |
| CVE-2025-47914 | `golang.org/x/crypto` | MEDIUM |
| CVE-2025-58181 | `golang.org/x/crypto` | MEDIUM |

### Files updated

- `diode-server/docker/Dockerfile-build.auth` — build Dockerfile (pinned by digest)
- `diode-server/docker/Dockerfile.auth` — runtime Dockerfile (pinned by digest)
- `diode-server/docker/docker-compose.yaml` — local development (2 references)

### Remaining

Hydra v26.2.0 was built with Go 1.26.0 which has stdlib HIGHs fixed in Go 1.26.1. Tracked upstream: https://github.com/ory/hydra/issues/4080

## Test plan

- [ ] Auth service builds successfully with the new Hydra version
- [ ] OAuth2 client bootstrap script works with Hydra v26.2.0
- [ ] Local `docker compose up` works
- [ ] Container scan shows reduced vulnerabilities for auth