### PR TITLE
docs(server): document custom CA support via SSL_CERT_FILE

### DIFF
--- a/diode-server/README.md
+++ b/diode-server/README.md
@@ -94,6 +94,29 @@ Edit the `.env` file to adjust Diode server settings as needed:
 
 Note that pprof profiling endpoints can be enabled for the reconciler, ingester, and auth services via the environnment variable `PPROF_ADDR` (using host:port addresses)
 
+### Connecting to NetBox over HTTPS with a private CA
+
+When `NETBOX_DIODE_PLUGIN_API_BASE_URL` points at a NetBox served over HTTPS with a certificate issued by a private/internal CA, the reconciler fails with:
+
+```
+tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+The reconciler uses Go's system certificate pool, which honors the standard `SSL_CERT_FILE` environment variable — including in the distroless container image. Mount your CA bundle and point `SSL_CERT_FILE` at it with a `docker-compose.override.yaml`:
+
+```yaml
+services:
+  diode-reconciler:
+    volumes:
+      - /path/to/your/ca.pem:/certs/ca.pem:ro
+    environment:
+      - SSL_CERT_FILE=/certs/ca.pem
+```
+
+Keep `NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY=false` — certificate verification stays enabled, validated against your CA. To trust a directory of CA certificates instead of a single bundle, mount the directory and use `SSL_CERT_DIR`.
+
+Setting `NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY=true` disables certificate verification entirely and should be a last resort.
+
 ---
 
 ### Stopping Diode

--- a/diode-server/docker/sample.env
+++ b/diode-server/docker/sample.env
@@ -37,6 +37,11 @@ DIODE_TO_NETBOX_RATE_LIMITER_BURST=1
 NETBOX_DIODE_PLUGIN_API_BASE_URL=<http://NETBOX_HOST>/api/plugins/diode
 NETBOX_DIODE_PLUGIN_API_TIMEOUT_SECONDS=30
 NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY=false
+# To reach a NetBox served over HTTPS with a certificate from a private CA,
+# mount the CA bundle into the diode-reconciler container and point Go's
+# standard SSL_CERT_FILE variable at it (keep SKIP_TLS_VERIFY=false).
+# See "Connecting to NetBox over HTTPS with a private CA" in the README.
+# SSL_CERT_FILE=/certs/ca.pem
 
 # Graph DB feature (optional - disabled by default)
 # When enabled, entities are also stored in a graph database for relationship tracking


### PR DESCRIPTION
## Summary

Documents how to connect the reconciler to a NetBox served over HTTPS with a **private/internal CA** while keeping TLS verification enabled — closing netboxlabs/diode#224 (also the recurring question in netboxlabs/diode#424).

The reconciler's HTTP client uses Go's system certificate pool, which natively honors the standard `SSL_CERT_FILE` / `SSL_CERT_DIR` environment variables, **including in the distroless image**. So the capability requested in netboxlabs/diode#224 already exists — it was just undocumented. This PR adds:

* a commented `SSL_CERT_FILE` example next to `NETBOX_DIODE_PLUGIN_SKIP_TLS_VERIFY` in `sample.env`
* a **Connecting to NetBox over HTTPS with a private CA** section in the diode-server README with the compose-override recipe, noting `SKIP_TLS_VERIFY=true` as last resort

## Verification

Tested in the actual `netboxlabs/diode-reconciler:0.0.0-7b347f0` image against a TLS server signed by a scratch CA, using a probe that mirrors `netboxdiodeplugin/client.go`'s exact TLS configuration (custom `tls.Config`, `MinVersion: TLS12`, no `RootCAs`):

<!-- linear:table-colwidths:400,400 -->
| Setup | Result |
| -- | -- |
| no custom CA | `tls: failed to verify certificate: x509: certificate signed by unknown authority` (the exact error from netboxlabs/diode#224/netboxlabs/diode#424) |
| `SSL_CERT_FILE=/certs/ca.pem` + CA mounted | `200 OK`, verification enabled |

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)