### PR TITLE
fix: set MaxIdleConnsPerHost for NetBox HTTP client connection reuse

### DIFF
--- a/diode-server/netboxdiodeplugin/client.go
+++ b/diode-server/netboxdiodeplugin/client.go
@@ -128,6 +128,7 @@ func NewHTTPTransport() *http.Transport {
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
## Summary

Go's `net/http` defaults `Transport.MaxIdleConnsPerHost` to **2**, while we configure `MaxIdleConns` to 100. Because the reconciler talks to a single host (the NetBox plugin API), the per-host cap is the effective ceiling — only 2 idle connections are ever kept warm, regardless of `MaxIdleConns`.

Under concurrent batched ingestion (many goroutines calling NetBox simultaneously), this means:
- Connections beyond the per-host limit get torn down right after use
- Each new request pays the full TCP + TLS handshake cost
- The connection pool never reaches its configured size

This PR sets `MaxIdleConnsPerHost: 100` to match `MaxIdleConns`, so the pool can actually scale to the configured capacity against a single host.

## Performance improvements

* **Eliminates connection churn** under concurrent load — idle connections stay warm and get reused
* **Removes per-request TLS handshake overhead** for the dominant case (single NetBox host, many concurrent callers)
* **No effect when traffic is low** — the pool simply doesn't grow large; this only kicks in under concurrency

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean (0 issues)
- [x] `go test ./diode-server/netboxdiodeplugin/...` passes

## Merge order

Part of the ingestion throughput series. Independent — can merge in any order relative to other foundational PRs.