### PR TITLE
fix: bump Go from 1.25.4 to 1.26.1

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -32,8 +32,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.x'
-          check-latest: true
+          go-version-file: diode-server/go.mod
+          cache-dependency-path: diode-server/go.sum
       - name: Run go build
         run: go build ./...
       - name: Install additional dependencies

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 #v9.1.0

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,11 +21,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.x'
-          check-latest: true
+          go-version-file: diode-server/go.mod
+          cache-dependency-path: diode-server/go.sum
       - name: Lint
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 #v9.1.0
         with:
-          version: v2.6
           working-directory: diode-server
           args: --config ../.github/golangci.yaml

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -16,7 +16,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 permissions:
   contents: write
   issues: write

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 

--- a/diode-server/docker/Dockerfile-build.ingester
+++ b/diode-server/docker/Dockerfile-build.ingester
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 

--- a/diode-server/docker/Dockerfile-build.reconciler
+++ b/diode-server/docker/Dockerfile-build.reconciler
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 

--- a/diode-server/go.mod
+++ b/diode-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/diode/diode-server
 
-go 1.25.4
+go 1.26.1
 
 require (
 	github.com/MicahParks/keyfunc/v3 v3.3.11


### PR DESCRIPTION
## Summary

Bumps Go toolchain from 1.25.4 to 1.26.1 across go.mod, Dockerfiles, and CI workflows.

### CVEs fixed

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2025-68121 | CRITICAL | Unexpected session resumption in `crypto/tls` |
| CVE-2025-61726 | HIGH | Memory exhaustion in `net/url` |
| CVE-2025-61728 | HIGH | CPU exhaustion in `archive/zip` |
| CVE-2025-61729 | HIGH | DoS via `crypto/x509` |
| CVE-2026-25679 | HIGH | Incorrect IPv6 parsing in `net/url` |
| CVE-2026-27142 | MEDIUM | URL escaping in `html/template` |
| CVE-2026-27139 | LOW | `FileInfo` escape from `Root` in `os` |

### Files updated

- `diode-server/go.mod` — `go 1.25.4` → `go 1.26.1`
- `diode-server/docker/Dockerfile-build.{auth,ingester,reconciler}` — `GO_VERSION=1.25` → `1.26`
- `.github/workflows/server-release.yaml` — `GO_VERSION: '1.25'` → `'1.26'`
- `.github/workflows/go-test.yaml` — `go-version: '1.25.x'` → `'1.26.x'`
- `.github/workflows/golangci-lint.yaml` — `go-version: '1.25.x'` → `'1.26.x'`

## Test plan

- [ ] Go tests pass with 1.26.1
- [ ] golangci-lint passes
- [ ] Docker builds succeed for all 3 services
- [ ] Container scan shows reduced vulnerabilities