### PR TITLE
docs(chart): document the client target endpoint

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: "1.15.0"
+version: "1.15.1"
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -192,6 +192,24 @@ helm install [RELEASE_NAME] diode/diode --namespace $NAMESPACE --create-namespac
 
 The equivalent keys can be set in your `values.yaml` instead.
 
+## Connecting clients
+
+Point clients at the ingress, not at the `diode-ingester` or `diode-reconciler` Services:
+
+```console
+target = grpc://<ingress-hostname>:<port>/diode
+```
+
+The path is `ingressNginx.pathPrefix` (default `/diode`). The same host serves the gRPC ingestion endpoints and, under `/diode/auth`, the token endpoint that clients call before ingesting.
+
+Targeting a component Service directly, for example `diode-ingester.<namespace>.svc:8081`, fails during authentication with:
+
+```console
+DiodeConfigError: Failed to obtain access token: [Errno 104] Connection reset by peer
+```
+
+That Service serves only gRPC. The token endpoint is on `diode-auth`, reachable through the ingress, so the client's HTTP token request has nowhere to land.
+
 ## Uninstalling the Chart
 
 To uninstall the `[RELEASE_NAME]` deployment:

--- a/charts/diode/README.md.gotmpl
+++ b/charts/diode/README.md.gotmpl
@@ -191,6 +191,24 @@ helm install [RELEASE_NAME] diode/{{ template "chart.name" . }} --namespace $NAM
 
 The equivalent keys can be set in your `values.yaml` instead.
 
+## Connecting clients
+
+Point clients at the ingress, not at the `diode-ingester` or `diode-reconciler` Services:
+
+```console
+target = grpc://<ingress-hostname>:<port>/diode
+```
+
+The path is `ingressNginx.pathPrefix` (default `/diode`). The same host serves the gRPC ingestion endpoints and, under `/diode/auth`, the token endpoint that clients call before ingesting.
+
+Targeting a component Service directly, for example `diode-ingester.<namespace>.svc:8081`, fails during authentication with:
+
+```console
+DiodeConfigError: Failed to obtain access token: [Errno 104] Connection reset by peer
+```
+
+That Service serves only gRPC. The token endpoint is on `diode-auth`, reachable through the ingress, so the client's HTTP token request has nowhere to land.
+
 ## Uninstalling the Chart
 
 To uninstall the `[RELEASE_NAME]` deployment:


### PR DESCRIPTION
Addresses the reported half of #456.

## Problem

The chart README goes from *Installing the Chart* straight to *Uninstalling the Chart*. Nothing tells you what endpoint to point a client at once it's running.

Pointing at the ingester Service directly looks entirely reasonable, resolves fine, and even answers `grpcurl list` — but it fails during authentication:

```
DiodeConfigError: Failed to obtain access token: [Errno 104] Connection reset by peer
```

That Service serves only gRPC. The SDK calls the token endpoint first, and that lives on `diode-auth` behind the ingress, so the HTTP token request lands on a gRPC listener and the connection resets. The error names neither the cause nor the fix.

In #456 the reporter lost about a day to this, and the same wrong target appears in their NetBox plugin config.

## Change

Adds a **Connecting clients** section after the install instructions, covering the correct target, the `pathPrefix` value it derives from, and the failure mode.

Two deliberate choices:

- **The error string is quoted verbatim**, so the next person searching it lands on the fix. That's most of the value here.
- **The wrong target is named explicitly** (`diode-ingester.<namespace>.svc:8081`) rather than only describing the right one, because that exact address is what people reach for.

Verified against the rendered chart with default values:

```
/diode/(diode.v1.IngesterService.*)     -> diode-ingester:8081
/diode/(diode.v1.ReconcilerService.*)   -> diode-reconciler:8081
/diode/auth/(.*)                        -> diode-auth:8080
```

`ingressNginx.pathPrefix` defaults to `/diode`, `diodeIngester.containerPort` to `8081`. `helm lint` clean. Chart bumped `1.15.0` → `1.15.1` (docs only).

## Not in scope

#456 also raises Gateway API support, since ingress-nginx retired in March 2026. That's the larger half of the issue and is being handled separately — @ifoughal has working HTTPRoute manifests and has offered to contribute them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)