### PR TITLE
feat(chart): parametrize k8s cluster domain

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: "1.14.1"
+version: "1.15.0"
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -335,6 +335,7 @@ helm show values diode/diode
 | externalRedis.tls.enabled | bool | `false` | enable TLS |
 | externalRedis.tls.skipVerify | bool | `false` | skip TLS verify |
 | externalRedis.username | string | `""` | username (optional, Redis 6+) |
+| global.clusterDomain | string | `"cluster.local"` | DNS domain of the k8s cluster, used to build in-cluster service FQDNs. Set this if your cluster does not use the default domain. It lives under `global` so that subchart values rendered with `tpl` can read it too. The redis, postgresql and hydra subcharts have their own `clusterDomain` values, which should be set to match. |
 | global.commonAnnotations | object | `{}` | common annotations for all resources |
 | global.commonLabels | object | `{}` | common labels for all resources |
 | global.diode | object | `{"busybox":{"image":"busybox:latest","imagePullPolicy":"IfNotPresent"},"hydra":{"waitForPostgres":true},"ingester":{"waitForRedis":true},"reconciler":{"waitForPostgres":true,"waitForRedis":true}}` | diode global configuration |
@@ -345,7 +346,7 @@ helm show values diode/diode
 | global.diode.reconciler.waitForPostgres | bool | `true` | wait for PostgreSQL to be reachable |
 | global.diode.reconciler.waitForRedis | bool | `true` | wait for Redis to be reachable |
 | global.security.allowInsecureImages | bool | `true` |  |
-| hydra | object | `{"deployment":{"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}},"enabled":true,"fullnameOverride":"diode-hydra","hydra":{"automigration":{"enabled":true},"config":{"oidc":{"subject_identifiers":{"supported_types":["public"]}},"strategies":{"access_token":"jwt","jwt":{"scope_claim":"both"}},"ttl":{"access_token":"1h"},"urls":{"self":{"issuer":"http://diode-hydra-public.{{ .Release.Namespace }}.svc.cluster.local:4444"}}},"dev":true,"ingress":{"admin":{"enabled":false},"public":{"enabled":false}},"service":{"admin":{"enabled":true,"port":4445,"type":"ClusterIP"},"public":{"enabled":true,"port":4444,"type":"ClusterIP"}}},"job":{"annotations":{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-delete-policy":"hook-succeeded","helm.sh/hook-weight":"1"},"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}"},"secret":{"enabled":false,"nameOverride":"diode-hydra-secret"}}` | ref: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml |
+| hydra | object | `{"deployment":{"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}},"enabled":true,"fullnameOverride":"diode-hydra","hydra":{"automigration":{"enabled":true},"config":{"oidc":{"subject_identifiers":{"supported_types":["public"]}},"strategies":{"access_token":"jwt","jwt":{"scope_claim":"both"}},"ttl":{"access_token":"1h"},"urls":{"self":{"issuer":"http://diode-hydra-public.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain | default \"cluster.local\" }}:4444"}}},"dev":true,"ingress":{"admin":{"enabled":false},"public":{"enabled":false}},"service":{"admin":{"enabled":true,"port":4445,"type":"ClusterIP"},"public":{"enabled":true,"port":4444,"type":"ClusterIP"}}},"job":{"annotations":{"helm.sh/hook":"post-install, post-upgrade","helm.sh/hook-delete-policy":"hook-succeeded","helm.sh/hook-weight":"1"},"extraInitContainers":"{{ include \"diode.hydra.extrainitcontainers\" . }}"},"secret":{"enabled":false,"nameOverride":"diode-hydra-secret"}}` | ref: https://github.com/ory/k8s/blob/master/helm/charts/hydra/values.yaml |
 | hydra.deployment.extraInitContainers | string or list | `"{{ include \"diode.hydra.extrainitcontainers\" . }}"` | extra init containers |
 | hydra.deployment.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | resources |
 | hydra.enabled | bool | `true` | enabled |
@@ -355,8 +356,8 @@ helm show values diode/diode
 | hydra.hydra.config.strategies.access_token | string | `"jwt"` | access token strategy |
 | hydra.hydra.config.strategies.jwt.scope_claim | string | `"both"` | scope claim |
 | hydra.hydra.config.ttl.access_token | string | `"1h"` | access token TTL |
-| hydra.hydra.config.urls.self | object | `{"issuer":"http://diode-hydra-public.{{ .Release.Namespace }}.svc.cluster.local:4444"}` | self issuer |
-| hydra.hydra.config.urls.self.issuer | string | `"http://diode-hydra-public.{{ .Release.Namespace }}.svc.cluster.local:4444"` | hydra public url |
+| hydra.hydra.config.urls.self | object | `{"issuer":"http://diode-hydra-public.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain | default \"cluster.local\" }}:4444"}` | self issuer |
+| hydra.hydra.config.urls.self.issuer | string | `"http://diode-hydra-public.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain | default \"cluster.local\" }}:4444"` | hydra public url |
 | hydra.hydra.dev | bool | `true` | dev mode |
 | hydra.hydra.ingress.admin.enabled | bool | `false` | admin ingress enabled |
 | hydra.hydra.ingress.public.enabled | bool | `false` | public ingress enabled |

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -181,6 +181,17 @@ Install chart with release name `[RELEASE_NAME]` in namespace `[NAMESPACE]` with
 helm install [RELEASE_NAME] diode/diode --namespace $NAMESPACE --create-namespace --set [KEY]=[VALUE]
 ```
 
+If your cluster does not use the default `cluster.local` DNS domain, pass the same domain you set as `CLUSTER_DOMAIN` above to the chart and to its Redis and PostgreSQL dependencies, otherwise the in-cluster service hostnames will not resolve:
+
+```console
+helm install [RELEASE_NAME] diode/diode --namespace $NAMESPACE --create-namespace \
+  --set global.clusterDomain=$CLUSTER_DOMAIN \
+  --set redis.clusterDomain=$CLUSTER_DOMAIN \
+  --set postgresql.clusterDomain=$CLUSTER_DOMAIN
+```
+
+The equivalent keys can be set in your `values.yaml` instead.
+
 ## Uninstalling the Chart
 
 To uninstall the `[RELEASE_NAME]` deployment:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -85,7 +85,8 @@ REDIS_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base6
 POSTGRES_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base64 | head -c 32)
 DIODE_POSTGRES_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base64 | head -c 32)
 HYDRA_POSTGRES_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base64 | head -c 32)
-POSTGRES_HOSTNAME=diode-postgresql.$NAMESPACE.svc.cluster.local
+CLUSTER_DOMAIN=cluster.local  # change if your cluster uses a different DNS domain
+POSTGRES_HOSTNAME=diode-postgresql.$NAMESPACE.svc.$CLUSTER_DOMAIN
 POSTGRES_PORT=5432
 ```
 

--- a/charts/diode/README.md.gotmpl
+++ b/charts/diode/README.md.gotmpl
@@ -180,6 +180,17 @@ Install chart with release name `[RELEASE_NAME]` in namespace `[NAMESPACE]` with
 helm install [RELEASE_NAME] diode/{{ template "chart.name" . }} --namespace $NAMESPACE --create-namespace --set [KEY]=[VALUE]
 ```
 
+If your cluster does not use the default `cluster.local` DNS domain, pass the same domain you set as `CLUSTER_DOMAIN` above to the chart and to its Redis and PostgreSQL dependencies, otherwise the in-cluster service hostnames will not resolve:
+
+```console
+helm install [RELEASE_NAME] diode/{{ template "chart.name" . }} --namespace $NAMESPACE --create-namespace \
+  --set global.clusterDomain=$CLUSTER_DOMAIN \
+  --set redis.clusterDomain=$CLUSTER_DOMAIN \
+  --set postgresql.clusterDomain=$CLUSTER_DOMAIN
+```
+
+The equivalent keys can be set in your `values.yaml` instead.
+
 ## Uninstalling the Chart
 
 To uninstall the `[RELEASE_NAME]` deployment:

--- a/charts/diode/README.md.gotmpl
+++ b/charts/diode/README.md.gotmpl
@@ -84,7 +84,8 @@ REDIS_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base6
 POSTGRES_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base64 | head -c 32)
 DIODE_POSTGRES_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base64 | head -c 32)
 HYDRA_POSTGRES_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 | base64 | head -c 32)
-POSTGRES_HOSTNAME=diode-postgresql.$NAMESPACE.svc.cluster.local
+CLUSTER_DOMAIN=cluster.local  # change if your cluster uses a different DNS domain
+POSTGRES_HOSTNAME=diode-postgresql.$NAMESPACE.svc.$CLUSTER_DOMAIN
 POSTGRES_PORT=5432
 ```
 

--- a/charts/diode/scripts/quickstart.sh
+++ b/charts/diode/scripts/quickstart.sh
@@ -34,8 +34,12 @@ error() {
 usage() {
     echo "Usage: $0 NAMESPACE"
     echo
-    echo "Example:"
+    echo "Environment:"
+    echo "  CLUSTER_DOMAIN  DNS domain of the k8s cluster (default: cluster.local)"
+    echo
+    echo "Examples:"
     echo "  $0 diode-dev"
+    echo "  CLUSTER_DOMAIN=cluster.example.net $0 diode-dev"
     exit 1
 }
 
@@ -55,6 +59,9 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 NAMESPACE=$1
+
+# DNS domain of the k8s cluster; override for clusters not using the default.
+CLUSTER_DOMAIN="${CLUSTER_DOMAIN:-cluster.local}"
 # check if namespace is provided
 if [ -z "$NAMESPACE" ]; then
     error "Error: namespace is required"
@@ -113,7 +120,7 @@ REDIS_PASSWORD=$(generate_secret)
 POSTGRES_PASSWORD=$(generate_secret)
 DIODE_POSTGRES_PASSWORD=$(generate_secret)
 HYDRA_POSTGRES_PASSWORD=$(generate_secret)
-POSTGRES_HOSTNAME=diode-postgresql.$NAMESPACE.svc.cluster.local
+POSTGRES_HOSTNAME=diode-postgresql.$NAMESPACE.svc.$CLUSTER_DOMAIN
 POSTGRES_PORT=5432
 
 DIODE_POSTGRES_SECRET="diode-postgresql-secret"
@@ -222,4 +229,11 @@ fi
 echo "----------------------------------------"
 ok "Environment setup completed!"
 info "You can now install the diode helm chart by running:"
-info "  helm install <RELEASE_NAME> diode/diode --namespace $NAMESPACE"
+if [[ "$CLUSTER_DOMAIN" == "cluster.local" ]]; then
+    info "  helm install <RELEASE_NAME> diode/diode --namespace $NAMESPACE"
+else
+    info "  helm install <RELEASE_NAME> diode/diode --namespace $NAMESPACE \\"
+    info "    --set global.clusterDomain=$CLUSTER_DOMAIN \\"
+    info "    --set redis.clusterDomain=$CLUSTER_DOMAIN \\"
+    info "    --set postgresql.clusterDomain=$CLUSTER_DOMAIN"
+fi

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -32,6 +32,13 @@ Allows overriding it for multi-namespace deployments in combined charts.
 {{- end -}}
 
 {{/*
+Create the DNS domain of the k8s cluster, used to build in-cluster service FQDNs.
+*/}}
+{{- define "diode.clusterDomain" -}}
+{{- default "cluster.local" .Values.global.clusterDomain -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "diode.chart" -}}
@@ -114,7 +121,7 @@ Create the name of the auth service account to use
 Create the hostname of the auth service
 */}}
 {{- define "diode.auth.hostname" -}}
-{{- printf "%s-auth.%s.svc.cluster.local" (include "diode.fullname" .) .Release.Namespace }}
+{{- printf "%s-auth.%s.svc.%s" (include "diode.fullname" .) .Release.Namespace (include "diode.clusterDomain" .) }}
 {{- end }}
 
 {{/*
@@ -236,7 +243,7 @@ Create the hostname of the PostgreSQL database
 */}}
 {{- define "diode.postgresql.hostname" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- printf "diode-postgresql.%s.svc.cluster.local" .Release.Namespace }}
+{{- printf "diode-postgresql.%s.svc.%s" .Release.Namespace (include "diode.clusterDomain" .) }}
 {{- else if and .Values.externalPostgresql (hasKey .Values.externalPostgresql "hostname") -}}
 {{- .Values.externalPostgresql.hostname }}
 {{- else -}}
@@ -262,7 +269,7 @@ Create the hostname of the Redis database
 */}}
 {{- define "diode.redis.hostname" -}}
 {{- if .Values.redis.enabled -}}
-{{- printf "diode-redis-master.%s.svc.cluster.local" .Release.Namespace }}
+{{- printf "diode-redis-master.%s.svc.%s" .Release.Namespace (include "diode.clusterDomain" .) }}
 {{- else if and .Values.externalRedis (hasKey .Values.externalRedis "hostname") -}}
 {{- .Values.externalRedis.hostname }}
 {{- else -}}
@@ -365,7 +372,7 @@ Create the SSL option for PostgreSQL
 Create the hostname of the public Hydra service
 */}}
 {{- define "diode.hydra.public.hostname" -}}
-{{- printf "diode-hydra-public.%s.svc.cluster.local" .Release.Namespace }}
+{{- printf "diode-hydra-public.%s.svc.%s" .Release.Namespace (include "diode.clusterDomain" .) }}
 {{- end }}
 
 {{/*
@@ -386,7 +393,7 @@ Create the URL to the public Hydra service
 Create the hostname of the admin Hydra service
 */}}
 {{- define "diode.hydra.admin.hostname" -}}
-{{- printf "diode-hydra-admin.%s.svc.cluster.local" .Release.Namespace }}
+{{- printf "diode-hydra-admin.%s.svc.%s" .Release.Namespace (include "diode.clusterDomain" .) }}
 {{- end }}
 
 {{/*

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -18,6 +18,13 @@ global:
       # -- wait for Redis to be reachable
       waitForRedis: true
 
+  # -- DNS domain of the k8s cluster, used to build in-cluster service FQDNs.
+  # Set this if your cluster does not use the default domain. It lives under
+  # `global` so that subchart values rendered with `tpl` can read it too.
+  # The redis, postgresql and hydra subcharts have their own `clusterDomain`
+  # values, which should be set to match.
+  clusterDomain: cluster.local
+
   # -- common annotations for all resources
   commonAnnotations: {}
 
@@ -463,7 +470,7 @@ hydra:
         # -- self issuer
         self:
           # -- hydra public url
-          issuer: http://diode-hydra-public.{{ .Release.Namespace }}.svc.cluster.local:4444
+          issuer: http://diode-hydra-public.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain | default "cluster.local" }}:4444
     automigration:
       # -- automigration enabled
       enabled: true


### PR DESCRIPTION
Closes #401.

## Problem

The chart hardcoded `svc.cluster.local` in six places, so on a cluster with a non-default DNS domain diode's components can't resolve Redis, PostgreSQL, Hydra or the auth service.

There's a stronger argument than the issue makes: **the redis and postgresql subcharts already expose `clusterDomain`** (`redis/values.yaml:73`, `postgresql/values.yaml:78`, both defaulting to `cluster.local`). So the chart was internally inconsistent — you could configure the dependencies for a custom domain, but diode's own references to those same services stayed pinned.

## Change

Adds `global.clusterDomain` (default `cluster.local`) and a `diode.clusterDomain` helper, used by all five hostname helpers plus the Hydra issuer.

**Why `global` rather than top-level as the issue proposed:** the Hydra issuer lives in `values.yaml` and is rendered with `tpl` *in the subchart's context*, where `.Values` is Hydra's, not ours. Only `global` crosses that boundary. I implemented the top-level version first and it silently kept emitting `cluster.local` for the issuer:

```
diode-hydra-public.default.svc.cluster.local:4444     ← leaked with top-level clusterDomain
diode-hydra-public.default.svc.cluster.example.net    ← correct, with global
```

## Verification

| scenario | result |
|---|---|
| default values | **byte-identical render to develop** — no change for existing users |
| `global.clusterDomain` set | every diode-owned FQDN follows it |
| + `redis`/`postgresql` `clusterDomain` | **zero** `cluster.local` anywhere in the output |
| `redis.enabled: false` + `externalRedis` | unaffected, renders fine |

`helm lint` clean. Chart bumped `1.14.1` → `1.15.0` (new value, backwards compatible).

## Notes

- The hardcoded `diode-` prefix in those helpers looks like a release-name bug but isn't — `values.yaml` pins `fullnameOverride: diode-redis` / `diode-postgresql` / `diode-hydra`. I confirmed by rendering with release name `notdiode`: services still come out `diode-postgresql` etc. Left alone deliberately.
- The subcharts keep their own `clusterDomain` values — Helm can't template values files, so those can't be driven from `global`. Documented in the values comment.

## Out of scope — separate pre-existing bug

While testing I found `namespaceOverride` is only partially honoured. With `namespaceOverride: my-ns` and release namespace `rel-ns`:

```
resource namespaces:  rel-ns, my-ns    ← inconsistent across templates
FQDNs:                diode-redis-master.rel-ns.svc.cluster.local
```

The hostname helpers use `.Release.Namespace` directly rather than the existing `diode.namespace` helper. Unrelated to this change and not touched here — happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)