### PR TITLE
fix(security): build the auth runtime stage without layer cache

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -62,6 +62,9 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha,scope=${{ matrix.app }}
           cache-to: type=gha,scope=${{ matrix.app }},mode=max
+          # The scan must see the packages a fresh build would install, not the
+          # ones cached in the runtime stage. No-op for images without the stage.
+          no-cache-filters: runtime
           build-args: |
             SVC=${{ matrix.app }}
             GO_VERSION=${{ env.GO_VERSION }}

--- a/.github/workflows/server-release.yaml
+++ b/.github/workflows/server-release.yaml
@@ -110,6 +110,8 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Always reinstall OS packages so releases pick up security updates.
+          no-cache-filters: runtime
           tags: |
             netboxlabs/${{ env.APP_NAME }}:latest
             netboxlabs/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }}

--- a/diode-server/docker/Dockerfile-build.auth
+++ b/diode-server/docker/Dockerfile-build.auth
@@ -18,7 +18,9 @@ RUN --mount=target=. \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/authmanager ./cmd/authmanager
 
 
-FROM alpine:3.22
+# Named so CI can build this stage without layer cache; a cached `apk upgrade`
+# silently keeps whatever package versions were current when it was first built.
+FROM alpine:3.22 AS runtime
 
 RUN apk upgrade --no-cache && apk add --no-cache jq
 


### PR DESCRIPTION
Fixes the `diode-auth` scan failure. Three lines, no application code — the hydra binary, `bootstrap-clients.sh`, the helm chart and the scan allowlist are all untouched.

## Problem

The scan reports `libssl3`/`libcrypto3` at `3.5.7-r0` with `3.5.8-r0` available — CVE-2026-14456 (HIGH) plus 9 MEDIUM/LOW.

**The Dockerfile is already correct.** Building it today with `--no-cache` installs `3.5.8-r0` with no changes at all:

```
P:libcrypto3
V:3.5.8-r0
P:libssl3
V:3.5.8-r0
```

The problem is the build cache. Both the scan and release workflows use `cache-from: type=gha`, which restores the

```dockerfile
RUN apk upgrade --no-cache && apk add --no-cache jq
```

layer instead of re-running it. Neither the `alpine:3.22` tag nor the `RUN` command has changed, so it stays a cache hit and the upgrade has silently frozen at whatever versions were current when the layer was first built. Bumping the base tag would only re-freeze at the next advisory.

This also affects **released** images — `server-release.yaml` builds with the same cache config, so the shipped `diode-auth` carries the stale packages too, not just the scan.

## Change

Name the alpine stage `runtime` and pass `no-cache-filters: runtime` in both workflows. OS packages are always reinstalled; the expensive go build stage stays cached.

The filter is silently ignored for Dockerfiles without that stage (verified locally — builds clean, exit 0), so the shared matrix step is safe for ingester and reconciler, which are distroless and have no package layer at all.

## Verification

Warmed the local cache with a plain build, then rebuilt with `--no-cache-filter runtime` exactly as CI will:

- `libssl3` / `libcrypto3` → **3.5.8-r0**
- trivy with CI's flags → **zero alpine findings**
- Replicating the workflow's `has_blocking` logic against the scan JSON: **0 blocking findings outside `usr/bin/hydra`**, `has_blocking = false` → scan passes

The image is otherwise byte-for-byte the same shape as before:

```
-rwxr-xr-x  appuser appgroup  /etc/config/oauth2/bootstrap-clients.sh
-rwxr-xr-x  appuser appgroup  /usr/bin/hydra
-rwxr-xr-x  root    root      /usr/bin/jq
-rwxr-xr-x  appuser appgroup  /usr/local/bin/authmanager
-rwxr-xr-x  appuser appgroup  /usr/local/bin/diode-server
uid=100(appuser) gid=101(appgroup)
```

The 66 pre-existing `usr/bin/hydra` findings are unchanged and still allowlisted by `isUpstreamHydra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)