### PR TITLE
fix(chart): wire external PostgreSQL password when existingSecret is set

### DIFF
--- a/charts/diode/Chart.yaml
+++ b/charts/diode/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: diode
 description: A Helm chart for Diode
 type: application
-version: "1.15.1"
+version: "1.15.2"
 appVersion: "1.5.0"
 home: https://github.com/netboxlabs/diode
 sources:

--- a/charts/diode/README.md
+++ b/charts/diode/README.md
@@ -336,7 +336,7 @@ helm show values diode/diode
 | diodeReconciler.config.telemetryTracesExporter | string | `"none"` | telemetry traces exporter |
 | diodeReconciler.containerPort | int | `8081` | port to listen on |
 | diodeReconciler.enabled | bool | `true` | enabled |
-| diodeReconciler.existingSecret | string | `"diode-reconciler-secret"` | existing secret name |
+| diodeReconciler.existingSecret | string | `"diode-reconciler-secret"` | existing secret name, loaded with envFrom. Keys here are overridden by any explicitly wired env of the same name, e.g. POSTGRES_PASSWORD from externalPostgresql |
 | diodeReconciler.extraEnvs | string or list | `[]` | extra environment variables to be set on containers' `env` section |
 | diodeReconciler.extraInitContainers | string or list | `""` | additional containers to run before the reconciler finishes initializing (may contain templating instructions) |
 | diodeReconciler.extraVolumeMounts | string or list | `[]` | additional volumes to mount in the container (may contain templating instructions) |

--- a/charts/diode/templates/_helpers.tpl
+++ b/charts/diode/templates/_helpers.tpl
@@ -330,6 +330,18 @@ Create the username for PostgreSQL
 {{- end }}
 
 {{/*
+Whether the chart can wire POSTGRES_PASSWORD itself, i.e. external PostgreSQL is in
+use and credentials were supplied through externalPostgresql. Returns "" when not,
+so it can be used directly in a boolean context.
+*/}}
+{{- define "diode.postgresql.externalcredentials" -}}
+{{- $ext := .Values.externalPostgresql | default dict -}}
+{{- if and (not .Values.postgresql.enabled) (or $ext.existingSecretName $ext.password) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the secret name for PostgreSQL credentials
 */}}
 {{- define "diode.postgresql.secretname" -}}

--- a/charts/diode/templates/diode-reconciler-deployment.yaml
+++ b/charts/diode/templates/diode-reconciler-deployment.yaml
@@ -85,7 +85,7 @@ spec:
             {{- toYaml .| nindent 12 }}
           {{- end }}
           env:
-            {{- if not .Values.diodeReconciler.existingSecret }}
+            {{- if or (not .Values.diodeReconciler.existingSecret) (include "diode.postgresql.externalcredentials" .) }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/diode/values.yaml
+++ b/charts/diode/values.yaml
@@ -39,7 +39,10 @@ diode:
   # -- environment name
   environment: development
 
-# External PostgreSQL configuration (optional)
+# External PostgreSQL configuration (used when postgresql.enabled is false).
+# Setting existingSecretName or password makes the chart wire POSTGRES_PASSWORD into
+# the reconciler explicitly. That takes precedence over a POSTGRES_PASSWORD supplied
+# through diodeReconciler.existingSecret, which is loaded with envFrom.
 externalPostgresql:
   # -- hostname
   hostname: localhost
@@ -236,7 +239,8 @@ diodeReconciler:
   serviceAccount:
     # -- create service account
     create: true
-  # -- existing secret name
+  # -- existing secret name, loaded with envFrom. Keys here are overridden by any
+  # explicitly wired env of the same name, e.g. POSTGRES_PASSWORD from externalPostgresql
   existingSecret: diode-reconciler-secret
   # -- port to listen on
   containerPort: 8081


### PR DESCRIPTION
Fixes #549. Analysis in MON-259.

## Problem

The chart's documented external-PostgreSQL credential interface is **silently inert with default values**.

`diode-reconciler-deployment.yaml:88` gated the password env behind `if not .Values.diodeReconciler.existingSecret`, and `values.yaml:240` defaults that to `diode-reconciler-secret` (truthy). That block is the *only* consumer of `externalPostgresql.existingSecretName` / `existingSecretKey` / `password`, so none of them did anything out of the box.

Rendering #549's exact values against `develop`, the reconciler container comes out as:

```
env:     []
envFrom: [diode-reconciler-configmap, diode-reconciler-secret, diode-auth-oauth2-secret]
```

Zero occurrences of `POSTGRES_PASSWORD` anywhere in the manifest. The pod only gets a password if the operator's secret happens to be named `diode-reconciler-secret` **and** contains a `POSTGRES_PASSWORD` key — which is why #549's reporter saw it work once and then stop when they renamed the secret.

The failure surfaces as `SQLSTATE 28P01` plus a Postgres-side `password authentication failed for user "diode"`, both of which point at the operator's credentials rather than at the chart. #549 spent the issue ruling out Cilium, pgadmin and ExternalSecrets first.

The plaintext path was worse: `externalPostgresql.password` rendered `diode-external-postgresql-secret` that **nothing referenced** — a dead Secret object.

## Change

Render the env whenever external PostgreSQL is in use *and* credentials were supplied, regardless of `existingSecret`, via a small `diode.postgresql.externalcredentials` helper. Kubernetes gives explicit `env` precedence over `envFrom`, so both models coexist and operators using the quickstart secret are untouched.

Chose MON-259's option 1 over option 2 (`fail` at render time) because it makes the documented interface work rather than teaching people to avoid it — and option 3 (docs only) leaves the trap in place. Values comments added regardless, since the precedence is worth stating.

## Verification

Rendered both versions across five credential scenarios:

| scenario | develop | with fix |
|---|---|---|
| default (internal pg) | absent | absent — **byte-identical render** |
| external, no creds given | absent | absent — **byte-identical render** |
| `existingSecret: ""` | renders | renders — **byte-identical render** |
| `existingSecretName` (#549) | absent | `diode-postgres-secret/POSTGRES_PASSWORD` |
| `password` (plaintext) | absent | `diode-external-postgresql-secret/postgresql-password` |

The two fixed scenarios gain exactly the five lines they were missing and nothing else. The plaintext secret goes from one name occurrence (its own definition) to two, so it's no longer dead.

`helm lint` clean. Chart bumped `1.15.1` → `1.15.2`.

## Upgrade note: previously-inert values become authoritative

This is a behaviour change, not purely additive. Anyone on external PostgreSQL who set
`externalPostgresql.existingSecretName` or `password` (which did nothing) while actually
supplying `POSTGRES_PASSWORD` through the `diodeReconciler.existingSecret` envFrom will
now have the explicit env win:

```
externalPostgresql.existingSecretName: stale-name-from-a-failed-attempt
diodeReconciler.existingSecret:        my-working-secret     # holds the real password
```

| | before | after |
|---|---|---|
| `env` | *(empty)* | `POSTGRES_PASSWORD -> secret=stale-name` |
| password source | `my-working-secret` via envFrom | the explicit env |

`optional` is unset, so if that secret or key is absent the reconciler fails to start with
`CreateContainerConfigError` rather than falling back.

The exposed population is specifically people who hit this bug and worked around it: the
natural path was to set `externalPostgresql.*`, find it inert, try a couple of secret names,
then put the password in the reconciler secret instead and leave the original setting behind.
If their leftover value points at their real secret they are fine; if it is stale, the upgrade
breaks them.

Deliberately not using `optional: true`. It would make this strictly non-breaking, but a user
declaring a secret that does not exist would then get nothing, silently, which is the exact
failure mode this PR removes. Config errors should be loud.

Worth carrying into the release notes, since the published jump is 1.14.0 -> 1.15.2 and reads
as a routine minor.

## Note for review

With `existingSecret: ""`, the `diode.reconciler.secret` helper falls back to the same literal `diode-reconciler-secret` name for a non-optional `envFrom` secretRef that no template creates. That's pre-existing and this PR doesn't change it — but it's now a path fewer people need to take, since the documented settings work as written. Flagged in MON-259 as a candidate for `optional: true` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
