### PR TITLE
fix: gracefully handle fork PR comment permissions

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -131,6 +131,7 @@ jobs:
             fs.writeFileSync('scan-result.json', artifact);
 
       - name: Post scan results as PR comment
+        continue-on-error: true  # Fork PRs have read-only tokens and cannot post comments
         if: github.event_name == 'pull_request'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:


### PR DESCRIPTION
PRs from forks run with a read-only GITHUB_TOKEN, which prevents posting PR comments (403). Add `continue-on-error: true` to the comment step so it fails gracefully without blocking the scan. Results remain visible in the step summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)