### PR TITLE
Metadata persistence

### DIFF
--- a/diode-server/dbstore/postgres/graph_repository.go
+++ b/diode-server/dbstore/postgres/graph_repository.go
@@ -68,6 +68,7 @@ func toSnapshot(s postgres.GraphNodeSnapshot) graph.Snapshot {
 		SnapshotData:   json.RawMessage(s.SnapshotData),
 		SequenceNumber: s.SequenceNumber,
 		CreatedAt:      s.CreatedAt.Time,
+		Metadata:       json.RawMessage(s.Metadata),
 	}
 }
 
@@ -201,9 +202,14 @@ func (r *GraphRepository) FindNodeByContentHash(ctx context.Context, arg graph.F
 
 // InsertSnapshot implements graph.Repository.
 func (r *GraphRepository) InsertSnapshot(ctx context.Context, arg graph.InsertSnapshotParams) (graph.Snapshot, error) {
+	metadata := []byte(arg.Metadata)
+	if len(metadata) == 0 {
+		metadata = []byte("{}")
+	}
 	result, err := r.queries.InsertSnapshot(ctx, postgres.InsertSnapshotParams{
 		NodeID:       arg.NodeID,
 		SnapshotData: []byte(arg.SnapshotData),
+		Metadata:     metadata,
 	})
 	if err != nil {
 		return graph.Snapshot{}, err

--- a/diode-server/dbstore/postgres/migrations/20260331000001_add_snapshot_metadata.sql
+++ b/diode-server/dbstore/postgres/migrations/20260331000001_add_snapshot_metadata.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- Add metadata column to graph_node_snapshots so each snapshot preserves
+-- the metadata (including run_id) that was current at the time of ingestion.
+-- This prevents run_id loss when the same entity is upserted across multiple
+-- discovery runs, since the node-level metadata only stores the latest run_id.
+
+ALTER TABLE graph_node_snapshots
+    ADD COLUMN metadata jsonb NOT NULL DEFAULT '{}';
+
+-- GIN index allows efficient @> containment queries (e.g. filter by run_id)
+CREATE INDEX IF NOT EXISTS idx_graph_node_snapshots_metadata_gin
+    ON graph_node_snapshots USING GIN (metadata);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_graph_node_snapshots_metadata_gin;
+
+ALTER TABLE graph_node_snapshots
+    DROP COLUMN IF EXISTS metadata;

--- a/diode-server/dbstore/postgres/queries/graph.sql
+++ b/diode-server/dbstore/postgres/queries/graph.sql
@@ -180,21 +180,21 @@ LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 WITH lock AS (
     SELECT pg_advisory_xact_lock(1, $1::int)
 )
-INSERT INTO graph_node_snapshots (node_id, snapshot_data, sequence_number)
-SELECT $1, $2, COALESCE(MAX(sequence_number), 0) + 1
+INSERT INTO graph_node_snapshots (node_id, snapshot_data, sequence_number, metadata)
+SELECT $1, $2, COALESCE(MAX(sequence_number), 0) + 1, $3
 FROM graph_node_snapshots, lock
 WHERE node_id = $1
-RETURNING id, node_id, snapshot_data, sequence_number, created_at;
+RETURNING id, node_id, snapshot_data, sequence_number, created_at, metadata;
 
 -- name: GetLatestSnapshot :one
-SELECT id, node_id, snapshot_data, sequence_number, created_at
+SELECT id, node_id, snapshot_data, sequence_number, created_at, metadata
 FROM graph_node_snapshots
 WHERE node_id = $1
 ORDER BY sequence_number DESC
 LIMIT 1;
 
 -- name: GetSnapshotsByNode :many
-SELECT id, node_id, snapshot_data, sequence_number, created_at
+SELECT id, node_id, snapshot_data, sequence_number, created_at, metadata
 FROM graph_node_snapshots
 WHERE node_id = $1
 ORDER BY sequence_number DESC
@@ -232,6 +232,9 @@ LEFT JOIN LATERAL (
 WHERE n.node_type = $1 AND n.external_id = $2;
 
 -- name: ListNodes :many
+-- When metadata_filter is provided, filters by snapshot metadata (not node metadata)
+-- so that entities remain visible for the run that discovered them, even after
+-- a later run overwrites the node-level metadata.
 SELECT
     n.id, n.external_id, n.node_type,
     n.data AS matching_data, n.duplicate_count,
@@ -244,12 +247,13 @@ LEFT JOIN LATERAL (
     SELECT snapshot_data, sequence_number, created_at
     FROM graph_node_snapshots
     WHERE node_id = n.id
+      AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR metadata @> sqlc.narg('metadata_filter')::jsonb)
     ORDER BY sequence_number DESC
     LIMIT 1
 ) s ON true
 WHERE
     (n.node_type = ANY(sqlc.narg('node_types')::text[]) OR sqlc.narg('node_types')::text[] IS NULL)
-    AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR n.metadata @> sqlc.narg('metadata_filter')::jsonb)
+    AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR s.snapshot_data IS NOT NULL)
 ORDER BY n.updated_at DESC
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 

--- a/diode-server/dbstore/postgres/queries/graph.sql
+++ b/diode-server/dbstore/postgres/queries/graph.sql
@@ -232,16 +232,19 @@ LEFT JOIN LATERAL (
 WHERE n.node_type = $1 AND n.external_id = $2;
 
 -- name: ListNodes :many
--- When metadata_filter is provided, filters by snapshot metadata (not node metadata)
--- so that entities remain visible for the run that discovered them, even after
--- a later run overwrites the node-level metadata.
+-- When metadata_filter is provided, prefers snapshot metadata so that entities
+-- remain visible for the run that discovered them even after a later run
+-- overwrites the node-level metadata. Falls back to node-level metadata for
+-- entities whose snapshots lack the filtered key (e.g. Device references).
+-- Uses two lateral joins: s_filtered tries metadata-matched snapshots first,
+-- s_latest provides the most recent snapshot as fallback for entity data.
 SELECT
     n.id, n.external_id, n.node_type,
     n.data AS matching_data, n.duplicate_count,
     n.last_seen_ts, n.created_at, n.updated_at, n.metadata,
-    COALESCE(s.snapshot_data, '{}'::jsonb) AS snapshot_data,
-    COALESCE(s.sequence_number, 0) AS sequence_number,
-    s.created_at AS snapshot_created_at
+    COALESCE(s_filtered.snapshot_data, s_latest.snapshot_data, '{}'::jsonb) AS snapshot_data,
+    COALESCE(s_filtered.sequence_number, s_latest.sequence_number, 0) AS sequence_number,
+    COALESCE(s_filtered.created_at, s_latest.created_at) AS snapshot_created_at
 FROM graph_nodes n
 LEFT JOIN LATERAL (
     SELECT snapshot_data, sequence_number, created_at
@@ -250,10 +253,17 @@ LEFT JOIN LATERAL (
       AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR metadata @> sqlc.narg('metadata_filter')::jsonb)
     ORDER BY sequence_number DESC
     LIMIT 1
-) s ON true
+) s_filtered ON true
+LEFT JOIN LATERAL (
+    SELECT snapshot_data, sequence_number, created_at
+    FROM graph_node_snapshots
+    WHERE node_id = n.id
+    ORDER BY sequence_number DESC
+    LIMIT 1
+) s_latest ON s_filtered.snapshot_data IS NULL
 WHERE
     (n.node_type = ANY(sqlc.narg('node_types')::text[]) OR sqlc.narg('node_types')::text[] IS NULL)
-    AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR s.snapshot_data IS NOT NULL)
+    AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR s_filtered.snapshot_data IS NOT NULL OR n.metadata @> sqlc.narg('metadata_filter')::jsonb)
 ORDER BY n.updated_at DESC
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 

--- a/diode-server/gen/dbstore/postgres/graph.sql.go
+++ b/diode-server/gen/dbstore/postgres/graph.sql.go
@@ -628,7 +628,7 @@ func (q *Queries) GetGraphStatsByType(ctx context.Context) ([]GetGraphStatsByTyp
 }
 
 const getLatestSnapshot = `-- name: GetLatestSnapshot :one
-SELECT id, node_id, snapshot_data, sequence_number, created_at
+SELECT id, node_id, snapshot_data, sequence_number, created_at, metadata
 FROM graph_node_snapshots
 WHERE node_id = $1
 ORDER BY sequence_number DESC
@@ -644,6 +644,7 @@ func (q *Queries) GetLatestSnapshot(ctx context.Context, nodeID int64) (GraphNod
 		&i.SnapshotData,
 		&i.SequenceNumber,
 		&i.CreatedAt,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -753,7 +754,7 @@ func (q *Queries) GetNodesByFrequency(ctx context.Context, arg GetNodesByFrequen
 }
 
 const getSnapshotsByNode = `-- name: GetSnapshotsByNode :many
-SELECT id, node_id, snapshot_data, sequence_number, created_at
+SELECT id, node_id, snapshot_data, sequence_number, created_at, metadata
 FROM graph_node_snapshots
 WHERE node_id = $1
 ORDER BY sequence_number DESC
@@ -781,6 +782,7 @@ func (q *Queries) GetSnapshotsByNode(ctx context.Context, arg GetSnapshotsByNode
 			&i.SnapshotData,
 			&i.SequenceNumber,
 			&i.CreatedAt,
+			&i.Metadata,
 		); err != nil {
 			return nil, err
 		}
@@ -797,23 +799,24 @@ const insertSnapshot = `-- name: InsertSnapshot :one
 WITH lock AS (
     SELECT pg_advisory_xact_lock(1, $1::int)
 )
-INSERT INTO graph_node_snapshots (node_id, snapshot_data, sequence_number)
-SELECT $1, $2, COALESCE(MAX(sequence_number), 0) + 1
+INSERT INTO graph_node_snapshots (node_id, snapshot_data, sequence_number, metadata)
+SELECT $1, $2, COALESCE(MAX(sequence_number), 0) + 1, $3
 FROM graph_node_snapshots, lock
 WHERE node_id = $1
-RETURNING id, node_id, snapshot_data, sequence_number, created_at
+RETURNING id, node_id, snapshot_data, sequence_number, created_at, metadata
 `
 
 type InsertSnapshotParams struct {
 	NodeID       int64  `json:"node_id"`
 	SnapshotData []byte `json:"snapshot_data"`
+	Metadata     []byte `json:"metadata"`
 }
 
 // Snapshot management queries
 // Atomically inserts a snapshot with next sequence number using advisory lock to prevent races.
 // Uses namespaced lock (1=snapshot_insert, node_id) to avoid clashes with other advisory locks.
 func (q *Queries) InsertSnapshot(ctx context.Context, arg InsertSnapshotParams) (GraphNodeSnapshot, error) {
-	row := q.db.QueryRow(ctx, insertSnapshot, arg.NodeID, arg.SnapshotData)
+	row := q.db.QueryRow(ctx, insertSnapshot, arg.NodeID, arg.SnapshotData, arg.Metadata)
 	var i GraphNodeSnapshot
 	err := row.Scan(
 		&i.ID,
@@ -821,6 +824,7 @@ func (q *Queries) InsertSnapshot(ctx context.Context, arg InsertSnapshotParams) 
 		&i.SnapshotData,
 		&i.SequenceNumber,
 		&i.CreatedAt,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -838,12 +842,13 @@ LEFT JOIN LATERAL (
     SELECT snapshot_data, sequence_number, created_at
     FROM graph_node_snapshots
     WHERE node_id = n.id
+      AND ($2::jsonb IS NULL OR metadata @> $2::jsonb)
     ORDER BY sequence_number DESC
     LIMIT 1
 ) s ON true
 WHERE
     (n.node_type = ANY($1::text[]) OR $1::text[] IS NULL)
-    AND ($2::jsonb IS NULL OR n.metadata @> $2::jsonb)
+    AND ($2::jsonb IS NULL OR s.snapshot_data IS NOT NULL)
 ORDER BY n.updated_at DESC
 LIMIT $4 OFFSET $3
 `

--- a/diode-server/gen/dbstore/postgres/graph.sql.go
+++ b/diode-server/gen/dbstore/postgres/graph.sql.go
@@ -834,9 +834,9 @@ SELECT
     n.id, n.external_id, n.node_type,
     n.data AS matching_data, n.duplicate_count,
     n.last_seen_ts, n.created_at, n.updated_at, n.metadata,
-    COALESCE(s.snapshot_data, '{}'::jsonb) AS snapshot_data,
-    COALESCE(s.sequence_number, 0) AS sequence_number,
-    s.created_at AS snapshot_created_at
+    COALESCE(s_filtered.snapshot_data, s_latest.snapshot_data, '{}'::jsonb) AS snapshot_data,
+    COALESCE(s_filtered.sequence_number, s_latest.sequence_number, 0) AS sequence_number,
+    COALESCE(s_filtered.created_at, s_latest.created_at) AS snapshot_created_at
 FROM graph_nodes n
 LEFT JOIN LATERAL (
     SELECT snapshot_data, sequence_number, created_at
@@ -845,10 +845,17 @@ LEFT JOIN LATERAL (
       AND ($2::jsonb IS NULL OR metadata @> $2::jsonb)
     ORDER BY sequence_number DESC
     LIMIT 1
-) s ON true
+) s_filtered ON true
+LEFT JOIN LATERAL (
+    SELECT snapshot_data, sequence_number, created_at
+    FROM graph_node_snapshots
+    WHERE node_id = n.id
+    ORDER BY sequence_number DESC
+    LIMIT 1
+) s_latest ON s_filtered.snapshot_data IS NULL
 WHERE
     (n.node_type = ANY($1::text[]) OR $1::text[] IS NULL)
-    AND ($2::jsonb IS NULL OR s.snapshot_data IS NOT NULL)
+    AND ($2::jsonb IS NULL OR s_filtered.snapshot_data IS NOT NULL OR n.metadata @> $2::jsonb)
 ORDER BY n.updated_at DESC
 LIMIT $4 OFFSET $3
 `

--- a/diode-server/gen/dbstore/postgres/types.go
+++ b/diode-server/gen/dbstore/postgres/types.go
@@ -79,6 +79,7 @@ type GraphNodeSnapshot struct {
 	// Sequential number for ordering snapshots, higher is newer
 	SequenceNumber int32              `json:"sequence_number"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	Metadata       []byte             `json:"metadata"`
 }
 
 type IngestionLog struct {

--- a/diode-server/graph/service.go
+++ b/diode-server/graph/service.go
@@ -92,15 +92,25 @@ func NewService(repo Repository, logger *slog.Logger, opts ...Option) *Service {
 }
 
 // UpsertEntity processes an entity and creates/updates its graph representation recursively.
+// ResetBatchState clears state accumulated across UpsertEntity calls.
+// Call this between ingestion batches (e.g. between Redis messages) so that
+// snapshot deduplication does not span unrelated batches.
+func (s *Service) ResetBatchState() {
+	s.seenInThisRequest = make(map[string]bool)
+}
+
 func (s *Service) UpsertEntity(ctx context.Context, entity *diodepb.Entity, requestMetadata ...map[string]any) (*Node, error) {
 	if entity == nil || entity.GetEntity() == nil {
 		return nil, fmt.Errorf("entity or entity content is nil")
 	}
 
-	// Clear caches for each top-level extraction
+	// Clear per-entity-tree caches. seenInThisRequest is intentionally
+	// preserved across UpsertEntity calls so that entities referenced by
+	// multiple root entities (e.g. a Device referenced by 20 Interfaces)
+	// only get one snapshot per batch, preventing snapshot retention from
+	// purging older runs' snapshots.
 	s.nodeCache = make(map[string]*Node)
 	s.updatedNodes = make(map[string]*Node)
-	s.seenInThisRequest = make(map[string]bool)
 
 	// Store request-level metadata for merging during entity processing
 	s.requestMetadata = nil
@@ -283,15 +293,22 @@ func (s *Service) updateMatchedNode(ctx context.Context, bestMatch *matching.Mat
 	// Ensure source_match.diode_id is set to externalID for future lookups
 	metadata = s.ensureDiodeID(metadata, existingNode.ExternalID)
 
+	requestKey := fmt.Sprintf("%s:%s", nodeType, existingNode.ExternalID)
+	alreadySeen := s.seenInThisRequest[requestKey]
+
 	// Upsert the node with appropriate duplicate count handling
 	result, err := s.upsertMatchedNodeData(ctx, nodeType, existingNode.ExternalID, matchingData, metadata, contentHash)
 	if err != nil {
 		return nil, fmt.Errorf("updating matched node: %w", err)
 	}
 
-	// Create snapshot with full entity data and current metadata
-	if err := s.createSnapshot(ctx, result.ID, entityData, metadata); err != nil {
-		s.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
+	// Only snapshot the first time this node is seen in this request to avoid
+	// exhausting snapshot retention with redundant copies from nested references.
+	if !alreadySeen {
+		s.seenInThisRequest[requestKey] = true
+		if err := s.createSnapshot(ctx, result.ID, entityData, metadata); err != nil {
+			s.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
+		}
 	}
 
 	node := &Node{
@@ -412,11 +429,14 @@ func (s *Service) upsertNode(ctx context.Context, externalID, nodeType string, f
 		s.seenInThisRequest[requestKey] = true
 	}
 
-	// Create snapshot with full entity data and current metadata
-	err = s.createSnapshot(ctx, result.ID, fullEntityData, metadata)
-	if err != nil {
-		s.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
-		// Don't fail the entire operation for snapshot issues
+	// Only snapshot the first time this node is seen in this request to avoid
+	// exhausting snapshot retention with redundant copies from nested references.
+	if !alreadySeenInRequest {
+		err = s.createSnapshot(ctx, result.ID, fullEntityData, metadata)
+		if err != nil {
+			s.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
+			// Don't fail the entire operation for snapshot issues
+		}
 	}
 
 	return &Node{

--- a/diode-server/graph/service.go
+++ b/diode-server/graph/service.go
@@ -289,8 +289,8 @@ func (s *Service) updateMatchedNode(ctx context.Context, bestMatch *matching.Mat
 		return nil, fmt.Errorf("updating matched node: %w", err)
 	}
 
-	// Create snapshot with full entity data
-	if err := s.createSnapshot(ctx, result.ID, entityData); err != nil {
+	// Create snapshot with full entity data and current metadata
+	if err := s.createSnapshot(ctx, result.ID, entityData, metadata); err != nil {
 		s.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
 	}
 
@@ -412,8 +412,8 @@ func (s *Service) upsertNode(ctx context.Context, externalID, nodeType string, f
 		s.seenInThisRequest[requestKey] = true
 	}
 
-	// Create snapshot with full entity data
-	err = s.createSnapshot(ctx, result.ID, fullEntityData)
+	// Create snapshot with full entity data and current metadata
+	err = s.createSnapshot(ctx, result.ID, fullEntityData, metadata)
 	if err != nil {
 		s.logger.Warn("failed to create entity snapshot", "error", err, "node_id", result.ID)
 		// Don't fail the entire operation for snapshot issues
@@ -429,12 +429,14 @@ func (s *Service) upsertNode(ctx context.Context, externalID, nodeType string, f
 	}, nil
 }
 
-// createSnapshot creates a new snapshot for the given node with the full entity data.
-func (s *Service) createSnapshot(ctx context.Context, nodeID int64, fullEntityData json.RawMessage) error {
+// createSnapshot creates a new snapshot for the given node with the full entity data
+// and the metadata that was current at the time of ingestion (e.g. run_id).
+func (s *Service) createSnapshot(ctx context.Context, nodeID int64, fullEntityData, metadata json.RawMessage) error {
 	// Insert the new snapshot (sequence number is auto-computed by the SQL query)
 	_, err := s.repo.InsertSnapshot(ctx, InsertSnapshotParams{
 		NodeID:       nodeID,
 		SnapshotData: fullEntityData,
+		Metadata:     metadata,
 	})
 	if err != nil {
 		return fmt.Errorf("inserting snapshot: %w", err)

--- a/diode-server/graph/service.go
+++ b/diode-server/graph/service.go
@@ -91,7 +91,6 @@ func NewService(repo Repository, logger *slog.Logger, opts ...Option) *Service {
 	return s
 }
 
-// UpsertEntity processes an entity and creates/updates its graph representation recursively.
 // ResetBatchState clears state accumulated across UpsertEntity calls.
 // Call this between ingestion batches (e.g. between Redis messages) so that
 // snapshot deduplication does not span unrelated batches.
@@ -99,6 +98,7 @@ func (s *Service) ResetBatchState() {
 	s.seenInThisRequest = make(map[string]bool)
 }
 
+// UpsertEntity processes an entity and creates/updates its graph representation recursively.
 func (s *Service) UpsertEntity(ctx context.Context, entity *diodepb.Entity, requestMetadata ...map[string]any) (*Node, error) {
 	if entity == nil || entity.GetEntity() == nil {
 		return nil, fmt.Errorf("entity or entity content is nil")

--- a/diode-server/graph/service_test.go
+++ b/diode-server/graph/service_test.go
@@ -1218,3 +1218,40 @@ func TestFindNodeByContentHash_DatabaseError(t *testing.T) {
 
 	repo.AssertExpectations(t)
 }
+
+func TestResetBatchState_ClearsSeenState(t *testing.T) {
+	repo := new(mocks.Repository)
+	logger := newTestLogger()
+	gb := graph.NewService(repo, logger)
+
+	// Verify seenInThisRequest starts empty
+	assert.Empty(t, gb.TestSeenInThisRequest())
+
+	ctx := context.Background()
+
+	device := &diodepb.Device{
+		Name: ptrString("batch-device"),
+	}
+
+	// First call populates seenInThisRequest
+	repo.EXPECT().FindNodeByContentHash(ctx, mock.AnythingOfType("graph.FindNodeByContentHashParams")).
+		Return(graph.Node{}, graph.ErrNotFound).Once()
+	repo.EXPECT().UpsertNode(ctx, mock.AnythingOfType("graph.UpsertNodeParams")).
+		Return(graph.Node{ID: 1, ExternalID: "batch-hash", NodeType: "Device", Data: json.RawMessage(`{}`)}, nil).Once()
+	repo.EXPECT().InsertSnapshot(ctx, mock.AnythingOfType("graph.InsertSnapshotParams")).
+		Return(graph.Snapshot{}, nil).Once()
+	repo.EXPECT().CleanupOldSnapshots(ctx, mock.AnythingOfType("graph.CleanupOldSnapshotsParams")).
+		Return(nil).Once()
+
+	_, err := gb.UpsertEntity(ctx, &diodepb.Entity{Entity: &diodepb.Entity_Device{Device: device}})
+	require.NoError(t, err)
+
+	// seenInThisRequest should NOT be empty (preserved across UpsertEntity calls)
+	assert.NotEmpty(t, gb.TestSeenInThisRequest())
+
+	// ResetBatchState clears it
+	gb.ResetBatchState()
+	assert.Empty(t, gb.TestSeenInThisRequest())
+
+	repo.AssertExpectations(t)
+}

--- a/diode-server/graph/service_test.go
+++ b/diode-server/graph/service_test.go
@@ -954,6 +954,97 @@ func TestUpsertEntity_RequestMetadataMergedIntoUpsertNode(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestUpsertEntity_SnapshotReceivesMetadata(t *testing.T) {
+	repo := new(mocks.Repository)
+	logger := newTestLogger()
+	gb := graph.NewService(repo, logger)
+
+	ctx := context.Background()
+
+	device := &diodepb.Device{
+		Name: ptrString("snap-meta-device"),
+	}
+	entity := &diodepb.Entity{
+		Entity: &diodepb.Entity_Device{Device: device},
+	}
+
+	repo.EXPECT().FindNodeByContentHash(ctx, mock.AnythingOfType("graph.FindNodeByContentHashParams")).
+		Return(graph.Node{}, graph.ErrNotFound).Once()
+
+	repo.EXPECT().UpsertNode(ctx, mock.AnythingOfType("graph.UpsertNodeParams")).
+		Return(graph.Node{
+			ID:             42,
+			ExternalID:     "snap-hash",
+			NodeType:       "Device",
+			Data:           json.RawMessage(`{}`),
+			DuplicateCount: 1,
+		}, nil).Once()
+
+	// Verify the snapshot receives metadata containing run_id
+	repo.EXPECT().InsertSnapshot(ctx, mock.MatchedBy(func(params graph.InsertSnapshotParams) bool {
+		if params.NodeID != 42 {
+			return false
+		}
+		if len(params.Metadata) == 0 {
+			return false
+		}
+		var m map[string]any
+		if err := json.Unmarshal(params.Metadata, &m); err != nil {
+			return false
+		}
+		return m["run_id"] == "snapshot-run-1"
+	})).Return(graph.Snapshot{}, nil).Once()
+
+	repo.EXPECT().CleanupOldSnapshots(ctx, mock.AnythingOfType("graph.CleanupOldSnapshotsParams")).
+		Return(nil).Once()
+
+	_, err := gb.UpsertEntity(ctx, entity, map[string]any{"run_id": "snapshot-run-1"})
+	require.NoError(t, err)
+
+	repo.AssertExpectations(t)
+}
+
+func TestUpsertEntity_SnapshotMetadataEmpty_WhenNoRequestMetadata(t *testing.T) {
+	repo := new(mocks.Repository)
+	logger := newTestLogger()
+	gb := graph.NewService(repo, logger)
+
+	ctx := context.Background()
+
+	device := &diodepb.Device{
+		Name: ptrString("no-meta-device"),
+	}
+	entity := &diodepb.Entity{
+		Entity: &diodepb.Entity_Device{Device: device},
+	}
+
+	repo.EXPECT().FindNodeByContentHash(ctx, mock.AnythingOfType("graph.FindNodeByContentHashParams")).
+		Return(graph.Node{}, graph.ErrNotFound).Once()
+
+	repo.EXPECT().UpsertNode(ctx, mock.AnythingOfType("graph.UpsertNodeParams")).
+		Return(graph.Node{
+			ID:             99,
+			ExternalID:     "no-meta-hash",
+			NodeType:       "Device",
+			Data:           json.RawMessage(`{}`),
+			DuplicateCount: 1,
+		}, nil).Once()
+
+	// Without request metadata the snapshot should still get metadata
+	// (containing at least source_match.diode_id from ensureDiodeID)
+	repo.EXPECT().InsertSnapshot(ctx, mock.MatchedBy(func(params graph.InsertSnapshotParams) bool {
+		return params.NodeID == 99 && len(params.Metadata) > 0
+	})).Return(graph.Snapshot{}, nil).Once()
+
+	repo.EXPECT().CleanupOldSnapshots(ctx, mock.AnythingOfType("graph.CleanupOldSnapshotsParams")).
+		Return(nil).Once()
+
+	_, err := gb.UpsertEntity(ctx, entity)
+	require.NoError(t, err)
+
+	repo.AssertExpectations(t)
+}
+
 func TestFindNodeByExternalID(t *testing.T) {
 	repo := new(mocks.Repository)
 	logger := newTestLogger()

--- a/diode-server/graph/types.go
+++ b/diode-server/graph/types.go
@@ -30,6 +30,7 @@ type Snapshot struct {
 	SnapshotData   json.RawMessage `json:"snapshot_data"`
 	SequenceNumber int32           `json:"sequence_number"`
 	CreatedAt      time.Time       `json:"created_at"`
+	Metadata       json.RawMessage `json:"metadata"`
 }
 
 // Edge represents an edge between two nodes.
@@ -145,6 +146,7 @@ type FindNodeByContentHashParams struct {
 type InsertSnapshotParams struct {
 	NodeID       int64
 	SnapshotData json.RawMessage
+	Metadata     json.RawMessage
 }
 
 // CleanupOldSnapshotsParams contains parameters for cleaning up old snapshots.

--- a/diode-server/reconciler/ingestion_processor.go
+++ b/diode-server/reconciler/ingestion_processor.go
@@ -395,6 +395,13 @@ func (p *IngestionProcessor) ApplyChangeSet(ctx context.Context, applyChan <-cha
 func (p *IngestionProcessor) CreateIngestionLogs(ctx context.Context, ingestReq *diodepb.IngestRequest, ingestionTs int, generateIngestionLogChan chan<- IngestionLogToProcess) []error {
 	defer close(generateIngestionLogChan)
 
+	// Reset graph snapshot deduplication state so each batch (IngestRequest)
+	// starts fresh, while entities within the same batch share state to avoid
+	// redundant snapshots for multiply-referenced entities (e.g. Device).
+	if p.graphService != nil {
+		p.graphService.ResetBatchState()
+	}
+
 	errs := make([]error, 0)
 
 	// Ensure the current default branch is retrieved


### PR DESCRIPTION
This pull request introduces support for storing and querying per-snapshot metadata in the graph node snapshot system. The main motivation is to ensure that metadata such as `run_id` is preserved for each snapshot, preventing data loss when the same entity is upserted across multiple discovery runs. The changes span database schema, queries, Go data models, service logic, and tests.

**Database schema and query changes:**

* Added a new `metadata` JSONB column to the `graph_node_snapshots` table, with a GIN index for efficient filtering by metadata fields like `run_id`. This allows each snapshot to store the metadata that was current at the time of ingestion.
* Updated all relevant SQL queries and generated Go code to handle the new `metadata` column, including snapshot insertion, retrieval, and filtering. The `ListNodes` query now prefers snapshot metadata when filtering, falling back to node-level metadata only when necessary. [[1]](diffhunk://#diff-9b5ef796a33386a1b39c4b9d1d379db6fd48766a5a1c2b2885075a5a9fcd5236L183-R197) [[2]](diffhunk://#diff-9b5ef796a33386a1b39c4b9d1d379db6fd48766a5a1c2b2885075a5a9fcd5236R235-R266) [[3]](diffhunk://#diff-53b4b91db25217d35523120f845ff039a07015132014af144c8521a6fc4ec3b0L631-R631) [[4]](diffhunk://#diff-53b4b91db25217d35523120f845ff039a07015132014af144c8521a6fc4ec3b0R647) [[5]](diffhunk://#diff-53b4b91db25217d35523120f845ff039a07015132014af144c8521a6fc4ec3b0L756-R757) [[6]](diffhunk://#diff-53b4b91db25217d35523120f845ff039a07015132014af144c8521a6fc4ec3b0R785) [[7]](diffhunk://#diff-53b4b91db25217d35523120f845ff039a07015132014af144c8521a6fc4ec3b0L800-R827) [[8]](diffhunk://#diff-53b4b91db25217d35523120f845ff039a07015132014af144c8521a6fc4ec3b0L833-R858)

**Go data model and repository changes:**

* Extended the `Snapshot`, `GraphNodeSnapshot`, and `InsertSnapshotParams` structs to include a `Metadata` field, ensuring metadata is passed through all layers of the application. [[1]](diffhunk://#diff-9c422544f6aa91f7ffe837949b1de5ec3adec927d8e773fa3faf343a18941107R33) [[2]](diffhunk://#diff-4c5dcf528b97eb804c11e53d55cf48dcb92e596428c47fcd8477501f17f10018R82) [[3]](diffhunk://#diff-9c422544f6aa91f7ffe837949b1de5ec3adec927d8e773fa3faf343a18941107R149) [[4]](diffhunk://#diff-563358b5d57aaf2de92f228f47d47aff161c4d1e23e24694d937b2124a79122aR71)
* Modified the repository insert and retrieval logic to handle the new metadata field, including defaulting to an empty JSON object if no metadata is provided.

**Service logic improvements:**

* Updated the snapshot creation logic in the graph service to include metadata with each snapshot, ensuring the metadata at the time of ingestion is preserved. [[1]](diffhunk://#diff-cf652b03535215d5385834c130aafc22ffbd0106b87883e45fd7199bce8b5168R296-R312) [[2]](diffhunk://#diff-cf652b03535215d5385834c130aafc22ffbd0106b87883e45fd7199bce8b5168L415-R440) [[3]](diffhunk://#diff-cf652b03535215d5385834c130aafc22ffbd0106b87883e45fd7199bce8b5168L432-R459)
* Added a `ResetBatchState` method to the service to allow clearing of per-batch deduplication state, ensuring snapshot deduplication does not span unrelated ingestion batches.
* Adjusted deduplication logic so that snapshots are only created once per node per batch, preventing redundant copies. [[1]](diffhunk://#diff-cf652b03535215d5385834c130aafc22ffbd0106b87883e45fd7199bce8b5168R296-R312) [[2]](diffhunk://#diff-cf652b03535215d5385834c130aafc22ffbd0106b87883e45fd7199bce8b5168L415-R440)

**Testing:**

* Added comprehensive tests to verify that snapshots correctly receive metadata, including cases with and without request metadata, and that batch state is properly reset between batches. [[1]](diffhunk://#diff-bbc8e0dbe62c9db5946916cb70e2386a6f00d49f816c70e3a8f09a3e86e728ebR957-R1047) [[2]](diffhunk://#diff-bbc8e0dbe62c9db5946916cb70e2386a6f00d49f816c70e3a8f09a3e86e728ebR1221-R1257)