### PR TITLE
feat(dbstore): composite (updated_at DESC, id DESC) index for list shape

### DIFF
--- a/diode-server/dbstore/postgres/migrations/20260526000001_add_ingestion_log_updated_at_desc_index.sql
+++ b/diode-server/dbstore/postgres/migrations/20260526000001_add_ingestion_log_updated_at_desc_index.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+
+-- Composite descending index to support the deviation-list LIST shape:
+-- "ORDER BY updated_at DESC, id DESC LIMIT N". Without this index Postgres
+-- falls back to Parallel Seq Scan + top-N heapsort over the full
+-- ingestion_logs table because updated_at carries many duplicate values
+-- from bulk operations, so the existing single-column
+-- idx_ingestion_logs_updated_at cannot satisfy the multi-column sort
+-- via Incremental Sort. With the composite, the planner does an
+-- Index Scan over (updated_at DESC, id DESC) and stops at LIMIT N,
+-- bringing top-N list queries from seconds to sub-millisecond on
+-- multi-million-row tables.
+--
+-- Complements idx_ingestion_logs_state_updated_at from migration
+-- 20260525000002, which helps state-filtered COUNTs but does not satisfy
+-- the DESC sort shape: state = ANY(...) requires merging multiple
+-- ascending index streams, which the planner estimates as costlier than
+-- a seq scan + sort. The composite below lets the planner satisfy the
+-- DESC sort directly and apply state as a cheap post-scan filter.
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_logs_updated_at_id_desc
+    ON ingestion_logs (updated_at DESC, id DESC);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_ingestion_logs_updated_at_id_desc;


### PR DESCRIPTION
## Summary

Adds `idx_ingestion_logs_updated_at_id_desc` on `ingestion_logs (updated_at DESC, id DESC)` to satisfy the LIST shape `ORDER BY updated_at DESC, id DESC LIMIT N` via a direct Index Scan, instead of the current Parallel Seq Scan + top-N heapsort over the full table.

Follow-up to #535. That PR added `(state, updated_at)` and `(state, ingestion_ts)` composites for state-filtered aggregations, which are correctly used by COUNT queries. But the LIST shape (default sort, with or without state filter) still falls back to Seq Scan because:

- The existing single-column `idx_ingestion_logs_updated_at` is ASC; backward scan + multi-column tie-break on `id DESC` doesn't compose into a clean Incremental Sort when there are many duplicate `updated_at` values (which there are, due to bulk operations).
- The `(state, updated_at)` composite is ASC/ASC; for `state = ANY(...)` ordered by `updated_at DESC`, the planner would need to MergeAppend multiple backward streams. Its cost estimate prefers Seq Scan.

## Measurements (3.5M-row ingestion_logs)

| Query | Before | After |
|---|---|---|
| `ORDER BY updated_at DESC, id DESC LIMIT 25` | 1793 ms | **0.035 ms** |
| `WHERE state IN (1,2) ORDER BY updated_at DESC, id DESC LIMIT 25` | 978 ms | **0.048 ms** |
| Buffer reads per query | ~717K | 7 |

EXPLAIN plans go from `Parallel Seq Scan + top-N heapsort` to `Limit -> Index Scan using idx_ingestion_logs_updated_at_id_desc`. For the state-filtered query the planner picks the same single-column-leading index and applies `state` as a cheap post-scan filter on the LIMIT'ed result set.

## Why not also `(ingestion_ts DESC, id DESC)`?

Tested. `ingestion_ts` already runs at 2.5 ms / 0.06 ms (no filter / state filter) on the same table because its values are essentially unique snowflake-style timestamps, so the existing `idx_ingestion_logs_ingestion_ts` composes cleanly with Incremental Sort. A composite gives marginal additional improvement (50x, but absolute already sub-ms) at the cost of another index to maintain. Not worth it. Only `updated_at`, with its duplicate-heavy values, needs the composite.

## Test plan

- [x] Migration applies cleanly to a populated dev DB (3.5M-row tenant)
- [x] `EXPLAIN ANALYZE` for both LIST query shapes confirms the new index is used
- [x] Sub-millisecond execution on warm cache; sub-second on cold
- [ ] Migration applies cleanly on staging tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)