### PR TITLE
perf: optimize DB throughput — bulk COPY, pre-allocated IDs, unnest queries

### DIFF
--- a/diode-server/dbstore/postgres/migrations/20260505000001_optimize_ingestion_log_claim.sql
+++ b/diode-server/dbstore/postgres/migrations/20260505000001_optimize_ingestion_log_claim.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+
+-- Replace single-column state index with composite (state, id) to support
+-- efficient ORDER BY id LIMIT N scans in ClaimQueuedIngestionLogs.
+DROP INDEX IF EXISTS idx_ingestion_logs_state;
+CREATE INDEX IF NOT EXISTS idx_ingestion_logs_state_id ON ingestion_logs (state, id);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_ingestion_logs_state_id;
+CREATE INDEX IF NOT EXISTS idx_ingestion_logs_state ON ingestion_logs (state);

--- a/diode-server/dbstore/postgres/queries/change_sets.sql
+++ b/diode-server/dbstore/postgres/queries/change_sets.sql
@@ -12,6 +12,12 @@ INSERT INTO changes (external_id, change_set_id, change_type, object_type, objec
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 RETURNING *;
 
+-- name: BulkCreateChanges :copyfrom
+INSERT INTO changes (external_id, change_set_id, change_type, object_type, object_primary_value, object_id,
+                     ref_id, object_version, before, after, new_refs,
+                     sequence_number)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
+
 -- name: TruncateChangeSets :exec
 DELETE FROM change_sets cs1
 WHERE cs1.ingestion_log_id = $1

--- a/diode-server/dbstore/postgres/queries/ingestion_logs.sql
+++ b/diode-server/dbstore/postgres/queries/ingestion_logs.sql
@@ -65,24 +65,28 @@ SET duplicate_count = duplicate_count + 1,
 WHERE id = $1;
 
 -- name: FindPriorIngestionLogsByEntityHashes :many
-SELECT DISTINCT ON (il.entity_hash) il.*
-FROM ingestion_logs il
-LEFT JOIN LATERAL (
-    SELECT branch_id
-    FROM change_sets cs
-    WHERE cs.ingestion_log_id = il.id
-    ORDER BY cs.id DESC
+SELECT il.*
+FROM unnest(@entity_hashes::text[]) AS h(entity_hash)
+CROSS JOIN LATERAL (
+    SELECT il2.*
+    FROM ingestion_logs il2
+    WHERE il2.entity_hash = h.entity_hash
+      AND (
+          SELECT cs.branch_id
+          FROM change_sets cs
+          WHERE cs.ingestion_log_id = il2.id
+          ORDER BY cs.id DESC
+          LIMIT 1
+      ) IS NOT DISTINCT FROM sqlc.narg('branch_id')::text
+    ORDER BY il2.created_at DESC
     LIMIT 1
-) lcs ON true
-WHERE il.entity_hash = ANY(@entity_hashes::text[])
-  AND lcs.branch_id IS NOT DISTINCT FROM sqlc.narg('branch_id')::text
-ORDER BY il.entity_hash, il.created_at DESC;
+) il;
 
 -- name: BulkCreateIngestionLogs :copyfrom
-INSERT INTO ingestion_logs (external_id, object_type, state, request_id, ingestion_ts, source_ts,
+INSERT INTO ingestion_logs (id, external_id, object_type, state, request_id, ingestion_ts, source_ts,
                             producer_app_name, producer_app_version, sdk_name, sdk_version,
                             entity, source_metadata, entity_hash)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);
 
 -- name: FindIngestionLogIDsByExternalIDs :many
 SELECT id, external_id FROM ingestion_logs WHERE external_id = ANY(@external_ids::text[]);
@@ -92,3 +96,15 @@ UPDATE ingestion_logs
 SET duplicate_count = duplicate_count + 1,
     last_seen = CURRENT_TIMESTAMP
 WHERE id = ANY(@ids::int4[]);
+
+-- name: ClaimQueuedIngestionLogs :many
+UPDATE ingestion_logs
+SET state = 2
+WHERE id IN (
+    SELECT id FROM ingestion_logs
+    WHERE state = 1
+    ORDER BY id
+    LIMIT sqlc.arg('batch_size')
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING *;

--- a/diode-server/dbstore/postgres/repository.go
+++ b/diode-server/dbstore/postgres/repository.go
@@ -269,6 +269,7 @@ func (r *Repository) CreateChangeSet(ctx context.Context, changeSet changeset.Ch
 		return nil, fmt.Errorf("failed to create change set: %w", err)
 	}
 
+	bulkParams := make([]postgres.BulkCreateChangesParams, 0, len(changeSet.Changes))
 	for i, change := range changeSet.Changes {
 		beforeJSON, err := json.Marshal(change.Before)
 		if err != nil {
@@ -282,7 +283,7 @@ func (r *Repository) CreateChangeSet(ctx context.Context, changeSet changeset.Ch
 			return nil, fmt.Errorf("failed to marshal after state: %w", err)
 		}
 
-		changeParams := postgres.CreateChangeParams{
+		p := postgres.BulkCreateChangesParams{
 			ExternalID:         change.ID,
 			ChangeSetID:        cs.ID,
 			ChangeType:         change.ChangeType,
@@ -294,19 +295,20 @@ func (r *Repository) CreateChangeSet(ctx context.Context, changeSet changeset.Ch
 			SequenceNumber:     pgtype.Int4{Int32: int32(i), Valid: true},
 		}
 		if change.ObjectID != nil {
-			changeParams.ObjectID = pgtype.Int4{Int32: int32(*change.ObjectID), Valid: true}
+			p.ObjectID = pgtype.Int4{Int32: int32(*change.ObjectID), Valid: true}
 		}
 		if change.ObjectVersion != nil {
-			changeParams.ObjectVersion = pgtype.Int4{Int32: int32(*change.ObjectVersion), Valid: true}
+			p.ObjectVersion = pgtype.Int4{Int32: int32(*change.ObjectVersion), Valid: true}
 		}
 		if change.RefID != nil {
-			changeParams.RefID = pgtype.Text{String: *change.RefID, Valid: true}
+			p.RefID = pgtype.Text{String: *change.RefID, Valid: true}
 		}
+		bulkParams = append(bulkParams, p)
+	}
 
-		if _, err = qtx.CreateChange(ctx, changeParams); err != nil {
-			rollback()
-			return nil, fmt.Errorf("failed to create change: %w", err)
-		}
+	if _, err = qtx.BulkCreateChanges(ctx, bulkParams); err != nil {
+		rollback()
+		return nil, fmt.Errorf("failed to bulk create changes: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -503,16 +505,23 @@ func (r *Repository) FindPriorIngestionLogsByEntityHashes(ctx context.Context, e
 }
 
 // BulkCreateIngestionLogs bulk inserts ingestion logs using the COPY protocol.
-func (r *Repository) BulkCreateIngestionLogs(ctx context.Context, logs []*reconcilerpb.IngestionLog, sourceMetadata [][]byte, entityHashes []string) (int64, error) {
+// It pre-allocates sequence IDs and returns a map of external_id → id.
+func (r *Repository) BulkCreateIngestionLogs(ctx context.Context, logs []*reconcilerpb.IngestionLog, sourceMetadata [][]byte, entityHashes []string) (map[string]int32, error) {
+	ids, err := r.allocateIngestionLogIDs(ctx, len(logs))
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate IDs: %w", err)
+	}
+
 	marshaler := protojson.MarshalOptions{
 		UseProtoNames: true,
 	}
 
 	params := make([]postgres.BulkCreateIngestionLogsParams, 0, len(logs))
+	idMap := make(map[string]int32, len(logs))
 	for i, log := range logs {
 		entityJSON, err := marshaler.Marshal(log.Entity)
 		if err != nil {
-			return 0, fmt.Errorf("failed to marshal entity at index %d: %w", i, err)
+			return nil, fmt.Errorf("failed to marshal entity at index %d: %w", i, err)
 		}
 
 		var sm []byte
@@ -521,6 +530,7 @@ func (r *Repository) BulkCreateIngestionLogs(ctx context.Context, logs []*reconc
 		}
 
 		params = append(params, postgres.BulkCreateIngestionLogsParams{
+			ID:                 ids[i],
 			ExternalID:         log.Id,
 			ObjectType:         pgtype.Text{String: log.ObjectType, Valid: true},
 			State:              pgtype.Int4{Int32: int32(log.State), Valid: true},
@@ -535,26 +545,55 @@ func (r *Repository) BulkCreateIngestionLogs(ctx context.Context, logs []*reconc
 			SourceMetadata:     sm,
 			EntityHash:         pgtype.Text{String: entityHashes[i], Valid: true},
 		})
+		idMap[log.Id] = ids[i]
 	}
 
-	return r.queries.BulkCreateIngestionLogs(ctx, params)
+	if _, err := r.queries.BulkCreateIngestionLogs(ctx, params); err != nil {
+		return nil, err
+	}
+	return idMap, nil
 }
 
-// FindIngestionLogIDsByExternalIDs returns a map of external_id → id for the given external IDs.
-func (r *Repository) FindIngestionLogIDsByExternalIDs(ctx context.Context, externalIDs []string) (map[string]int32, error) {
-	rows, err := r.queries.FindIngestionLogIDsByExternalIDs(ctx, externalIDs)
+func (r *Repository) allocateIngestionLogIDs(ctx context.Context, n int) ([]int32, error) {
+	rows, err := r.pool.Query(ctx, "SELECT nextval('ingestion_logs_id_seq')::int4 FROM generate_series(1, $1)", n)
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
-	result := make(map[string]int32, len(rows))
-	for _, row := range rows {
-		result[row.ExternalID] = row.ID
+	ids := make([]int32, 0, n)
+	for rows.Next() {
+		var id int32
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
 	}
-	return result, nil
+	return ids, rows.Err()
 }
 
 // BulkIncrementDuplicateCounts increments the duplicate count for multiple ingestion logs.
 func (r *Repository) BulkIncrementDuplicateCounts(ctx context.Context, ids []int32) error {
 	return r.queries.BulkIncrementDuplicateCounts(ctx, ids)
+}
+
+// ClaimQueuedIngestionLogs returns a batch of ingestion logs in QUEUED state for processing.
+func (r *Repository) ClaimQueuedIngestionLogs(ctx context.Context, batchSize int32) ([]ops.QueuedIngestionLog, error) {
+	dbLogs, err := r.queries.ClaimQueuedIngestionLogs(ctx, batchSize)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]ops.QueuedIngestionLog, 0, len(dbLogs))
+	for _, dbLog := range dbLogs {
+		log, err := dbLog.ToProto()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to proto: %w", err)
+		}
+		result = append(result, ops.QueuedIngestionLog{
+			ID:           dbLog.ID,
+			IngestionLog: log,
+		})
+	}
+	return result, nil
 }

--- a/diode-server/gen/dbstore/postgres/change_sets.sql.go
+++ b/diode-server/gen/dbstore/postgres/change_sets.sql.go
@@ -12,6 +12,21 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type BulkCreateChangesParams struct {
+	ExternalID         string          `json:"external_id"`
+	ChangeSetID        int32           `json:"change_set_id"`
+	ChangeType         string          `json:"change_type"`
+	ObjectType         string          `json:"object_type"`
+	ObjectPrimaryValue string          `json:"object_primary_value"`
+	ObjectID           pgtype.Int4     `json:"object_id"`
+	RefID              pgtype.Text     `json:"ref_id"`
+	ObjectVersion      pgtype.Int4     `json:"object_version"`
+	Before             json.RawMessage `json:"before"`
+	After              json.RawMessage `json:"after"`
+	NewRefs            []string        `json:"new_refs"`
+	SequenceNumber     pgtype.Int4     `json:"sequence_number"`
+}
+
 const createChange = `-- name: CreateChange :one
 
 INSERT INTO changes (external_id, change_set_id, change_type, object_type, object_primary_value, object_id,

--- a/diode-server/gen/dbstore/postgres/copyfrom.go
+++ b/diode-server/gen/dbstore/postgres/copyfrom.go
@@ -9,6 +9,49 @@ import (
 	"context"
 )
 
+// iteratorForBulkCreateChanges implements pgx.CopyFromSource.
+type iteratorForBulkCreateChanges struct {
+	rows                 []BulkCreateChangesParams
+	skippedFirstNextCall bool
+}
+
+func (r *iteratorForBulkCreateChanges) Next() bool {
+	if len(r.rows) == 0 {
+		return false
+	}
+	if !r.skippedFirstNextCall {
+		r.skippedFirstNextCall = true
+		return true
+	}
+	r.rows = r.rows[1:]
+	return len(r.rows) > 0
+}
+
+func (r iteratorForBulkCreateChanges) Values() ([]interface{}, error) {
+	return []interface{}{
+		r.rows[0].ExternalID,
+		r.rows[0].ChangeSetID,
+		r.rows[0].ChangeType,
+		r.rows[0].ObjectType,
+		r.rows[0].ObjectPrimaryValue,
+		r.rows[0].ObjectID,
+		r.rows[0].RefID,
+		r.rows[0].ObjectVersion,
+		r.rows[0].Before,
+		r.rows[0].After,
+		r.rows[0].NewRefs,
+		r.rows[0].SequenceNumber,
+	}, nil
+}
+
+func (r iteratorForBulkCreateChanges) Err() error {
+	return nil
+}
+
+func (q *Queries) BulkCreateChanges(ctx context.Context, arg []BulkCreateChangesParams) (int64, error) {
+	return q.db.CopyFrom(ctx, []string{"changes"}, []string{"external_id", "change_set_id", "change_type", "object_type", "object_primary_value", "object_id", "ref_id", "object_version", "before", "after", "new_refs", "sequence_number"}, &iteratorForBulkCreateChanges{rows: arg})
+}
+
 // iteratorForBulkCreateIngestionLogs implements pgx.CopyFromSource.
 type iteratorForBulkCreateIngestionLogs struct {
 	rows                 []BulkCreateIngestionLogsParams
@@ -29,6 +72,7 @@ func (r *iteratorForBulkCreateIngestionLogs) Next() bool {
 
 func (r iteratorForBulkCreateIngestionLogs) Values() ([]interface{}, error) {
 	return []interface{}{
+		r.rows[0].ID,
 		r.rows[0].ExternalID,
 		r.rows[0].ObjectType,
 		r.rows[0].State,
@@ -50,5 +94,5 @@ func (r iteratorForBulkCreateIngestionLogs) Err() error {
 }
 
 func (q *Queries) BulkCreateIngestionLogs(ctx context.Context, arg []BulkCreateIngestionLogsParams) (int64, error) {
-	return q.db.CopyFrom(ctx, []string{"ingestion_logs"}, []string{"external_id", "object_type", "state", "request_id", "ingestion_ts", "source_ts", "producer_app_name", "producer_app_version", "sdk_name", "sdk_version", "entity", "source_metadata", "entity_hash"}, &iteratorForBulkCreateIngestionLogs{rows: arg})
+	return q.db.CopyFrom(ctx, []string{"ingestion_logs"}, []string{"id", "external_id", "object_type", "state", "request_id", "ingestion_ts", "source_ts", "producer_app_name", "producer_app_version", "sdk_name", "sdk_version", "entity", "source_metadata", "entity_hash"}, &iteratorForBulkCreateIngestionLogs{rows: arg})
 }

--- a/diode-server/gen/dbstore/postgres/ingestion_logs.sql.go
+++ b/diode-server/gen/dbstore/postgres/ingestion_logs.sql.go
@@ -13,6 +13,7 @@ import (
 )
 
 type BulkCreateIngestionLogsParams struct {
+	ID                 int32       `json:"id"`
 	ExternalID         string      `json:"external_id"`
 	ObjectType         pgtype.Text `json:"object_type"`
 	State              pgtype.Int4 `json:"state"`
@@ -38,6 +39,59 @@ WHERE id = ANY($1::int4[])
 func (q *Queries) BulkIncrementDuplicateCounts(ctx context.Context, ids []int32) error {
 	_, err := q.db.Exec(ctx, bulkIncrementDuplicateCounts, ids)
 	return err
+}
+
+const claimQueuedIngestionLogs = `-- name: ClaimQueuedIngestionLogs :many
+UPDATE ingestion_logs
+SET state = 2
+WHERE id IN (
+    SELECT id FROM ingestion_logs
+    WHERE state = 1
+    ORDER BY id
+    LIMIT $1
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING id, external_id, object_type, state, request_id, ingestion_ts, source_ts, producer_app_name, producer_app_version, sdk_name, sdk_version, entity, error, source_metadata, created_at, updated_at, entity_hash, last_seen, duplicate_count
+`
+
+func (q *Queries) ClaimQueuedIngestionLogs(ctx context.Context, batchSize int32) ([]IngestionLog, error) {
+	rows, err := q.db.Query(ctx, claimQueuedIngestionLogs, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []IngestionLog
+	for rows.Next() {
+		var i IngestionLog
+		if err := rows.Scan(
+			&i.ID,
+			&i.ExternalID,
+			&i.ObjectType,
+			&i.State,
+			&i.RequestID,
+			&i.IngestionTs,
+			&i.SourceTs,
+			&i.ProducerAppName,
+			&i.ProducerAppVersion,
+			&i.SdkName,
+			&i.SdkVersion,
+			&i.Entity,
+			&i.Error,
+			&i.SourceMetadata,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.EntityHash,
+			&i.LastSeen,
+			&i.DuplicateCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const countIngestionLogsPerState = `-- name: CountIngestionLogsPerState :many
@@ -213,18 +267,22 @@ func (q *Queries) FindPriorIngestionLogByEntityHash(ctx context.Context, arg Fin
 }
 
 const findPriorIngestionLogsByEntityHashes = `-- name: FindPriorIngestionLogsByEntityHashes :many
-SELECT DISTINCT ON (il.entity_hash) il.id, il.external_id, il.object_type, il.state, il.request_id, il.ingestion_ts, il.source_ts, il.producer_app_name, il.producer_app_version, il.sdk_name, il.sdk_version, il.entity, il.error, il.source_metadata, il.created_at, il.updated_at, il.entity_hash, il.last_seen, il.duplicate_count
-FROM ingestion_logs il
-LEFT JOIN LATERAL (
-    SELECT branch_id
-    FROM change_sets cs
-    WHERE cs.ingestion_log_id = il.id
-    ORDER BY cs.id DESC
+SELECT il.id, il.external_id, il.object_type, il.state, il.request_id, il.ingestion_ts, il.source_ts, il.producer_app_name, il.producer_app_version, il.sdk_name, il.sdk_version, il.entity, il.error, il.source_metadata, il.created_at, il.updated_at, il.entity_hash, il.last_seen, il.duplicate_count
+FROM unnest($1::text[]) AS h(entity_hash)
+CROSS JOIN LATERAL (
+    SELECT il2.id, il2.external_id, il2.object_type, il2.state, il2.request_id, il2.ingestion_ts, il2.source_ts, il2.producer_app_name, il2.producer_app_version, il2.sdk_name, il2.sdk_version, il2.entity, il2.error, il2.source_metadata, il2.created_at, il2.updated_at, il2.entity_hash, il2.last_seen, il2.duplicate_count
+    FROM ingestion_logs il2
+    WHERE il2.entity_hash = h.entity_hash
+      AND (
+          SELECT cs.branch_id
+          FROM change_sets cs
+          WHERE cs.ingestion_log_id = il2.id
+          ORDER BY cs.id DESC
+          LIMIT 1
+      ) IS NOT DISTINCT FROM $2::text
+    ORDER BY il2.created_at DESC
     LIMIT 1
-) lcs ON true
-WHERE il.entity_hash = ANY($1::text[])
-  AND lcs.branch_id IS NOT DISTINCT FROM $2::text
-ORDER BY il.entity_hash, il.created_at DESC
+) il
 `
 
 type FindPriorIngestionLogsByEntityHashesParams struct {

--- a/diode-server/reconciler/ingestion_processor_internal_test.go
+++ b/diode-server/reconciler/ingestion_processor_internal_test.go
@@ -230,12 +230,11 @@ func TestHandleStreamMessage(t *testing.T) {
 			if tt.entities[0].Entity != nil {
 				// Bulk path mocks
 				mockRepository.On("FindPriorIngestionLogsByEntityHashes", mock.Anything, mock.Anything, mock.Anything).Return(map[string]*ops.PriorIngestionLog{}, nil)
-				mockRepository.On("BulkCreateIngestionLogs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
-				mockRepository.On("FindIngestionLogIDsByExternalIDs", mock.Anything, mock.Anything).Return(
-					func(_ context.Context, externalIDs []string) map[string]int32 {
-						result := make(map[string]int32, len(externalIDs))
-						for _, id := range externalIDs {
-							result[id] = 1
+				mockRepository.On("BulkCreateIngestionLogs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+					func(_ context.Context, logs []*reconcilerpb.IngestionLog, _ [][]byte, _ []string) map[string]int32 {
+						result := make(map[string]int32, len(logs))
+						for _, log := range logs {
+							result[log.Id] = 1
 						}
 						return result
 					}, nil)
@@ -406,12 +405,11 @@ func TestHandleStreamMessageLegacyUncompressed(t *testing.T) {
 		},
 	}, nil)
 	mockRepository.On("FindPriorIngestionLogsByEntityHashes", mock.Anything, mock.Anything, mock.Anything).Return(map[string]*ops.PriorIngestionLog{}, nil)
-	mockRepository.On("BulkCreateIngestionLogs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
-	mockRepository.On("FindIngestionLogIDsByExternalIDs", mock.Anything, mock.Anything).Return(
-		func(_ context.Context, externalIDs []string) map[string]int32 {
-			result := make(map[string]int32, len(externalIDs))
-			for _, id := range externalIDs {
-				result[id] = 1
+	mockRepository.On("BulkCreateIngestionLogs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		func(_ context.Context, logs []*reconcilerpb.IngestionLog, _ [][]byte, _ []string) map[string]int32 {
+			result := make(map[string]int32, len(logs))
+			for _, log := range logs {
+				result[log.Id] = 1
 			}
 			return result
 		}, nil)

--- a/diode-server/reconciler/ingestion_processor_test.go
+++ b/diode-server/reconciler/ingestion_processor_test.go
@@ -289,12 +289,11 @@ func TestIngestionProcessorStart(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	mockRepository.On("FindPriorIngestionLogsByEntityHashes", mock.Anything, mock.Anything, mock.Anything).Return(map[string]*reconops.PriorIngestionLog{}, nil)
-	mockRepository.On("BulkCreateIngestionLogs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
-	mockRepository.On("FindIngestionLogIDsByExternalIDs", mock.Anything, mock.Anything).Return(
-		func(_ context.Context, externalIDs []string) map[string]int32 {
-			result := make(map[string]int32, len(externalIDs))
-			for i, id := range externalIDs {
-				result[id] = int32(i + 1)
+	mockRepository.On("BulkCreateIngestionLogs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		func(_ context.Context, logs []*reconcilerpb.IngestionLog, _ [][]byte, _ []string) map[string]int32 {
+			result := make(map[string]int32, len(logs))
+			for i, log := range logs {
+				result[log.Id] = int32(i + 1)
 			}
 			return result
 		}, nil)

--- a/diode-server/reconciler/mocks/repository.go
+++ b/diode-server/reconciler/mocks/repository.go
@@ -28,22 +28,24 @@ func (_m *Repository) EXPECT() *Repository_Expecter {
 }
 
 // BulkCreateIngestionLogs provides a mock function with given fields: ctx, logs, sourceMetadata, entityHashes
-func (_m *Repository) BulkCreateIngestionLogs(ctx context.Context, logs []*reconcilerpb.IngestionLog, sourceMetadata [][]byte, entityHashes []string) (int64, error) {
+func (_m *Repository) BulkCreateIngestionLogs(ctx context.Context, logs []*reconcilerpb.IngestionLog, sourceMetadata [][]byte, entityHashes []string) (map[string]int32, error) {
 	ret := _m.Called(ctx, logs, sourceMetadata, entityHashes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BulkCreateIngestionLogs")
 	}
 
-	var r0 int64
+	var r0 map[string]int32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []*reconcilerpb.IngestionLog, [][]byte, []string) (int64, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []*reconcilerpb.IngestionLog, [][]byte, []string) (map[string]int32, error)); ok {
 		return rf(ctx, logs, sourceMetadata, entityHashes)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []*reconcilerpb.IngestionLog, [][]byte, []string) int64); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []*reconcilerpb.IngestionLog, [][]byte, []string) map[string]int32); ok {
 		r0 = rf(ctx, logs, sourceMetadata, entityHashes)
 	} else {
-		r0 = ret.Get(0).(int64)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]int32)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, []*reconcilerpb.IngestionLog, [][]byte, []string) error); ok {
@@ -76,12 +78,12 @@ func (_c *Repository_BulkCreateIngestionLogs_Call) Run(run func(ctx context.Cont
 	return _c
 }
 
-func (_c *Repository_BulkCreateIngestionLogs_Call) Return(_a0 int64, _a1 error) *Repository_BulkCreateIngestionLogs_Call {
+func (_c *Repository_BulkCreateIngestionLogs_Call) Return(_a0 map[string]int32, _a1 error) *Repository_BulkCreateIngestionLogs_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Repository_BulkCreateIngestionLogs_Call) RunAndReturn(run func(context.Context, []*reconcilerpb.IngestionLog, [][]byte, []string) (int64, error)) *Repository_BulkCreateIngestionLogs_Call {
+func (_c *Repository_BulkCreateIngestionLogs_Call) RunAndReturn(run func(context.Context, []*reconcilerpb.IngestionLog, [][]byte, []string) (map[string]int32, error)) *Repository_BulkCreateIngestionLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -129,6 +131,65 @@ func (_c *Repository_BulkIncrementDuplicateCounts_Call) Return(_a0 error) *Repos
 }
 
 func (_c *Repository_BulkIncrementDuplicateCounts_Call) RunAndReturn(run func(context.Context, []int32) error) *Repository_BulkIncrementDuplicateCounts_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ClaimQueuedIngestionLogs provides a mock function with given fields: ctx, batchSize
+func (_m *Repository) ClaimQueuedIngestionLogs(ctx context.Context, batchSize int32) ([]ops.QueuedIngestionLog, error) {
+	ret := _m.Called(ctx, batchSize)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClaimQueuedIngestionLogs")
+	}
+
+	var r0 []ops.QueuedIngestionLog
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int32) ([]ops.QueuedIngestionLog, error)); ok {
+		return rf(ctx, batchSize)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int32) []ops.QueuedIngestionLog); ok {
+		r0 = rf(ctx, batchSize)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ops.QueuedIngestionLog)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int32) error); ok {
+		r1 = rf(ctx, batchSize)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Repository_ClaimQueuedIngestionLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClaimQueuedIngestionLogs'
+type Repository_ClaimQueuedIngestionLogs_Call struct {
+	*mock.Call
+}
+
+// ClaimQueuedIngestionLogs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - batchSize int32
+func (_e *Repository_Expecter) ClaimQueuedIngestionLogs(ctx interface{}, batchSize interface{}) *Repository_ClaimQueuedIngestionLogs_Call {
+	return &Repository_ClaimQueuedIngestionLogs_Call{Call: _e.mock.On("ClaimQueuedIngestionLogs", ctx, batchSize)}
+}
+
+func (_c *Repository_ClaimQueuedIngestionLogs_Call) Run(run func(ctx context.Context, batchSize int32)) *Repository_ClaimQueuedIngestionLogs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int32))
+	})
+	return _c
+}
+
+func (_c *Repository_ClaimQueuedIngestionLogs_Call) Return(_a0 []ops.QueuedIngestionLog, _a1 error) *Repository_ClaimQueuedIngestionLogs_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Repository_ClaimQueuedIngestionLogs_Call) RunAndReturn(run func(context.Context, int32) ([]ops.QueuedIngestionLog, error)) *Repository_ClaimQueuedIngestionLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -308,65 +369,6 @@ func (_c *Repository_CreateIngestionLog_Call) Return(_a0 *int32, _a1 error) *Rep
 }
 
 func (_c *Repository_CreateIngestionLog_Call) RunAndReturn(run func(context.Context, *reconcilerpb.IngestionLog, []byte, string) (*int32, error)) *Repository_CreateIngestionLog_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// FindIngestionLogIDsByExternalIDs provides a mock function with given fields: ctx, externalIDs
-func (_m *Repository) FindIngestionLogIDsByExternalIDs(ctx context.Context, externalIDs []string) (map[string]int32, error) {
-	ret := _m.Called(ctx, externalIDs)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FindIngestionLogIDsByExternalIDs")
-	}
-
-	var r0 map[string]int32
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []string) (map[string]int32, error)); ok {
-		return rf(ctx, externalIDs)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, []string) map[string]int32); ok {
-		r0 = rf(ctx, externalIDs)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]int32)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
-		r1 = rf(ctx, externalIDs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Repository_FindIngestionLogIDsByExternalIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindIngestionLogIDsByExternalIDs'
-type Repository_FindIngestionLogIDsByExternalIDs_Call struct {
-	*mock.Call
-}
-
-// FindIngestionLogIDsByExternalIDs is a helper method to define mock.On call
-//   - ctx context.Context
-//   - externalIDs []string
-func (_e *Repository_Expecter) FindIngestionLogIDsByExternalIDs(ctx interface{}, externalIDs interface{}) *Repository_FindIngestionLogIDsByExternalIDs_Call {
-	return &Repository_FindIngestionLogIDsByExternalIDs_Call{Call: _e.mock.On("FindIngestionLogIDsByExternalIDs", ctx, externalIDs)}
-}
-
-func (_c *Repository_FindIngestionLogIDsByExternalIDs_Call) Run(run func(ctx context.Context, externalIDs []string)) *Repository_FindIngestionLogIDsByExternalIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]string))
-	})
-	return _c
-}
-
-func (_c *Repository_FindIngestionLogIDsByExternalIDs_Call) Return(_a0 map[string]int32, _a1 error) *Repository_FindIngestionLogIDsByExternalIDs_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Repository_FindIngestionLogIDsByExternalIDs_Call) RunAndReturn(run func(context.Context, []string) (map[string]int32, error)) *Repository_FindIngestionLogIDsByExternalIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/diode-server/reconciler/ops.go
+++ b/diode-server/reconciler/ops.go
@@ -234,18 +234,9 @@ func (o *Ops) BulkCreateIngestionLogs(ctx context.Context, ingestionLogs []*reco
 
 	// Bulk insert new logs
 	if len(newLogs) > 0 {
-		if _, err := o.repository.BulkCreateIngestionLogs(ctx, newLogs, newSourceMetadata, newEntityHashes); err != nil {
-			return nil, fmt.Errorf("failed to bulk create ingestion logs: %w", err)
-		}
-
-		// Fetch the auto-generated IDs
-		externalIDs := make([]string, len(newLogs))
-		for i, log := range newLogs {
-			externalIDs[i] = log.Id
-		}
-		idMap, err := o.repository.FindIngestionLogIDsByExternalIDs(ctx, externalIDs)
+		idMap, err := o.repository.BulkCreateIngestionLogs(ctx, newLogs, newSourceMetadata, newEntityHashes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch inserted ingestion log IDs: %w", err)
+			return nil, fmt.Errorf("failed to bulk create ingestion logs: %w", err)
 		}
 
 		for j, log := range newLogs {

--- a/diode-server/reconciler/ops/types.go
+++ b/diode-server/reconciler/ops/types.go
@@ -15,3 +15,9 @@ type PriorIngestionLog struct {
 	ID           int32
 	IngestionLog *reconcilerpb.IngestionLog
 }
+
+// QueuedIngestionLog represents an ingestion log in QUEUED state ready for processing
+type QueuedIngestionLog struct {
+	ID           int32
+	IngestionLog *reconcilerpb.IngestionLog
+}

--- a/diode-server/reconciler/repository.go
+++ b/diode-server/reconciler/repository.go
@@ -25,7 +25,9 @@ type Repository interface {
 
 	// Bulk operations
 	FindPriorIngestionLogsByEntityHashes(ctx context.Context, entityHashes []string, currentBranch *string) (map[string]*ops.PriorIngestionLog, error)
-	BulkCreateIngestionLogs(ctx context.Context, logs []*reconcilerpb.IngestionLog, sourceMetadata [][]byte, entityHashes []string) (int64, error)
-	FindIngestionLogIDsByExternalIDs(ctx context.Context, externalIDs []string) (map[string]int32, error)
+	BulkCreateIngestionLogs(ctx context.Context, logs []*reconcilerpb.IngestionLog, sourceMetadata [][]byte, entityHashes []string) (map[string]int32, error)
 	BulkIncrementDuplicateCounts(ctx context.Context, ids []int32) error
+
+	// Inbox processing
+	ClaimQueuedIngestionLogs(ctx context.Context, batchSize int32) ([]ops.QueuedIngestionLog, error)
 }


### PR DESCRIPTION
## Summary

Three Postgres-layer optimizations identified via `pg_stat_statements` profiling of the reconciler write path. All three target the hot ingestion path where the reconciler persists batches of ingestion logs and their related change sets.

### 1. Bulk COPY for `changes`

`CreateChangeSet` previously inserted each `change` row in a separate `INSERT` statement inside a single transaction. For a change set with N changes, that's N statements plus one for the change set itself.

This PR switches the per-row INSERTs to a single sqlc `:copyfrom` (Postgres COPY protocol). The change set row still uses INSERT (one row, one statement), but the N `changes` rows now go through one COPY call.

### 2. Pre-allocated sequence IDs for `BulkCreateIngestionLogs`

Previously, `BulkCreateIngestionLogs` did:
1. Bulk INSERT logs (server fills `id` from sequence on each row)
2. Round-trip back to fetch the auto-generated IDs via `FindIngestionLogIDsByExternalIDs`

Now it:
1. Pre-allocates N IDs in one query: `SELECT nextval('ingestion_logs_id_seq') FROM generate_series(1, $1)`
2. Includes the pre-allocated IDs in the COPY parameters

That eliminates the second round-trip entirely. The dead `FindIngestionLogIDsByExternalIDs` method (and its sqlc query) are deleted.

`BulkCreateIngestionLogs` signature changes from `(count int64, err)` to `(map[string]int32, err)` — returning the external_id → id mapping directly to the caller, since that's what the caller did with the previous round-trip anyway.

### 3. Composite `(state, id)` index for claim queries

The new `ClaimQueuedIngestionLogs` repository method does `WHERE state = $1 ORDER BY id LIMIT $2 FOR UPDATE SKIP LOCKED`. The existing `idx_ingestion_logs_state` (single-column) supports the WHERE filter but forces a separate sort for `ORDER BY id`. A composite `(state, id)` index supports both in one B-tree scan.

Migration: `20260505000001_optimize_ingestion_log_claim.sql` drops the old single-column index and creates the composite. Reversible.

### 4. Unnest-driven FindPrior rewrite

`FindPriorIngestionLogsByEntityHashes` previously used `DISTINCT ON (entity_hash) ... ORDER BY entity_hash, id DESC` over a `LEFT JOIN LATERAL`. For a batch of N hashes, the planner often picks an inefficient scan strategy.

Rewrites to `unnest($1::text[]) AS h CROSS JOIN LATERAL (SELECT ... WHERE entity_hash = h ORDER BY id DESC LIMIT 1)` — one targeted lookup per hash, which the planner can satisfy with N index seeks instead of one big scan.

## What this improves

* **Fewer DB statements per batch** — COPY replaces N individual INSERTs for changes
* **One fewer round-trip per ingestion batch** — pre-allocated IDs eliminate the ID-fetch query
* **Cheaper claim queries** — composite index removes a sort step
* **Faster prior-log lookup** — `LIMIT 1` per hash is more index-friendly than `DISTINCT ON` over a join

No behavior change. All new repository methods are pure additions; the only API change is `BulkCreateIngestionLogs` returning an ID map instead of a row count, which is consumed by the single caller (`Ops.BulkCreateIngestionLogs`).

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean (0 issues)
- [x] `go test ./...` all pass
- [ ] Migration applies cleanly on a fresh dev DB
- [ ] `EXPLAIN ANALYZE` confirms the composite index is used for claim queries
- [ ] No regression in existing batch insert paths

## Merge order

Part of the ingestion throughput series. Depends on no other PR. Required to land **before** the architectural decoupling PR, which consumes the new `ClaimQueuedIngestionLogs` method.