### PR TITLE
fix(security): base ingester/reconciler on distroless/static

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - "diode-server/**"
       - "!diode-server/docker/**"
+      # Dockerfiles define the image being scanned, so changes to them must
+      # re-run the scan even though the rest of docker/ is excluded.
+      - "diode-server/docker/Dockerfile*"
       - "!diode-server/Makefile"
       - "!diode-server/README.md"
       - ".github/workflows/container-scan.yaml"

--- a/diode-server/docker/Dockerfile
+++ b/diode-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/static-debian13:nonroot
 
 USER nonroot
 

--- a/diode-server/docker/Dockerfile-build
+++ b/diode-server/docker/Dockerfile-build
@@ -10,9 +10,9 @@ ARG TARGETOS TARGETARCH SVC
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
 
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/static-debian13:nonroot
 
 USER nonroot
 

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -10,12 +10,12 @@ ARG TARGETOS TARGETARCH SVC
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
 
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/authmanager ./cmd/authmanager
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/authmanager ./cmd/authmanager
 
 
 FROM alpine:3.22

--- a/diode-server/docker/Dockerfile-build.ingester
+++ b/diode-server/docker/Dockerfile-build.ingester
@@ -10,9 +10,9 @@ ARG TARGETOS TARGETARCH SVC
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
 
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/static-debian13:nonroot
 
 USER nonroot
 

--- a/diode-server/docker/Dockerfile-build.reconciler
+++ b/diode-server/docker/Dockerfile-build.reconciler
@@ -10,9 +10,9 @@ ARG TARGETOS TARGETARCH SVC
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/$SVC ./cmd/$SVC
 
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/static-debian13:nonroot
 
 USER nonroot
 

--- a/diode-server/docker/Dockerfile.ingester
+++ b/diode-server/docker/Dockerfile.ingester
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/static-debian13:nonroot
 
 USER nonroot
 

--- a/diode-server/docker/Dockerfile.reconciler
+++ b/diode-server/docker/Dockerfile.reconciler
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/static-debian13:nonroot
 
 USER nonroot
 


### PR DESCRIPTION
## Problem

The container scan fails on `diode-ingester` and `diode-reconciler` (e.g. on #577) with 10 `libssl3t64` findings, one of them blocking:

| CVE | Severity | Installed | Fixed |
|---|---|---|---|
| CVE-2026-14456 | 🟠 HIGH | 3.5.6-1~deb13u2 | 3.5.7-1~deb13u2 |
| CVE-2026-18798, -63072, -63076 | 🟡 MEDIUM | 3.5.6-1~deb13u2 | 3.5.7-1~deb13u2 |
| CVE-2026-14457, -54874, -63073, -63074, -63075, -75803 | ⚪ LOW | 3.5.6-1~deb13u2 | 3.5.7-1~deb13u2 |

Both images are based on `gcr.io/distroless/base`, which ships glibc and OpenSSL. Our Go binaries are statically linked and never load `libssl` — we inherit the entire OpenSSL CVE stream for a library we don't use. Bumping the base tag would only buy time until the next OpenSSL advisory.

## Change

- **`gcr.io/distroless/base:latest` → `gcr.io/distroless/static-debian13:nonroot`** for the ingester, reconciler, and the shared `Dockerfile`/`Dockerfile-build`. The `static` variant contains only `ca-certificates`, `tzdata`, and `/etc/passwd` — no glibc, no OpenSSL, no shared libraries at all. This removes the vulnerability class rather than patching one release of it.
- **`CGO_ENABLED=0` set explicitly** in every build stage (including auth). It was implicit before — Buildx only disables cgo when it actually cross-compiles, so a same-arch build could in principle have produced a dynamically linked binary. The Makefile already pins this; the Dockerfiles now match.
- **`diode-server/docker/Dockerfile*` re-included in the container-scan path filter.** Dockerfiles define the image being scanned, so a change to one must re-run the scan — otherwise this very PR would merge without a scan. The rest of `docker/` (compose, nginx, oauth2, scripts) stays excluded.

## Verification

Built both images locally and scanned with the same trivy invocation CI uses (`--scanners vuln,secret --vuln-type os,library --severity CRITICAL,HIGH,MEDIUM,LOW --ignore-unfixed`):

```
diode-ingester:scan (debian 13.6)     debian    0 vulnerabilities
usr/local/bin/diode-server            gobinary  0 vulnerabilities

diode-reconciler:scan (debian 13.6)   debian    0 vulnerabilities
usr/local/bin/diode-server            gobinary  0 vulnerabilities
```

Runtime checks on the resulting images:

- Both start as `nonroot` and reach application-level errors (`failed to connect to redis stream`, `required key NETBOX_DIODE_PLUGIN_API_BASE_URL missing value`) — the static binaries execute correctly, no dynamic-linker failure.
- `etc/ssl/certs/ca-certificates.crt`, `etc/passwd`, and `usr/share/zoneinfo/` are present; **zero `.so` files** in the image.
- Reconciler still carries `/etc/diode/migrations` (all 20 migrations present).

The auth image is unaffected (alpine-based). It rebuilds cleanly with `CGO_ENABLED=0`; `diode-server` and `authmanager` scan clean, and the pre-existing upstream `usr/bin/hydra` findings are unchanged and still allowlisted by the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)