### PR TITLE
feat(OBS-2873): add gRPC server keepalive for ingester and reconciler

### DIFF
--- a/diode-server/grpckeepalive/options.go
+++ b/diode-server/grpckeepalive/options.go
@@ -1,0 +1,33 @@
+// Package grpckeepalive provides shared gRPC server keepalive settings for Diode
+// services. Values mirror typical Diode SDK client keepalive (e.g. 10s ping
+// interval, 20s ping timeout) so servers send path traffic through idle timeouts
+// and do not enforce the default 5m minimum between client PINGs (which would
+// fight those clients).
+package grpckeepalive
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	serverPingInterval    = 10 * time.Second
+	serverPingTimeout     = 20 * time.Second
+	minClientPingInterval = 5 * time.Second
+)
+
+// ServerOptions returns grpc.ServerOptions for production Diode gRPC servers.
+func ServerOptions() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    serverPingInterval,
+			Timeout: serverPingTimeout,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             minClientPingInterval,
+			PermitWithoutStream: true,
+		}),
+	}
+}

--- a/diode-server/grpckeepalive/options_test.go
+++ b/diode-server/grpckeepalive/options_test.go
@@ -1,0 +1,54 @@
+package grpckeepalive
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestServerOptions_ServeBufConn(t *testing.T) {
+	t.Parallel()
+
+	const bufSize = 1024 * 1024
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer(ServerOptions()...)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		if err := <-errCh; err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Errorf("Serve returned unexpected error: %v", err)
+		}
+	})
+
+	dial := func(context.Context, string) (net.Conn, error) { return lis.Dial() }
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(dial),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	conn.Connect()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		st := conn.GetState()
+		if st == connectivity.Ready {
+			break
+		}
+		if !conn.WaitForStateChange(ctx, st) {
+			require.Failf(t, "connection did not become ready", "state=%s", st.String())
+		}
+	}
+}

--- a/diode-server/ingester/component.go
+++ b/diode-server/ingester/component.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
+	"github.com/netboxlabs/diode/diode-server/grpckeepalive"
 	"github.com/netboxlabs/diode/diode-server/reconciler"
 	"github.com/netboxlabs/diode/diode-server/sentry"
 	"github.com/netboxlabs/diode/diode-server/telemetry"
@@ -87,10 +88,10 @@ func New(ctx context.Context, logger *slog.Logger, cfg Config, redisStreamClient
 		return nil, fmt.Errorf("failed to get hostname: %v", err)
 	}
 
-	grpcServer := grpc.NewServer(
+	grpcServer := grpc.NewServer(append(grpckeepalive.ServerOptions(),
 		grpc.ChainUnaryInterceptor(serverInterceptors...),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-	)
+	)...)
 
 	component := &Component{
 		ctx:               ctx,

--- a/diode-server/reconciler/server.go
+++ b/diode-server/reconciler/server.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/reconcilerpb"
+	"github.com/netboxlabs/diode/diode-server/grpckeepalive"
 )
 
 // Server is a reconciler Server
@@ -59,10 +60,10 @@ func NewServer(ctx context.Context, logger *slog.Logger, repository Repository, 
 		return nil, fmt.Errorf("failed to listen on port %d: %v", cfg.GRPCPort, err)
 	}
 
-	grpcServer := grpc.NewServer(
+	grpcServer := grpc.NewServer(append(grpckeepalive.ServerOptions(),
 		grpc.ChainUnaryInterceptor(serverInterceptors...),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-	)
+	)...)
 
 	component := &Server{
 		config:       cfg,


### PR DESCRIPTION
## Summary

Shared gRPC server keepalive settings (server-initiated pings and permissive enforcement for client pings) are applied to the ingester and reconciler `grpc.NewServer` constructors so long-lived connections stay compatible with middleboxes and Diode SDK client keepalive.

## What changed

- Added `diode-server/grpckeepalive` with `ServerOptions()` (10s ping interval, 20s timeout; enforcement `MinTime` 5s, `PermitWithoutStream: true`).
- Wired options into `reconciler.NewServer` and `ingester.New`.
- Added unit tests for durations, `NewServer` smoke, and bufconn dial readiness.

## How tested

- `go test ./...` from `diode-server` (739 tests passed).