### PR TITLE
chore(codeowners): add @samiura, remove @MicahParks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jajeffries @leoparente @manrodrigues @mfiedorowicz @MicahParks @grant-nbl @paulstuart @davidlanouette
+* @jajeffries @leoparente @manrodrigues @mfiedorowicz @grant-nbl @paulstuart @davidlanouette @samiura


### PR DESCRIPTION
Adds Samiur Arif (@samiura) as a code owner and removes @MicahParks.

```diff
-* @jajeffries @leoparente @manrodrigues @mfiedorowicz @MicahParks @grant-nbl @paulstuart @davidlanouette
+* @jajeffries @leoparente @manrodrigues @mfiedorowicz @grant-nbl @paulstuart @davidlanouette @samiura
```

New owner appended at the end, matching how @grant-nbl, @paulstuart and @davidlanouette were added.

Note: Luke (@ltucker) was already removed in #465, so there's nothing to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)