### PR TITLE
fix: exclude metadata fields from entity hash computation

### DIFF
--- a/diode-server/entityhash/entityhash.go
+++ b/diode-server/entityhash/entityhash.go
@@ -3,6 +3,7 @@ package entityhash
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"github.com/gowebpki/jcs"
@@ -28,6 +29,7 @@ func NewEntityFingerprinter() *EntityFingerprinter {
 
 // GenerateEntityHash creates a SHA256 hash for an entity that includes the object type
 // and canonicalized entity content, excluding the timestamp from the outer envelope
+// and metadata fields from all entity types.
 func (f *EntityFingerprinter) GenerateEntityHash(entity *diodepb.Entity) (string, error) {
 	if entity == nil {
 		return "", fmt.Errorf("entity cannot be nil")
@@ -45,6 +47,14 @@ func (f *EntityFingerprinter) GenerateEntityHash(entity *diodepb.Entity) (string
 		return "", fmt.Errorf("failed to marshal entity: %w", err)
 	}
 
+	// Strip metadata fields before hashing — metadata is not part of entity
+	// identity and varies between ingestion runs (e.g. run_id), causing
+	// duplicate deviations for identical entity data.
+	entityJSON, err = stripMetadataFromJSON(entityJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip metadata from entity: %w", err)
+	}
+
 	return f.GenerateEntityHashFromJSON(entityJSON)
 }
 
@@ -60,4 +70,30 @@ func (f *EntityFingerprinter) GenerateEntityHashFromJSON(entityJSON []byte) (str
 	// Generate SHA256 hash
 	hash := sha256.Sum256(canonicalJSON)
 	return hex.EncodeToString(hash[:]), nil
+}
+
+// stripMetadataFromJSON removes all "metadata" keys from a JSON object
+// recursively, so that entity-level metadata does not affect the hash.
+func stripMetadataFromJSON(data []byte) ([]byte, error) {
+	var obj interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	stripMetadata(obj)
+	return json.Marshal(obj)
+}
+
+// stripMetadata recursively removes "metadata" keys from JSON objects.
+func stripMetadata(v interface{}) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		delete(val, "metadata")
+		for _, child := range val {
+			stripMetadata(child)
+		}
+	case []interface{}:
+		for _, item := range val {
+			stripMetadata(item)
+		}
+	}
 }

--- a/diode-server/entityhash/entityhash_test.go
+++ b/diode-server/entityhash/entityhash_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/netboxlabs/diode/diode-server/entityhash"
@@ -134,6 +135,127 @@ func TestEntityFingerprinter_BasicEntities(t *testing.T) {
 				},
 			},
 			shouldMatch: false,
+		},
+		{
+			name: "same device with different metadata produces same hash",
+			entity1: &diodepb.Entity{
+				Timestamp: timestamp,
+				Entity: &diodepb.Entity_Device{
+					Device: &diodepb.Device{
+						Name:   strPtr("device1"),
+						Serial: strPtr("serial123"),
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"run_id": structpb.NewStringValue("run-1"),
+							},
+						},
+					},
+				},
+			},
+			entity2: &diodepb.Entity{
+				Timestamp: timestamp,
+				Entity: &diodepb.Entity_Device{
+					Device: &diodepb.Device{
+						Name:   strPtr("device1"),
+						Serial: strPtr("serial123"),
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"run_id": structpb.NewStringValue("run-2"),
+							},
+						},
+					},
+				},
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "same device with and without metadata produces same hash",
+			entity1: &diodepb.Entity{
+				Timestamp: timestamp,
+				Entity: &diodepb.Entity_Device{
+					Device: &diodepb.Device{
+						Name:   strPtr("device1"),
+						Serial: strPtr("serial123"),
+					},
+				},
+			},
+			entity2: &diodepb.Entity{
+				Timestamp: timestamp,
+				Entity: &diodepb.Entity_Device{
+					Device: &diodepb.Device{
+						Name:   strPtr("device1"),
+						Serial: strPtr("serial123"),
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"run_id": structpb.NewStringValue("run-1"),
+							},
+						},
+					},
+				},
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "same site with different metadata produces same hash",
+			entity1: &diodepb.Entity{
+				Entity: &diodepb.Entity_Site{
+					Site: &diodepb.Site{
+						Name: "site1",
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"job_name": structpb.NewStringValue("job-a"),
+							},
+						},
+					},
+				},
+			},
+			entity2: &diodepb.Entity{
+				Entity: &diodepb.Entity_Site{
+					Site: &diodepb.Site{
+						Name: "site1",
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"job_name": structpb.NewStringValue("job-b"),
+							},
+						},
+					},
+				},
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "device with nested entity metadata produces same hash",
+			entity1: &diodepb.Entity{
+				Entity: &diodepb.Entity_Device{
+					Device: &diodepb.Device{
+						Name: strPtr("device1"),
+						Site: &diodepb.Site{
+							Name: "site1",
+							Metadata: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"run_id": structpb.NewStringValue("run-1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			entity2: &diodepb.Entity{
+				Entity: &diodepb.Entity_Device{
+					Device: &diodepb.Device{
+						Name: strPtr("device1"),
+						Site: &diodepb.Site{
+							Name: "site1",
+							Metadata: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"run_id": structpb.NewStringValue("run-2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldMatch: true,
 		},
 		{
 			name: "different entity types produce different hashes",

--- a/diode-server/entityhash/entityhash_test.go
+++ b/diode-server/entityhash/entityhash_test.go
@@ -229,6 +229,11 @@ func TestEntityFingerprinter_BasicEntities(t *testing.T) {
 				Entity: &diodepb.Entity_Device{
 					Device: &diodepb.Device{
 						Name: strPtr("device1"),
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"run_id": structpb.NewStringValue("run-1"),
+							},
+						},
 						Site: &diodepb.Site{
 							Name: "site1",
 							Metadata: &structpb.Struct{
@@ -244,6 +249,11 @@ func TestEntityFingerprinter_BasicEntities(t *testing.T) {
 				Entity: &diodepb.Entity_Device{
 					Device: &diodepb.Device{
 						Name: strPtr("device1"),
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"run_id": structpb.NewStringValue("run-2"),
+							},
+						},
 						Site: &diodepb.Site{
 							Name: "site1",
 							Metadata: &structpb.Struct{


### PR DESCRIPTION
## Summary
- Entity-level metadata varies between ingestion runs, causing identical entity data to produce different hashes and duplicate deviations in the assurance plugin
- Strips `metadata` fields recursively from serialized JSON in `GenerateEntityHash` before canonicalization and hashing, so entity identity is based solely on actual entity data
- Adds 4 test cases covering metadata exclusion: different metadata, with/without metadata, and nested entity metadata