### PR TITLE
fix(differ): return structured errors with plugin error details

### DIFF
--- a/diode-server/reconciler/differ/differ.go
+++ b/diode-server/reconciler/differ/differ.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 
+	diodeErrors "github.com/netboxlabs/diode/diode-server/errors"
 	"github.com/netboxlabs/diode/diode-server/gen/diode/v1/diodepb"
 	"github.com/netboxlabs/diode/diode-server/gen/netbox"
 	"github.com/netboxlabs/diode/diode-server/netboxdiodeplugin"
@@ -24,7 +25,7 @@ type IngestEntity struct {
 // Returns nil changeset if the result contains errors.
 func ConvertBulkPlanResult(result netboxdiodeplugin.BulkPlanResult, objectType string) (*changeset.ChangeSet, error) {
 	if len(result.Errors) > 0 && string(result.Errors) != "null" {
-		return nil, fmt.Errorf("bulk plan error for entity %s: %s", result.ID, string(result.Errors))
+		return nil, changeset.NewError("failed to determine deviation", diodeErrors.ErrCodeOpsGenerateDiff, result.Errors)
 	}
 
 	if result.ChangeSet == nil {
@@ -66,10 +67,10 @@ func ConvertBulkPlanApplyResult(result netboxdiodeplugin.BulkPlanApplyResult, ob
 	var planErr, applyErr error
 	if result.Errors != nil {
 		if len(result.Errors.Plan) > 0 && string(result.Errors.Plan) != "null" {
-			planErr = fmt.Errorf("plan error for entity %s: %s", result.ID, string(result.Errors.Plan))
+			planErr = changeset.NewError("failed to determine deviation", diodeErrors.ErrCodeOpsGenerateDiff, result.Errors.Plan)
 		}
 		if len(result.Errors.Apply) > 0 && string(result.Errors.Apply) != "null" {
-			applyErr = fmt.Errorf("apply error for entity %s: %s", result.ID, string(result.Errors.Apply))
+			applyErr = changeset.NewError("failed to apply deviation to NetBox", diodeErrors.ErrCodeOpsApplyChangeSet, result.Errors.Apply)
 		}
 	}
 


### PR DESCRIPTION
Per-entity plan/apply failures from `/bulk-plan` and `/bulk-plan-apply` were flattened into `fmt.Errorf` strings, so the plugin's error list was lost as structure and the ingestion log message leaked internal jargon ("bulk plan error for entity 123: [...]").

`ConvertBulkPlanResult` and `ConvertBulkPlanApplyResult` now return `changeset.Error` with:
- a user-facing message: "failed to determine deviation" (plan) / "failed to apply deviation to NetBox" (apply)
- the matching error code (`ERR_OPS_GENERATE_DIFF` / `ERR_OPS_APPLY_CHANGE_SET`)
- the plugin's raw error list in `details`

`handleChangeSetError` passes `*changeset.Error` through untouched, so the ingestion log error column now stores `{message, code, details}` with the causes intact instead of everything squashed into the message. Entity attribution isn't lost — the error is persisted on its ingestion log and callers log the ID.